### PR TITLE
fix(template): pin taiki-e/install-action by version tag with tool input

### DIFF
--- a/generated/monorepo/.github/workflows/test.yml
+++ b/generated/monorepo/.github/workflows/test.yml
@@ -182,7 +182,9 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@e3f5de9dc07635c0989e7620a8768b93e675db16
+        uses: taiki-e/install-action@7a4939c09608b2a1986b484eca1d16fd0db8ebef # v2.75.5
+        with:
+          tool: cargo-llvm-cov
 
       - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview

--- a/generated/rust-release/.github/workflows/test.yml
+++ b/generated/rust-release/.github/workflows/test.yml
@@ -102,7 +102,9 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@e3f5de9dc07635c0989e7620a8768b93e675db16
+        uses: taiki-e/install-action@7a4939c09608b2a1986b484eca1d16fd0db8ebef # v2.75.5
+        with:
+          tool: cargo-llvm-cov
 
       - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -225,7 +225,9 @@ jobs:
 {%- if use_coverage %}
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@e3f5de9dc07635c0989e7620a8768b93e675db16
+        uses: taiki-e/install-action@7a4939c09608b2a1986b484eca1d16fd0db8ebef # v2.75.5
+        with:
+          tool: cargo-llvm-cov
 
       - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview
@@ -373,7 +375,9 @@ jobs:
 {%- if use_coverage %}
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@e3f5de9dc07635c0989e7620a8768b93e675db16
+        uses: taiki-e/install-action@7a4939c09608b2a1986b484eca1d16fd0db8ebef # v2.75.5
+        with:
+          tool: cargo-llvm-cov
 
       - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview


### PR DESCRIPTION
## Why

- `cargo llvm-cov` installation is broken for rust projects generated with `use_coverage=true`
  - The floating tag `@cargo-llvm-cov` of `taiki-e/install-action` was pinned by SHA, so once the upstream tag advanced, the pin referenced a commit that is not part of any release
- The `taiki-e/install-action` README strongly discourages hash-pinning `@<tool_name>` tags
  > Pinning `@<tool_name>` tags by hash is strongly discouraged, as it causes the workflow to reference a commit that is not present on the repository when a new version is released.
  from: https://github.com/taiki-e/install-action/blob/main/README.md

## What

- Repin `taiki-e/install-action` in `template/.github/workflows/test.yml.jinja` to the SHA of the install-action release tag (`v2.75.5`) and pass `tool: cargo-llvm-cov` via `with:`

  ```yaml
  - name: Install cargo-llvm-cov
    uses: taiki-e/install-action@7a4939c09608b2a1986b484eca1d16fd0db8ebef # v2.75.5
    with:
      tool: cargo-llvm-cov
  ```

  - Supply chain protection via `pinact` is preserved, and the Renovate `github-actions` manager can keep tracking the SHA through the semver comment as before

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/generic-boilerplate/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
