### PR TITLE
chore(skill): prevent version downgrade during copier conflict resolution

### DIFF
--- a/.claude/skills/update-boilerplate-prs/SKILL.md
+++ b/.claude/skills/update-boilerplate-prs/SKILL.md
@@ -100,7 +100,7 @@ gh pr diff <number> -R fohte/<repo>
 ```
 
 - Check for copier conflict markers (`<<<<<<< before updating`, `=======`, `>>>>>>> after updating`)
-- For each conflict, compare versions on both sides. If the `before updating` side has a newer version than the `after updating` side, flag it as a potential downgrade (the repo may have been updated independently by Renovate or other means)
+- For each conflict, compare versions on both sides. If the `before updating` side has a newer version than the `after updating` side, flag it as a potential downgrade in the Step 6 report (the repo may have been updated independently by Renovate or other means)
 - Verify that Step 1 changes propagated correctly
   - Each repository's template configuration (copier-answers.yml settings) determines which changes apply. Judge "expected changes" vs "not applicable" based on the configuration
   - Ensure repository-specific customizations (non-template changes) are not broken
@@ -171,7 +171,8 @@ For each conflict, compare the versions on both sides:
 
 - If `before updating` has a newer version, keep it -- do not downgrade
 - If `after updating` introduces structural changes (e.g., new `with:` inputs, format changes like SHA pinning), apply the structural change but preserve the newer version from `before updating`
-- Example: `before updating` has `actions/create-github-app-token@SHA-A # v3.1.0`, `after updating` has `actions/create-github-app-token@SHA-B # v3.0.0` -> keep `@SHA-A # v3.1.0`
+- Example (version only): `before updating` has `actions/create-github-app-token@SHA-A # v3.1.0`, `after updating` has `actions/create-github-app-token@SHA-B # v3.0.0` -> keep `@SHA-A # v3.1.0`
+- Example (structural + version): `before updating` has `actions/setup-node@v4`, `after updating` has `actions/setup-node@v3` with a new `with: { cache: 'pnpm' }` input -> result should be `actions/setup-node@v4` with `with: { cache: 'pnpm' }`
 
 This rule must be explicitly included in every delegation prompt.
 

--- a/.claude/skills/update-boilerplate-prs/SKILL.md
+++ b/.claude/skills/update-boilerplate-prs/SKILL.md
@@ -100,6 +100,7 @@ gh pr diff <number> -R fohte/<repo>
 ```
 
 - Check for copier conflict markers (`<<<<<<< before updating`, `=======`, `>>>>>>> after updating`)
+- For each conflict, compare versions on both sides. If the `before updating` side has a newer version than the `after updating` side, flag it as a potential downgrade (the repo may have been updated independently by Renovate or other means)
 - Verify that Step 1 changes propagated correctly
   - Each repository's template configuration (copier-answers.yml settings) determines which changes apply. Judge "expected changes" vs "not applicable" based on the configuration
   - Ensure repository-specific customizations (non-template changes) are not broken
@@ -158,6 +159,21 @@ Include the following in the delegation prompt:
 - Issues found during validation (conflict markers, incorrect parameter values, missing files, etc.)
 - Repository-specific customizations to preserve (e.g., repo-specific dependencies, local settings)
 - Context for resolution decisions (e.g., lefthook-config referencing itself remotely is inappropriate)
+
+### Conflict resolution rule: do NOT blindly choose `after updating` (always include in prompt)
+
+Copier conflict markers have two sides:
+
+- `before updating`: the repository's current state, which may have been updated independently (e.g., by Renovate) to a newer version than the template
+- `after updating`: the template's rendered result, which is NOT always the correct choice
+
+For each conflict, compare the versions on both sides:
+
+- If `before updating` has a newer version, keep it -- do not downgrade
+- If `after updating` introduces structural changes (e.g., new `with:` inputs, format changes like SHA pinning), apply the structural change but preserve the newer version from `before updating`
+- Example: `before updating` has `actions/create-github-app-token@SHA-A # v3.1.0`, `after updating` has `actions/create-github-app-token@SHA-B # v3.0.0` -> keep `@SHA-A # v3.1.0`
+
+This rule must be explicitly included in every delegation prompt.
 
 ### copier update notes (always include in prompt)
 


### PR DESCRIPTION
## Why

- The `update-boilerplate-prs` skill's delegation prompt could overwrite dependencies that the repo had already updated (via Renovate or similar tools) to a newer version than the template provides

## What

- Add version downgrade prevention rules to Step 5a and Step 7 of the `update-boilerplate-prs` skill
  - Explicitly require keeping the `before updating` side when it has a newer version than `after updating`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/generic-boilerplate/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
