### PR TITLE
fix(template): align `pr-title-check` scope regex with Conventional Commits spec

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -22,7 +22,7 @@ jobs:
           # Valid:   feat: ..., feat!: ..., feat(scope): ..., feat(scope)!: ...
           # Invalid: feat!(scope): ... (! must come after scope, before :)
           allowed_types="feat|fix|perf|deps|revert|chore|docs|style|refactor|test|build|ci"
-          pattern="^(${allowed_types})(\([a-zA-Z0-9_./* -]+\))?(!)?: .+"
+          pattern="^(${allowed_types})(\([^()]+\))?(!)?: .+"
 
           if [[ "${PR_TITLE}" =~ ${pattern} ]]; then
             echo "PR title is valid: ${PR_TITLE}"

--- a/generated/base-release/.github/workflows/pr-title-check.yml
+++ b/generated/base-release/.github/workflows/pr-title-check.yml
@@ -22,7 +22,7 @@ jobs:
           # Valid:   feat: ..., feat!: ..., feat(scope): ..., feat(scope)!: ...
           # Invalid: feat!(scope): ... (! must come after scope, before :)
           allowed_types="feat|fix|perf|deps|revert|chore|docs|style|refactor|test|build|ci"
-          pattern="^(${allowed_types})(\([a-zA-Z0-9_./* -]+\))?(!)?: .+"
+          pattern="^(${allowed_types})(\([^()]+\))?(!)?: .+"
 
           if [[ "${PR_TITLE}" =~ ${pattern} ]]; then
             echo "PR title is valid: ${PR_TITLE}"

--- a/generated/rust-release/.github/workflows/pr-title-check.yml
+++ b/generated/rust-release/.github/workflows/pr-title-check.yml
@@ -22,7 +22,7 @@ jobs:
           # Valid:   feat: ..., feat!: ..., feat(scope): ..., feat(scope)!: ...
           # Invalid: feat!(scope): ... (! must come after scope, before :)
           allowed_types="feat|fix|perf|deps|revert|chore|docs|style|refactor|test|build|ci"
-          pattern="^(${allowed_types})(\([a-zA-Z0-9_./* -]+\))?(!)?: .+"
+          pattern="^(${allowed_types})(\([^()]+\))?(!)?: .+"
 
           if [[ "${PR_TITLE}" =~ ${pattern} ]]; then
             echo "PR title is valid: ${PR_TITLE}"


### PR DESCRIPTION
## Why

- `pr-title-check` workflow rejects scopes containing commas (e.g., `feat(cc, wm): ...`)

## What

- Align scope regex with the Conventional Commits v1.0.0 BNF spec by accepting any character except parentheses
  - Before: `[a-zA-Z0-9_./* -]+` (allowlist)
  - After: `[^()]+` (deny only parentheses)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/generic-boilerplate/pull/289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
