### PR TITLE
docs(claude): document CI validation constraints for template changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,21 @@ When a file in `template/` has identical content to a file in the repository roo
 - `generated/` directory contains snapshot fixtures auto-generated from `template/` and `tests/fixtures/*.yml`
 - Never edit files in `generated/` directly. Always modify the template source and regenerate
 - Run `scripts/generate-snapshots` to regenerate all snapshots after template changes
+- `scripts/generate-snapshots` intentionally omits `--defaults`. If a fixture is missing any parameter, copier drops into an interactive prompt and fails in non-TTY contexts. This fail-loud behavior enforces the rule that every fixture explicitly specifies every parameter
+
+## CI validation
+
+`.github/workflows/validate-template.yml` validates template changes through the following jobs. New template files must be designed to pass all of them:
+
+- `regenerate-and-commit`: runs `scripts/generate-snapshots` and auto-commits any diff in `generated/`. If you forget to regenerate locally, CI will commit the regeneration for you, but any push that also touches `generated/` inconsistently will still need to reconcile
+- `validate (<fixture>)`: for each fixture in `tests/fixtures/`, initializes a git repo inside `generated/<fixture>/`, runs `lefthook run pre-commit --all-files` (prettier, eslint, etc. as configured by that fixture's own lefthook), then fails if any file has a diff. **This means every file under `generated/` must already be in the exact form its own lefthook would produce.**
+- `validate-node` / `validate-rust`: run the generated project's test suite when the corresponding `generated/node` or `generated/rust` tree changed
+
+### Implications for `template/` authors
+
+- Because generated files must be lefthook-clean, the bytes emitted by copier rendering must already match the downstream formatter's output. Prettier cannot format `.jinja` files directly (it errors on unknown parser), so you cannot rely on post-rendering formatting of the jinja source itself
+- Write jinja templates so that the rendered output is byte-identical to what prettier (or the relevant formatter) would produce. For constructs where an inline conditional would break formatter invariants (e.g. a markdown table cell whose width changes between branches of a `{% if %}`), split the whole block with `{% if %}` / `{% else %}` instead of using an inline ternary, so each branch is independently well-formatted
+- Any new parameter added to `copier.yml` must be set in every `tests/fixtures/*.yml`; otherwise `scripts/generate-snapshots` will hang on a prompt in CI (see above)
 
 ## Test fixture policy
 


### PR DESCRIPTION
## Why

- Modifying files under `template/` without knowing how CI validates snapshots makes failure investigation exploratory and wasteful

## What

- Document the CI validation mechanism and the constraints it places on `template/` authors in `CLAUDE.md`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/generic-boilerplate/pull/292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
