### PR TITLE
feat(template): inline lefthook config and host shared tooling at the root

### DIFF
--- a/generated/base-public/.github/workflows/test.yml
+++ b/generated/base-public/.github/workflows/test.yml
@@ -45,8 +45,8 @@ jobs:
         continue-on-error: true
         run: lefthook run pre-commit --all-files
 
-      # lefthook-config's formatters run `git add` after formatting, which stages the changes.
-      # https://github.com/fohte/lefthook-config/blob/v0.1.7/base.yml
+      # Formatters configured with `stage_fixed: true` run `git add` after formatting,
+      # which stages the changes.
       # commit-action uses `git ls-files --modified` which only detects unstaged changes.
       # https://github.com/suzuki-shunsuke/commit-action/blob/87b297f0ce551411b43d1880f4fb3cbc60381055/action.yaml#L57
       # We need to unstage the changes so commit-action can detect them.

--- a/generated/base-public/.mise.toml
+++ b/generated/base-public/.mise.toml
@@ -6,6 +6,8 @@ actionlint = "1.7.12"
 node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
+# When no node project is present in the repo, prettier and commitlint are
+# provided via mise since there is no package.json to host them.
 "npm:@commitlint/cli" = "20.5.0"
 "npm:prettier" = "3.8.1"
 shellcheck = "0.11.0"

--- a/generated/base-public/lefthook.yml
+++ b/generated/base-public/lefthook.yml
@@ -40,17 +40,18 @@ pre-commit:
         # Renovate does not support the `gh:` prefix in _src_path.
         # See: https://github.com/renovatebot/renovate/issues/39938
         for file in {staged_files}; do
-          if [ -f "$file" ]; then
-            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
-            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
-              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+          [ -f "$file" ] || continue
+          # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+          src_path=$(sed -n 's/^_src_path:[[:space:]]*//p' "$file" | head -n 1)
+          case "$src_path" in
+            gh:* | "'gh:"* | '"gh:'*)
               suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
               echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
               echo "Please use a full 'https://' URL instead." >&2
               printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
               exit 1
-            fi
-          fi
+              ;;
+          esac
         done
 
 commit-msg:

--- a/generated/base-public/lefthook.yml
+++ b/generated/base-public/lefthook.yml
@@ -1,5 +1,59 @@
-remotes:
-  - git_url: https://github.com/fohte/lefthook-config.git
-    ref: v0.1.16 # renovate: datasource=github-tags depName=fohte/lefthook-config
-    configs:
-      - base.yml
+pre-commit:
+  commands:
+    format:
+      # Remove trailing whitespace and ensure final newline
+      run: basefmt {staged_files}
+      glob: '*'
+      stage_fixed: true
+
+    prettier:
+      run: mise x -- prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
+      stage_fixed: true
+
+    shellcheck:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shellcheck -- shellcheck {staged_files}
+
+    shfmt:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shfmt -- shfmt --apply-ignore -w {staged_files}
+      stage_fixed: true
+
+    pinact:
+      glob: '{.github/workflows/*.{yml,yaml},.github/actions/**/action.{yml,yaml}}'
+      run: mise x pinact -- pinact run {staged_files}
+      stage_fixed: true
+
+    actionlint:
+      glob: '.github/workflows/*.{yml,yaml}'
+      run: mise x actionlint -- actionlint {staged_files}
+
+    copier-src-path:
+      glob: '.copier-answers.yml'
+      run: |
+        # Renovate does not support the `gh:` prefix in _src_path.
+        # See: https://github.com/renovatebot/renovate/issues/39938
+        for file in {staged_files}; do
+          if [ -f "$file" ]; then
+            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
+              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+              suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
+              echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
+              echo "Please use a full 'https://' URL instead." >&2
+              printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
+              exit 1
+            fi
+          fi
+        done
+
+commit-msg:
+  commands:
+    commitlint:
+      run: mise x -- commitlint --edit {1}

--- a/generated/base-release/.github/workflows/test.yml
+++ b/generated/base-release/.github/workflows/test.yml
@@ -48,8 +48,8 @@ jobs:
         continue-on-error: true
         run: lefthook run pre-commit --all-files
 
-      # lefthook-config's formatters run `git add` after formatting, which stages the changes.
-      # https://github.com/fohte/lefthook-config/blob/v0.1.7/base.yml
+      # Formatters configured with `stage_fixed: true` run `git add` after formatting,
+      # which stages the changes.
       # commit-action uses `git ls-files --modified` which only detects unstaged changes.
       # https://github.com/suzuki-shunsuke/commit-action/blob/87b297f0ce551411b43d1880f4fb3cbc60381055/action.yaml#L57
       # We need to unstage the changes so commit-action can detect them.

--- a/generated/base-release/.mise.toml
+++ b/generated/base-release/.mise.toml
@@ -6,6 +6,8 @@ actionlint = "1.7.12"
 node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
+# When no node project is present in the repo, prettier and commitlint are
+# provided via mise since there is no package.json to host them.
 "npm:@commitlint/cli" = "20.5.0"
 "npm:prettier" = "3.8.1"
 shellcheck = "0.11.0"

--- a/generated/base-release/lefthook.yml
+++ b/generated/base-release/lefthook.yml
@@ -40,17 +40,18 @@ pre-commit:
         # Renovate does not support the `gh:` prefix in _src_path.
         # See: https://github.com/renovatebot/renovate/issues/39938
         for file in {staged_files}; do
-          if [ -f "$file" ]; then
-            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
-            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
-              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+          [ -f "$file" ] || continue
+          # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+          src_path=$(sed -n 's/^_src_path:[[:space:]]*//p' "$file" | head -n 1)
+          case "$src_path" in
+            gh:* | "'gh:"* | '"gh:'*)
               suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
               echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
               echo "Please use a full 'https://' URL instead." >&2
               printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
               exit 1
-            fi
-          fi
+              ;;
+          esac
         done
 
 commit-msg:

--- a/generated/base-release/lefthook.yml
+++ b/generated/base-release/lefthook.yml
@@ -1,5 +1,59 @@
-remotes:
-  - git_url: https://github.com/fohte/lefthook-config.git
-    ref: v0.1.16 # renovate: datasource=github-tags depName=fohte/lefthook-config
-    configs:
-      - base.yml
+pre-commit:
+  commands:
+    format:
+      # Remove trailing whitespace and ensure final newline
+      run: basefmt {staged_files}
+      glob: '*'
+      stage_fixed: true
+
+    prettier:
+      run: mise x -- prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
+      stage_fixed: true
+
+    shellcheck:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shellcheck -- shellcheck {staged_files}
+
+    shfmt:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shfmt -- shfmt --apply-ignore -w {staged_files}
+      stage_fixed: true
+
+    pinact:
+      glob: '{.github/workflows/*.{yml,yaml},.github/actions/**/action.{yml,yaml}}'
+      run: mise x pinact -- pinact run {staged_files}
+      stage_fixed: true
+
+    actionlint:
+      glob: '.github/workflows/*.{yml,yaml}'
+      run: mise x actionlint -- actionlint {staged_files}
+
+    copier-src-path:
+      glob: '.copier-answers.yml'
+      run: |
+        # Renovate does not support the `gh:` prefix in _src_path.
+        # See: https://github.com/renovatebot/renovate/issues/39938
+        for file in {staged_files}; do
+          if [ -f "$file" ]; then
+            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
+              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+              suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
+              echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
+              echo "Please use a full 'https://' URL instead." >&2
+              printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
+              exit 1
+            fi
+          fi
+        done
+
+commit-msg:
+  commands:
+    commitlint:
+      run: mise x -- commitlint --edit {1}

--- a/generated/base/.github/workflows/test.yml
+++ b/generated/base/.github/workflows/test.yml
@@ -45,8 +45,8 @@ jobs:
         continue-on-error: true
         run: lefthook run pre-commit --all-files
 
-      # lefthook-config's formatters run `git add` after formatting, which stages the changes.
-      # https://github.com/fohte/lefthook-config/blob/v0.1.7/base.yml
+      # Formatters configured with `stage_fixed: true` run `git add` after formatting,
+      # which stages the changes.
       # commit-action uses `git ls-files --modified` which only detects unstaged changes.
       # https://github.com/suzuki-shunsuke/commit-action/blob/87b297f0ce551411b43d1880f4fb3cbc60381055/action.yaml#L57
       # We need to unstage the changes so commit-action can detect them.

--- a/generated/base/.mise.toml
+++ b/generated/base/.mise.toml
@@ -6,6 +6,8 @@ actionlint = "1.7.12"
 node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
+# When no node project is present in the repo, prettier and commitlint are
+# provided via mise since there is no package.json to host them.
 "npm:@commitlint/cli" = "20.5.0"
 "npm:prettier" = "3.8.1"
 shellcheck = "0.11.0"

--- a/generated/base/lefthook.yml
+++ b/generated/base/lefthook.yml
@@ -40,17 +40,18 @@ pre-commit:
         # Renovate does not support the `gh:` prefix in _src_path.
         # See: https://github.com/renovatebot/renovate/issues/39938
         for file in {staged_files}; do
-          if [ -f "$file" ]; then
-            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
-            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
-              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+          [ -f "$file" ] || continue
+          # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+          src_path=$(sed -n 's/^_src_path:[[:space:]]*//p' "$file" | head -n 1)
+          case "$src_path" in
+            gh:* | "'gh:"* | '"gh:'*)
               suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
               echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
               echo "Please use a full 'https://' URL instead." >&2
               printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
               exit 1
-            fi
-          fi
+              ;;
+          esac
         done
 
 commit-msg:

--- a/generated/base/lefthook.yml
+++ b/generated/base/lefthook.yml
@@ -1,5 +1,59 @@
-remotes:
-  - git_url: https://github.com/fohte/lefthook-config.git
-    ref: v0.1.16 # renovate: datasource=github-tags depName=fohte/lefthook-config
-    configs:
-      - base.yml
+pre-commit:
+  commands:
+    format:
+      # Remove trailing whitespace and ensure final newline
+      run: basefmt {staged_files}
+      glob: '*'
+      stage_fixed: true
+
+    prettier:
+      run: mise x -- prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
+      stage_fixed: true
+
+    shellcheck:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shellcheck -- shellcheck {staged_files}
+
+    shfmt:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shfmt -- shfmt --apply-ignore -w {staged_files}
+      stage_fixed: true
+
+    pinact:
+      glob: '{.github/workflows/*.{yml,yaml},.github/actions/**/action.{yml,yaml}}'
+      run: mise x pinact -- pinact run {staged_files}
+      stage_fixed: true
+
+    actionlint:
+      glob: '.github/workflows/*.{yml,yaml}'
+      run: mise x actionlint -- actionlint {staged_files}
+
+    copier-src-path:
+      glob: '.copier-answers.yml'
+      run: |
+        # Renovate does not support the `gh:` prefix in _src_path.
+        # See: https://github.com/renovatebot/renovate/issues/39938
+        for file in {staged_files}; do
+          if [ -f "$file" ]; then
+            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
+              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+              suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
+              echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
+              echo "Please use a full 'https://' URL instead." >&2
+              printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
+              exit 1
+            fi
+          fi
+        done
+
+commit-msg:
+  commands:
+    commitlint:
+      run: mise x -- commitlint --edit {1}

--- a/generated/monorepo-node-workspace/.github/workflows/test.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/test.yml
@@ -64,8 +64,8 @@ jobs:
         continue-on-error: true
         run: lefthook run pre-commit --all-files
 
-      # lefthook-config's formatters run `git add` after formatting, which stages the changes.
-      # https://github.com/fohte/lefthook-config/blob/v0.1.7/base.yml
+      # Formatters configured with `stage_fixed: true` run `git add` after formatting,
+      # which stages the changes.
       # commit-action uses `git ls-files --modified` which only detects unstaged changes.
       # https://github.com/suzuki-shunsuke/commit-action/blob/87b297f0ce551411b43d1880f4fb3cbc60381055/action.yaml#L57
       # We need to unstage the changes so commit-action can detect them.

--- a/generated/monorepo-node-workspace/lefthook.yml
+++ b/generated/monorepo-node-workspace/lefthook.yml
@@ -40,17 +40,18 @@ pre-commit:
         # Renovate does not support the `gh:` prefix in _src_path.
         # See: https://github.com/renovatebot/renovate/issues/39938
         for file in {staged_files}; do
-          if [ -f "$file" ]; then
-            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
-            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
-              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+          [ -f "$file" ] || continue
+          # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+          src_path=$(sed -n 's/^_src_path:[[:space:]]*//p' "$file" | head -n 1)
+          case "$src_path" in
+            gh:* | "'gh:"* | '"gh:'*)
               suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
               echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
               echo "Please use a full 'https://' URL instead." >&2
               printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
               exit 1
-            fi
-          fi
+              ;;
+          esac
         done
 
     # lefthook's default glob uses gobwas/glob without a delimiter, so

--- a/generated/monorepo-node-workspace/lefthook.yml
+++ b/generated/monorepo-node-workspace/lefthook.yml
@@ -53,7 +53,8 @@ pre-commit:
               ;;
           esac
         done
-# lefthook's default glob uses gobwas/glob without a delimiter, so
+
+    # lefthook's default glob uses gobwas/glob without a delimiter, so
     # '*.{js,ts,...}' also matches nested paths (e.g. frontend/src/foo.ts).
     # A single root-level eslint covers every workspace package, and running
     # per-package eslint in parallel would race on --fix / stage_fixed writes.

--- a/generated/monorepo-node-workspace/lefthook.yml
+++ b/generated/monorepo-node-workspace/lefthook.yml
@@ -53,7 +53,7 @@ pre-commit:
               ;;
           esac
         done
-# lefthook's default glob uses gobwas/glob without a delimiter, so
+    # lefthook's default glob uses gobwas/glob without a delimiter, so
     # '*.{js,ts,...}' also matches nested paths (e.g. frontend/src/foo.ts).
     # A single root-level eslint covers every workspace package, and running
     # per-package eslint in parallel would race on --fix / stage_fixed writes.

--- a/generated/monorepo-node-workspace/lefthook.yml
+++ b/generated/monorepo-node-workspace/lefthook.yml
@@ -53,7 +53,7 @@ pre-commit:
               ;;
           esac
         done
-    # lefthook's default glob uses gobwas/glob without a delimiter, so
+# lefthook's default glob uses gobwas/glob without a delimiter, so
     # '*.{js,ts,...}' also matches nested paths (e.g. frontend/src/foo.ts).
     # A single root-level eslint covers every workspace package, and running
     # per-package eslint in parallel would race on --fix / stage_fixed writes.

--- a/generated/monorepo-node-workspace/lefthook.yml
+++ b/generated/monorepo-node-workspace/lefthook.yml
@@ -53,7 +53,6 @@ pre-commit:
               ;;
           esac
         done
-
     # lefthook's default glob uses gobwas/glob without a delimiter, so
     # '*.{js,ts,...}' also matches nested paths (e.g. frontend/src/foo.ts).
     # A single root-level eslint covers every workspace package, and running

--- a/generated/monorepo-node-workspace/lefthook.yml
+++ b/generated/monorepo-node-workspace/lefthook.yml
@@ -1,11 +1,58 @@
-remotes:
-  - git_url: https://github.com/fohte/lefthook-config.git
-    ref: v0.1.16 # renovate: datasource=github-tags depName=fohte/lefthook-config
-    configs:
-      - base.yml
-
 pre-commit:
   commands:
+    format:
+      # Remove trailing whitespace and ensure final newline
+      run: basefmt {staged_files}
+      glob: '*'
+      stage_fixed: true
+
+    prettier:
+      run: pnpm exec prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
+      stage_fixed: true
+
+    shellcheck:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shellcheck -- shellcheck {staged_files}
+
+    shfmt:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shfmt -- shfmt --apply-ignore -w {staged_files}
+      stage_fixed: true
+
+    pinact:
+      glob: '{.github/workflows/*.{yml,yaml},.github/actions/**/action.{yml,yaml}}'
+      run: mise x pinact -- pinact run {staged_files}
+      stage_fixed: true
+
+    actionlint:
+      glob: '.github/workflows/*.{yml,yaml}'
+      run: mise x actionlint -- actionlint {staged_files}
+
+    copier-src-path:
+      glob: '.copier-answers.yml'
+      run: |
+        # Renovate does not support the `gh:` prefix in _src_path.
+        # See: https://github.com/renovatebot/renovate/issues/39938
+        for file in {staged_files}; do
+          if [ -f "$file" ]; then
+            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
+              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+              suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
+              echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
+              echo "Please use a full 'https://' URL instead." >&2
+              printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
+              exit 1
+            fi
+          fi
+        done
+
     # lefthook's default glob uses gobwas/glob without a delimiter, so
     # '*.{js,ts,...}' also matches nested paths (e.g. frontend/src/foo.ts).
     # A single root-level eslint covers every workspace package, and running
@@ -13,3 +60,8 @@ pre-commit:
     eslint:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
       run: pnpm exec eslint {staged_files}
+
+commit-msg:
+  commands:
+    commitlint:
+      run: pnpm exec commitlint --edit {1}

--- a/generated/monorepo/.github/workflows/test.yml
+++ b/generated/monorepo/.github/workflows/test.yml
@@ -64,9 +64,13 @@ jobs:
         with:
           path: |
             ${{ steps.pnpm-store.outputs.path }}
+            node_modules
             frontend/node_modules
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml', 'frontend/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-
+
+      - name: Install pnpm dependencies (root)
+        run: pnpm install --frozen-lockfile
 
       - name: Install pnpm dependencies (frontend)
         run: cd "frontend" && pnpm install --frozen-lockfile

--- a/generated/monorepo/.github/workflows/test.yml
+++ b/generated/monorepo/.github/workflows/test.yml
@@ -79,8 +79,8 @@ jobs:
         continue-on-error: true
         run: lefthook run pre-commit --all-files
 
-      # lefthook-config's formatters run `git add` after formatting, which stages the changes.
-      # https://github.com/fohte/lefthook-config/blob/v0.1.7/base.yml
+      # Formatters configured with `stage_fixed: true` run `git add` after formatting,
+      # which stages the changes.
       # commit-action uses `git ls-files --modified` which only detects unstaged changes.
       # https://github.com/suzuki-shunsuke/commit-action/blob/87b297f0ce551411b43d1880f4fb3cbc60381055/action.yaml#L57
       # We need to unstage the changes so commit-action can detect them.

--- a/generated/monorepo/.mise.toml
+++ b/generated/monorepo/.mise.toml
@@ -7,8 +7,6 @@ actionlint = "1.7.12"
 node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
-"npm:@commitlint/cli" = "20.5.0"
-"npm:prettier" = "3.8.1"
 shellcheck = "0.11.0"
 shfmt = "3.13.0"
 

--- a/generated/monorepo/lefthook.yml
+++ b/generated/monorepo/lefthook.yml
@@ -40,17 +40,18 @@ pre-commit:
         # Renovate does not support the `gh:` prefix in _src_path.
         # See: https://github.com/renovatebot/renovate/issues/39938
         for file in {staged_files}; do
-          if [ -f "$file" ]; then
-            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
-            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
-              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+          [ -f "$file" ] || continue
+          # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+          src_path=$(sed -n 's/^_src_path:[[:space:]]*//p' "$file" | head -n 1)
+          case "$src_path" in
+            gh:* | "'gh:"* | '"gh:'*)
               suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
               echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
               echo "Please use a full 'https://' URL instead." >&2
               printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
               exit 1
-            fi
-          fi
+              ;;
+          esac
         done
 
     # Non-workspace multi-package monorepo: each subpackage has its own
@@ -70,7 +71,8 @@ pre-commit:
     cargo-fmt:
       glob: '*.rs'
       root: 'backend/'
-      run: cargo fmt -- {staged_files}
+      run: cargo fmt
+      stage_fixed: true
 
     cargo-clippy:
       glob: '*.rs'

--- a/generated/monorepo/lefthook.yml
+++ b/generated/monorepo/lefthook.yml
@@ -1,22 +1,83 @@
-remotes:
-  - git_url: https://github.com/fohte/lefthook-config.git
-    ref: v0.1.16 # renovate: datasource=github-tags depName=fohte/lefthook-config
-    configs:
-      - base.yml
-      - rust.yml
-
 pre-commit:
   commands:
+    format:
+      # Remove trailing whitespace and ensure final newline
+      run: basefmt {staged_files}
+      glob: '*'
+      stage_fixed: true
+
+    prettier:
+      run: mise x -- prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
+      stage_fixed: true
+
+    shellcheck:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shellcheck -- shellcheck {staged_files}
+
+    shfmt:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shfmt -- shfmt --apply-ignore -w {staged_files}
+      stage_fixed: true
+
+    pinact:
+      glob: '{.github/workflows/*.{yml,yaml},.github/actions/**/action.{yml,yaml}}'
+      run: mise x pinact -- pinact run {staged_files}
+      stage_fixed: true
+
+    actionlint:
+      glob: '.github/workflows/*.{yml,yaml}'
+      run: mise x actionlint -- actionlint {staged_files}
+
+    copier-src-path:
+      glob: '.copier-answers.yml'
+      run: |
+        # Renovate does not support the `gh:` prefix in _src_path.
+        # See: https://github.com/renovatebot/renovate/issues/39938
+        for file in {staged_files}; do
+          if [ -f "$file" ]; then
+            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
+              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+              suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
+              echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
+              echo "Please use a full 'https://' URL instead." >&2
+              printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
+              exit 1
+            fi
+          fi
+        done
+
     # Non-workspace multi-package monorepo: each subpackage has its own
     # eslint.config.js and dependencies, so lint per package from its root.
     eslint-frontend:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
       root: 'frontend/'
       run: pnpm exec eslint {staged_files}
+
     ast-grep:
       glob: '*.rs'
       run: ast-grep scan {staged_files}
+
+    # Using glob instead of file_types because text/x-rust is not supported
+    # by the mimetype library used by lefthook.
+    # See: https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md
     cargo-fmt:
+      glob: '*.rs'
       root: 'backend/'
+      run: cargo fmt -- {staged_files}
+
     cargo-clippy:
+      glob: '*.rs'
       root: 'backend/'
+      run: cargo clippy --all-targets -- -D warnings
+
+commit-msg:
+  commands:
+    commitlint:
+      run: mise x -- commitlint --edit {1}

--- a/generated/monorepo/lefthook.yml
+++ b/generated/monorepo/lefthook.yml
@@ -7,7 +7,7 @@ pre-commit:
       stage_fixed: true
 
     prettier:
-      run: mise x -- prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
+      run: pnpm exec prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true
 
     shellcheck:
@@ -82,4 +82,4 @@ pre-commit:
 commit-msg:
   commands:
     commitlint:
-      run: mise x -- commitlint --edit {1}
+      run: pnpm exec commitlint --edit {1}

--- a/generated/monorepo/lefthook.yml
+++ b/generated/monorepo/lefthook.yml
@@ -60,7 +60,7 @@ pre-commit:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
       root: 'frontend/'
       run: pnpm exec eslint {staged_files}
-
+    
     ast-grep:
       glob: '*.rs'
       run: ast-grep scan {staged_files}

--- a/generated/monorepo/lefthook.yml
+++ b/generated/monorepo/lefthook.yml
@@ -60,7 +60,7 @@ pre-commit:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
       root: 'frontend/'
       run: pnpm exec eslint {staged_files}
-    
+
     ast-grep:
       glob: '*.rs'
       run: ast-grep scan {staged_files}

--- a/generated/monorepo/package.json
+++ b/generated/monorepo/package.json
@@ -1,5 +1,9 @@
 {
   "name": "monorepo",
   "private": true,
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@10.33.0",
+  "devDependencies": {
+    "@commitlint/cli": "20.5.0",
+    "prettier": "3.8.1"
+  }
 }

--- a/generated/monorepo/scripts/bootstrap
+++ b/generated/monorepo/scripts/bootstrap
@@ -39,7 +39,9 @@ if [ "$worktree" = false ] && command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi
 
-# Install Node.js dependencies
+# Install shared dev tools (prettier, commitlint) at the repo root
+pnpm install
+# Install Node.js dependencies for each subpackage
 (cd frontend && pnpm install)
 
 # Fetch Rust dependencies

--- a/generated/node/.github/workflows/test.yml
+++ b/generated/node/.github/workflows/test.yml
@@ -62,8 +62,8 @@ jobs:
         continue-on-error: true
         run: lefthook run pre-commit --all-files
 
-      # lefthook-config's formatters run `git add` after formatting, which stages the changes.
-      # https://github.com/fohte/lefthook-config/blob/v0.1.7/base.yml
+      # Formatters configured with `stage_fixed: true` run `git add` after formatting,
+      # which stages the changes.
       # commit-action uses `git ls-files --modified` which only detects unstaged changes.
       # https://github.com/suzuki-shunsuke/commit-action/blob/87b297f0ce551411b43d1880f4fb3cbc60381055/action.yaml#L57
       # We need to unstage the changes so commit-action can detect them.

--- a/generated/node/lefthook.yml
+++ b/generated/node/lefthook.yml
@@ -1,11 +1,63 @@
-remotes:
-  - git_url: https://github.com/fohte/lefthook-config.git
-    ref: v0.1.16 # renovate: datasource=github-tags depName=fohte/lefthook-config
-    configs:
-      - base.yml
-
 pre-commit:
   commands:
+    format:
+      # Remove trailing whitespace and ensure final newline
+      run: basefmt {staged_files}
+      glob: '*'
+      stage_fixed: true
+
+    prettier:
+      run: pnpm exec prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
+      stage_fixed: true
+
+    shellcheck:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shellcheck -- shellcheck {staged_files}
+
+    shfmt:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shfmt -- shfmt --apply-ignore -w {staged_files}
+      stage_fixed: true
+
+    pinact:
+      glob: '{.github/workflows/*.{yml,yaml},.github/actions/**/action.{yml,yaml}}'
+      run: mise x pinact -- pinact run {staged_files}
+      stage_fixed: true
+
+    actionlint:
+      glob: '.github/workflows/*.{yml,yaml}'
+      run: mise x actionlint -- actionlint {staged_files}
+
+    copier-src-path:
+      glob: '.copier-answers.yml'
+      run: |
+        # Renovate does not support the `gh:` prefix in _src_path.
+        # See: https://github.com/renovatebot/renovate/issues/39938
+        for file in {staged_files}; do
+          if [ -f "$file" ]; then
+            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
+              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+              suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
+              echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
+              echo "Please use a full 'https://' URL instead." >&2
+              printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
+              exit 1
+            fi
+          fi
+        done
+
     eslint:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
       run: pnpm exec eslint {staged_files}
+
+commit-msg:
+  commands:
+    commitlint:
+      run: pnpm exec commitlint --edit {1}

--- a/generated/node/lefthook.yml
+++ b/generated/node/lefthook.yml
@@ -53,10 +53,9 @@ pre-commit:
               ;;
           esac
         done
-
-    eslint:
-      glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
-      run: pnpm exec eslint {staged_files}
+eslint:
+  glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
+  run: pnpm exec eslint {staged_files}
 
 commit-msg:
   commands:

--- a/generated/node/lefthook.yml
+++ b/generated/node/lefthook.yml
@@ -54,8 +54,8 @@ pre-commit:
           esac
         done
 eslint:
-      glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
-      run: pnpm exec eslint {staged_files}
+  glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
+  run: pnpm exec eslint {staged_files}
 
 commit-msg:
   commands:

--- a/generated/node/lefthook.yml
+++ b/generated/node/lefthook.yml
@@ -40,17 +40,18 @@ pre-commit:
         # Renovate does not support the `gh:` prefix in _src_path.
         # See: https://github.com/renovatebot/renovate/issues/39938
         for file in {staged_files}; do
-          if [ -f "$file" ]; then
-            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
-            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
-              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+          [ -f "$file" ] || continue
+          # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+          src_path=$(sed -n 's/^_src_path:[[:space:]]*//p' "$file" | head -n 1)
+          case "$src_path" in
+            gh:* | "'gh:"* | '"gh:'*)
               suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
               echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
               echo "Please use a full 'https://' URL instead." >&2
               printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
               exit 1
-            fi
-          fi
+              ;;
+          esac
         done
 
     eslint:

--- a/generated/node/lefthook.yml
+++ b/generated/node/lefthook.yml
@@ -54,8 +54,8 @@ pre-commit:
           esac
         done
 eslint:
-  glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
-  run: pnpm exec eslint {staged_files}
+      glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
+      run: pnpm exec eslint {staged_files}
 
 commit-msg:
   commands:

--- a/generated/node/lefthook.yml
+++ b/generated/node/lefthook.yml
@@ -53,7 +53,8 @@ pre-commit:
               ;;
           esac
         done
-eslint:
+
+    eslint:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
       run: pnpm exec eslint {staged_files}
 

--- a/generated/rust-release/.github/workflows/test.yml
+++ b/generated/rust-release/.github/workflows/test.yml
@@ -63,8 +63,8 @@ jobs:
         continue-on-error: true
         run: lefthook run pre-commit --all-files
 
-      # lefthook-config's formatters run `git add` after formatting, which stages the changes.
-      # https://github.com/fohte/lefthook-config/blob/v0.1.7/base.yml
+      # Formatters configured with `stage_fixed: true` run `git add` after formatting,
+      # which stages the changes.
       # commit-action uses `git ls-files --modified` which only detects unstaged changes.
       # https://github.com/suzuki-shunsuke/commit-action/blob/87b297f0ce551411b43d1880f4fb3cbc60381055/action.yaml#L57
       # We need to unstage the changes so commit-action can detect them.

--- a/generated/rust-release/.mise.toml
+++ b/generated/rust-release/.mise.toml
@@ -7,6 +7,8 @@ actionlint = "1.7.12"
 node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
+# When no node project is present in the repo, prettier and commitlint are
+# provided via mise since there is no package.json to host them.
 "npm:@commitlint/cli" = "20.5.0"
 "npm:prettier" = "3.8.1"
 shellcheck = "0.11.0"

--- a/generated/rust-release/lefthook.yml
+++ b/generated/rust-release/lefthook.yml
@@ -40,17 +40,18 @@ pre-commit:
         # Renovate does not support the `gh:` prefix in _src_path.
         # See: https://github.com/renovatebot/renovate/issues/39938
         for file in {staged_files}; do
-          if [ -f "$file" ]; then
-            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
-            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
-              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+          [ -f "$file" ] || continue
+          # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+          src_path=$(sed -n 's/^_src_path:[[:space:]]*//p' "$file" | head -n 1)
+          case "$src_path" in
+            gh:* | "'gh:"* | '"gh:'*)
               suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
               echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
               echo "Please use a full 'https://' URL instead." >&2
               printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
               exit 1
-            fi
-          fi
+              ;;
+          esac
         done
 
     ast-grep:
@@ -62,7 +63,8 @@ pre-commit:
     # See: https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md
     cargo-fmt:
       glob: '*.rs'
-      run: cargo fmt -- {staged_files}
+      run: cargo fmt
+      stage_fixed: true
 
     cargo-clippy:
       glob: '*.rs'

--- a/generated/rust-release/lefthook.yml
+++ b/generated/rust-release/lefthook.yml
@@ -1,12 +1,74 @@
-remotes:
-  - git_url: https://github.com/fohte/lefthook-config.git
-    ref: v0.1.16 # renovate: datasource=github-tags depName=fohte/lefthook-config
-    configs:
-      - base.yml
-      - rust.yml
-
 pre-commit:
   commands:
+    format:
+      # Remove trailing whitespace and ensure final newline
+      run: basefmt {staged_files}
+      glob: '*'
+      stage_fixed: true
+
+    prettier:
+      run: mise x -- prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
+      stage_fixed: true
+
+    shellcheck:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shellcheck -- shellcheck {staged_files}
+
+    shfmt:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shfmt -- shfmt --apply-ignore -w {staged_files}
+      stage_fixed: true
+
+    pinact:
+      glob: '{.github/workflows/*.{yml,yaml},.github/actions/**/action.{yml,yaml}}'
+      run: mise x pinact -- pinact run {staged_files}
+      stage_fixed: true
+
+    actionlint:
+      glob: '.github/workflows/*.{yml,yaml}'
+      run: mise x actionlint -- actionlint {staged_files}
+
+    copier-src-path:
+      glob: '.copier-answers.yml'
+      run: |
+        # Renovate does not support the `gh:` prefix in _src_path.
+        # See: https://github.com/renovatebot/renovate/issues/39938
+        for file in {staged_files}; do
+          if [ -f "$file" ]; then
+            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
+              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+              suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
+              echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
+              echo "Please use a full 'https://' URL instead." >&2
+              printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
+              exit 1
+            fi
+          fi
+        done
+
     ast-grep:
       glob: '*.rs'
       run: ast-grep scan {staged_files}
+
+    # Using glob instead of file_types because text/x-rust is not supported
+    # by the mimetype library used by lefthook.
+    # See: https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md
+    cargo-fmt:
+      glob: '*.rs'
+      run: cargo fmt -- {staged_files}
+
+    cargo-clippy:
+      glob: '*.rs'
+      run: cargo clippy --all-targets -- -D warnings
+
+commit-msg:
+  commands:
+    commitlint:
+      run: mise x -- commitlint --edit {1}

--- a/generated/rust/.github/workflows/test.yml
+++ b/generated/rust/.github/workflows/test.yml
@@ -60,8 +60,8 @@ jobs:
         continue-on-error: true
         run: lefthook run pre-commit --all-files
 
-      # lefthook-config's formatters run `git add` after formatting, which stages the changes.
-      # https://github.com/fohte/lefthook-config/blob/v0.1.7/base.yml
+      # Formatters configured with `stage_fixed: true` run `git add` after formatting,
+      # which stages the changes.
       # commit-action uses `git ls-files --modified` which only detects unstaged changes.
       # https://github.com/suzuki-shunsuke/commit-action/blob/87b297f0ce551411b43d1880f4fb3cbc60381055/action.yaml#L57
       # We need to unstage the changes so commit-action can detect them.

--- a/generated/rust/.mise.toml
+++ b/generated/rust/.mise.toml
@@ -7,6 +7,8 @@ actionlint = "1.7.12"
 node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
+# When no node project is present in the repo, prettier and commitlint are
+# provided via mise since there is no package.json to host them.
 "npm:@commitlint/cli" = "20.5.0"
 "npm:prettier" = "3.8.1"
 shellcheck = "0.11.0"

--- a/generated/rust/lefthook.yml
+++ b/generated/rust/lefthook.yml
@@ -40,17 +40,18 @@ pre-commit:
         # Renovate does not support the `gh:` prefix in _src_path.
         # See: https://github.com/renovatebot/renovate/issues/39938
         for file in {staged_files}; do
-          if [ -f "$file" ]; then
-            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
-            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
-              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+          [ -f "$file" ] || continue
+          # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+          src_path=$(sed -n 's/^_src_path:[[:space:]]*//p' "$file" | head -n 1)
+          case "$src_path" in
+            gh:* | "'gh:"* | '"gh:'*)
               suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
               echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
               echo "Please use a full 'https://' URL instead." >&2
               printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
               exit 1
-            fi
-          fi
+              ;;
+          esac
         done
 
     ast-grep:
@@ -62,7 +63,8 @@ pre-commit:
     # See: https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md
     cargo-fmt:
       glob: '*.rs'
-      run: cargo fmt -- {staged_files}
+      run: cargo fmt
+      stage_fixed: true
 
     cargo-clippy:
       glob: '*.rs'

--- a/generated/rust/lefthook.yml
+++ b/generated/rust/lefthook.yml
@@ -1,12 +1,74 @@
-remotes:
-  - git_url: https://github.com/fohte/lefthook-config.git
-    ref: v0.1.16 # renovate: datasource=github-tags depName=fohte/lefthook-config
-    configs:
-      - base.yml
-      - rust.yml
-
 pre-commit:
   commands:
+    format:
+      # Remove trailing whitespace and ensure final newline
+      run: basefmt {staged_files}
+      glob: '*'
+      stage_fixed: true
+
+    prettier:
+      run: mise x -- prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
+      stage_fixed: true
+
+    shellcheck:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shellcheck -- shellcheck {staged_files}
+
+    shfmt:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shfmt -- shfmt --apply-ignore -w {staged_files}
+      stage_fixed: true
+
+    pinact:
+      glob: '{.github/workflows/*.{yml,yaml},.github/actions/**/action.{yml,yaml}}'
+      run: mise x pinact -- pinact run {staged_files}
+      stage_fixed: true
+
+    actionlint:
+      glob: '.github/workflows/*.{yml,yaml}'
+      run: mise x actionlint -- actionlint {staged_files}
+
+    copier-src-path:
+      glob: '.copier-answers.yml'
+      run: |
+        # Renovate does not support the `gh:` prefix in _src_path.
+        # See: https://github.com/renovatebot/renovate/issues/39938
+        for file in {staged_files}; do
+          if [ -f "$file" ]; then
+            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
+              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+              suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
+              echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
+              echo "Please use a full 'https://' URL instead." >&2
+              printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
+              exit 1
+            fi
+          fi
+        done
+
     ast-grep:
       glob: '*.rs'
       run: ast-grep scan {staged_files}
+
+    # Using glob instead of file_types because text/x-rust is not supported
+    # by the mimetype library used by lefthook.
+    # See: https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md
+    cargo-fmt:
+      glob: '*.rs'
+      run: cargo fmt -- {staged_files}
+
+    cargo-clippy:
+      glob: '*.rs'
+      run: cargo clippy --all-targets -- -D warnings
+
+commit-msg:
+  commands:
+    commitlint:
+      run: mise x -- commitlint --edit {1}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -40,17 +40,18 @@ pre-commit:
         # Renovate does not support the `gh:` prefix in _src_path.
         # See: https://github.com/renovatebot/renovate/issues/39938
         for file in {staged_files}; do
-          if [ -f "$file" ]; then
-            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
-            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
-              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+          [ -f "$file" ] || continue
+          # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+          src_path=$(sed -n 's/^_src_path:[[:space:]]*//p' "$file" | head -n 1)
+          case "$src_path" in
+            gh:* | "'gh:"* | '"gh:'*)
               suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
               echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
               echo "Please use a full 'https://' URL instead." >&2
               printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
               exit 1
-            fi
-          fi
+              ;;
+          esac
         done
 
 commit-msg:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,59 @@
-remotes:
-  - git_url: https://github.com/fohte/lefthook-config.git
-    ref: v0.1.16 # renovate: datasource=github-tags depName=fohte/lefthook-config
-    configs:
-      - base.yml
+pre-commit:
+  commands:
+    format:
+      # Remove trailing whitespace and ensure final newline
+      run: basefmt {staged_files}
+      glob: '*'
+      stage_fixed: true
+
+    prettier:
+      run: mise x -- prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
+      stage_fixed: true
+
+    shellcheck:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shellcheck -- shellcheck {staged_files}
+
+    shfmt:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shfmt -- shfmt --apply-ignore -w {staged_files}
+      stage_fixed: true
+
+    pinact:
+      glob: '{.github/workflows/*.{yml,yaml},.github/actions/**/action.{yml,yaml}}'
+      run: mise x pinact -- pinact run {staged_files}
+      stage_fixed: true
+
+    actionlint:
+      glob: '.github/workflows/*.{yml,yaml}'
+      run: mise x actionlint -- actionlint {staged_files}
+
+    copier-src-path:
+      glob: '.copier-answers.yml'
+      run: |
+        # Renovate does not support the `gh:` prefix in _src_path.
+        # See: https://github.com/renovatebot/renovate/issues/39938
+        for file in {staged_files}; do
+          if [ -f "$file" ]; then
+            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
+              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+              suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
+              echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
+              echo "Please use a full 'https://' URL instead." >&2
+              printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
+              exit 1
+            fi
+          fi
+        done
+
+commit-msg:
+  commands:
+    commitlint:
+      run: mise x -- commitlint --edit {1}

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -114,7 +114,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 {%- else %}
-{#- Non-workspace mode: per-package install #}
+{#- Non-workspace mode: root install for shared tools + per-package install #}
 
       - run: corepack enable
 
@@ -127,12 +127,15 @@ jobs:
         with:
           path: |
             {% raw %}${{ steps.pnpm-store.outputs.path }}{% endraw %}
+            node_modules
 {%- for pkg in node_pkgs %}
             {{ pkg.name }}/node_modules
 {%- endfor %}
-          key: {% raw %}${{ runner.os }}-pnpm-${{ hashFiles({% endraw %}{% for pkg in node_pkgs %}'{{ pkg.name }}/pnpm-lock.yaml'{{ ', ' if not loop.last else '' }}{% endfor %}{% raw %}) }}{% endraw %}
+          key: {% raw %}${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml', {% endraw %}{% for pkg in node_pkgs %}'{{ pkg.name }}/pnpm-lock.yaml'{{ ', ' if not loop.last else '' }}{% endfor %}{% raw %}) }}{% endraw %}
           restore-keys: {% raw %}${{ runner.os }}-pnpm-{% endraw %}
 
+      - name: Install pnpm dependencies (root)
+        run: pnpm install --frozen-lockfile
 {%- for pkg in node_pkgs %}
 
       - name: Install pnpm dependencies ({{ pkg.name }})

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -155,8 +155,8 @@ jobs:
         continue-on-error: true
         run: lefthook run pre-commit --all-files
 
-      # lefthook-config's formatters run `git add` after formatting, which stages the changes.
-      # https://github.com/fohte/lefthook-config/blob/v0.1.7/base.yml
+      # Formatters configured with `stage_fixed: true` run `git add` after formatting,
+      # which stages the changes.
       # commit-action uses `git ls-files --modified` which only detects unstaged changes.
       # https://github.com/suzuki-shunsuke/commit-action/blob/87b297f0ce551411b43d1880f4fb3cbc60381055/action.yaml#L57
       # We need to unstage the changes so commit-action can detect them.

--- a/template/.mise.toml.jinja
+++ b/template/.mise.toml.jinja
@@ -11,7 +11,9 @@ actionlint = "1.7.12"
 node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
-{% if type != 'node' and not (monorepo_node_workspace | default(false)) -%}
+{% if not has_node -%}
+# When no node project is present in the repo, prettier and commitlint are
+# provided via mise since there is no package.json to host them.
 "npm:@commitlint/cli" = "20.5.0"
 "npm:prettier" = "3.8.1"
 {% endif -%}

--- a/template/lefthook.yml.jinja
+++ b/template/lefthook.yml.jinja
@@ -2,7 +2,7 @@
 {%- set node_pkgs = subpackages | selectattr('type', 'equalto', 'node') | list -%}
 {%- set rust_pkgs = subpackages | selectattr('type', 'equalto', 'rust') | list -%}
 {%- set has_rust = (type == 'rust') or (rust_pkgs | length > 0) -%}
-{%- set root_pnpm = (type == 'node') or (monorepo_node_workspace | default(false)) -%}
+{%- set root_pnpm = has_node -%}
 pre-commit:
   commands:
     format:
@@ -67,7 +67,7 @@ pre-commit:
     eslint:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
       run: pnpm exec eslint {staged_files}
-{%- elif has_node and root_pnpm %}
+{%- elif type == 'node' %}
 
     eslint:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'

--- a/template/lefthook.yml.jinja
+++ b/template/lefthook.yml.jinja
@@ -3,13 +3,6 @@
 {%- set rust_pkgs = subpackages | selectattr('type', 'equalto', 'rust') | list -%}
 {%- set has_rust = (type == 'rust') or (rust_pkgs | length > 0) -%}
 {%- set root_pnpm = (type == 'node') or (monorepo_node_workspace | default(false)) -%}
-{%- if root_pnpm -%}
-{%-   set prettier_run = 'pnpm exec prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}' -%}
-{%-   set commitlint_run = 'pnpm exec commitlint --edit {1}' -%}
-{%- else -%}
-{%-   set prettier_run = 'mise x -- prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}' -%}
-{%-   set commitlint_run = 'mise x -- commitlint --edit {1}' -%}
-{%- endif -%}
 pre-commit:
   commands:
     format:
@@ -19,7 +12,7 @@ pre-commit:
       stage_fixed: true
 
     prettier:
-      run: {{ prettier_run }}
+      run: {{ 'pnpm exec' if root_pnpm else 'mise x --' }} prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true
 
     shellcheck:
@@ -118,4 +111,4 @@ pre-commit:
 commit-msg:
   commands:
     commitlint:
-      run: {{ commitlint_run }}
+      run: {{ 'pnpm exec' if root_pnpm else 'mise x --' }} commitlint --edit {1}

--- a/template/lefthook.yml.jinja
+++ b/template/lefthook.yml.jinja
@@ -2,50 +2,124 @@
 {%- set node_pkgs = subpackages | selectattr('type', 'equalto', 'node') | list -%}
 {%- set rust_pkgs = subpackages | selectattr('type', 'equalto', 'rust') | list -%}
 {%- set has_rust = (type == 'rust') or (rust_pkgs | length > 0) -%}
-{%- set eslint_run = 'pnpm exec eslint {staged_files}' -%}
-remotes:
-  - git_url: https://github.com/fohte/lefthook-config.git
-    ref: v0.1.16 # renovate: datasource=github-tags depName=fohte/lefthook-config
-    configs:
-      - base.yml
-{%- if has_rust %}
-      - rust.yml
-{%- endif %}
-{%- if has_node or has_rust %}
-
+{%- set root_pnpm = (type == 'node') or (monorepo_node_workspace | default(false)) -%}
+{%- if root_pnpm -%}
+{%-   set prettier_run = 'pnpm exec prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}' -%}
+{%-   set commitlint_run = 'pnpm exec commitlint --edit {1}' -%}
+{%- else -%}
+{%-   set prettier_run = 'mise x -- prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}' -%}
+{%-   set commitlint_run = 'mise x -- commitlint --edit {1}' -%}
+{%- endif -%}
+{#- Build node eslint block -#}
+{%- set node_block = '' -%}
+{%- if has_node and root_pnpm -%}
+{%-   if monorepo_node_workspace | default(false) -%}
+{%-     set node_block = '    # lefthook\'s default glob uses gobwas/glob without a delimiter, so\n    # \'*.{js,ts,...}\' also matches nested paths (e.g. frontend/src/foo.ts).\n    # A single root-level eslint covers every workspace package, and running\n    # per-package eslint in parallel would race on --fix / stage_fixed writes.\n    eslint:\n      glob: \'*.{js,ts,jsx,tsx,mjs,cjs}\'\n      run: pnpm exec eslint {staged_files}\n' -%}
+{%-   else -%}
+{%-     set node_block = '    eslint:\n      glob: \'*.{js,ts,jsx,tsx,mjs,cjs}\'\n      run: pnpm exec eslint {staged_files}\n' -%}
+{%-   endif -%}
+{%- elif has_node -%}
+{%-   set lines = [] -%}
+{%-   for pkg in node_pkgs -%}
+{%-     set _ = lines.append('    # Non-workspace multi-package monorepo: each subpackage has its own') -%}
+{%-     set _ = lines.append('    # eslint.config.js and dependencies, so lint per package from its root.') -%}
+{%-     set _ = lines.append('    eslint-' ~ pkg.name ~ ':') -%}
+{%-     set _ = lines.append('      glob: \'*.{js,ts,jsx,tsx,mjs,cjs}\'') -%}
+{%-     set _ = lines.append('      root: \'' ~ pkg.name ~ '/\'') -%}
+{%-     set _ = lines.append('      run: pnpm exec eslint {staged_files}') -%}
+{%-   endfor -%}
+{%-   set node_block = lines | join('\n') ~ '\n' -%}
+{%- endif -%}
+{#- Build rust block -#}
+{%- set rust_block = '' -%}
+{%- if has_rust -%}
+{%-   set rust_lines = [
+        '    ast-grep:',
+        '      glob: \'*.rs\'',
+        '      run: ast-grep scan {staged_files}',
+        '',
+        '    # Using glob instead of file_types because text/x-rust is not supported',
+        '    # by the mimetype library used by lefthook.',
+        '    # See: https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md',
+        '    cargo-fmt:',
+        '      glob: \'*.rs\''
+      ] -%}
+{%-   if rust_pkgs | length > 0 -%}
+{%-     set _ = rust_lines.append('      root: \'' ~ rust_pkgs[0].name ~ '/\'') -%}
+{%-   endif -%}
+{%-   set _ = rust_lines.append('      run: cargo fmt -- {staged_files}') -%}
+{%-   set _ = rust_lines.append('') -%}
+{%-   set _ = rust_lines.append('    cargo-clippy:') -%}
+{%-   set _ = rust_lines.append('      glob: \'*.rs\'') -%}
+{%-   if rust_pkgs | length > 0 -%}
+{%-     set _ = rust_lines.append('      root: \'' ~ rust_pkgs[0].name ~ '/\'') -%}
+{%-   endif -%}
+{%-   set _ = rust_lines.append('      run: cargo clippy --all-targets -- -D warnings') -%}
+{%-   set rust_block = rust_lines | join('\n') ~ '\n' -%}
+{%- endif -%}
+{#- Combine extra sections with proper blank line separation -#}
+{%- set extras = [] -%}
+{%- if node_block -%}{%- set _ = extras.append(node_block) -%}{%- endif -%}
+{%- if rust_block -%}{%- set _ = extras.append(rust_block) -%}{%- endif -%}
+{%- set extras_text = extras | join('\n') -%}
 pre-commit:
   commands:
-{%- if has_node %}
-{%- if type == 'node' or (monorepo_node_workspace | default(false)) %}
-{%- if monorepo_node_workspace | default(false) %}
-    # lefthook's default glob uses gobwas/glob without a delimiter, so
-    # '*.{js,ts,...}' also matches nested paths (e.g. frontend/src/foo.ts).
-    # A single root-level eslint covers every workspace package, and running
-    # per-package eslint in parallel would race on --fix / stage_fixed writes.
+    format:
+      # Remove trailing whitespace and ensure final newline
+      run: basefmt {staged_files}
+      glob: '*'
+      stage_fixed: true
+
+    prettier:
+      run: {{ prettier_run }}
+      stage_fixed: true
+
+    shellcheck:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shellcheck -- shellcheck {staged_files}
+
+    shfmt:
+      file_types:
+        - text/x-shellscript
+      exclude:
+        - '*.zsh'
+      run: mise x shfmt -- shfmt --apply-ignore -w {staged_files}
+      stage_fixed: true
+
+    pinact:
+      glob: '{.github/workflows/*.{yml,yaml},.github/actions/**/action.{yml,yaml}}'
+      run: mise x pinact -- pinact run {staged_files}
+      stage_fixed: true
+
+    actionlint:
+      glob: '.github/workflows/*.{yml,yaml}'
+      run: mise x actionlint -- actionlint {staged_files}
+
+    copier-src-path:
+      glob: '.copier-answers.yml'
+      run: |
+        # Renovate does not support the `gh:` prefix in _src_path.
+        # See: https://github.com/renovatebot/renovate/issues/39938
+        for file in {staged_files}; do
+          if [ -f "$file" ]; then
+            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
+              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+              suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
+              echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
+              echo "Please use a full 'https://' URL instead." >&2
+              printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
+              exit 1
+            fi
+          fi
+        done
+{% if extras_text %}
+{{ extras_text }}
 {%- endif %}
-    eslint:
-      glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
-      run: {{ eslint_run }}
-{%- else %}
-{%- for pkg in node_pkgs %}
-    # Non-workspace multi-package monorepo: each subpackage has its own
-    # eslint.config.js and dependencies, so lint per package from its root.
-    eslint-{{ pkg.name }}:
-      glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
-      root: '{{ pkg.name }}/'
-      run: {{ eslint_run }}
-{%- endfor %}
-{%- endif %}
-{%- endif %}
-{%- if has_rust %}
-    ast-grep:
-      glob: '*.rs'
-      run: ast-grep scan {staged_files}
-{%- if rust_pkgs | length > 0 %}
-    cargo-fmt:
-      root: '{{ rust_pkgs[0].name }}/'
-    cargo-clippy:
-      root: '{{ rust_pkgs[0].name }}/'
-{%- endif %}
-{%- endif %}
-{%- endif %}
+commit-msg:
+  commands:
+    commitlint:
+      run: {{ commitlint_run }}

--- a/template/lefthook.yml.jinja
+++ b/template/lefthook.yml.jinja
@@ -10,59 +10,6 @@
 {%-   set prettier_run = 'mise x -- prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}' -%}
 {%-   set commitlint_run = 'mise x -- commitlint --edit {1}' -%}
 {%- endif -%}
-{#- Build node eslint block -#}
-{%- set node_block = '' -%}
-{%- if has_node and root_pnpm -%}
-{%-   if monorepo_node_workspace | default(false) -%}
-{%-     set node_block = '    # lefthook\'s default glob uses gobwas/glob without a delimiter, so\n    # \'*.{js,ts,...}\' also matches nested paths (e.g. frontend/src/foo.ts).\n    # A single root-level eslint covers every workspace package, and running\n    # per-package eslint in parallel would race on --fix / stage_fixed writes.\n    eslint:\n      glob: \'*.{js,ts,jsx,tsx,mjs,cjs}\'\n      run: pnpm exec eslint {staged_files}\n' -%}
-{%-   else -%}
-{%-     set node_block = '    eslint:\n      glob: \'*.{js,ts,jsx,tsx,mjs,cjs}\'\n      run: pnpm exec eslint {staged_files}\n' -%}
-{%-   endif -%}
-{%- elif has_node -%}
-{%-   set lines = [] -%}
-{%-   for pkg in node_pkgs -%}
-{%-     set _ = lines.append('    # Non-workspace multi-package monorepo: each subpackage has its own') -%}
-{%-     set _ = lines.append('    # eslint.config.js and dependencies, so lint per package from its root.') -%}
-{%-     set _ = lines.append('    eslint-' ~ pkg.name ~ ':') -%}
-{%-     set _ = lines.append('      glob: \'*.{js,ts,jsx,tsx,mjs,cjs}\'') -%}
-{%-     set _ = lines.append('      root: \'' ~ pkg.name ~ '/\'') -%}
-{%-     set _ = lines.append('      run: pnpm exec eslint {staged_files}') -%}
-{%-   endfor -%}
-{%-   set node_block = lines | join('\n') ~ '\n' -%}
-{%- endif -%}
-{#- Build rust block -#}
-{%- set rust_block = '' -%}
-{%- if has_rust -%}
-{%-   set rust_lines = [
-        '    ast-grep:',
-        '      glob: \'*.rs\'',
-        '      run: ast-grep scan {staged_files}',
-        '',
-        '    # Using glob instead of file_types because text/x-rust is not supported',
-        '    # by the mimetype library used by lefthook.',
-        '    # See: https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md',
-        '    cargo-fmt:',
-        '      glob: \'*.rs\''
-      ] -%}
-{%-   if rust_pkgs | length > 0 -%}
-{%-     set _ = rust_lines.append('      root: \'' ~ rust_pkgs[0].name ~ '/\'') -%}
-{%-   endif -%}
-{%-   set _ = rust_lines.append('      run: cargo fmt') -%}
-{%-   set _ = rust_lines.append('      stage_fixed: true') -%}
-{%-   set _ = rust_lines.append('') -%}
-{%-   set _ = rust_lines.append('    cargo-clippy:') -%}
-{%-   set _ = rust_lines.append('      glob: \'*.rs\'') -%}
-{%-   if rust_pkgs | length > 0 -%}
-{%-     set _ = rust_lines.append('      root: \'' ~ rust_pkgs[0].name ~ '/\'') -%}
-{%-   endif -%}
-{%-   set _ = rust_lines.append('      run: cargo clippy --all-targets -- -D warnings') -%}
-{%-   set rust_block = rust_lines | join('\n') ~ '\n' -%}
-{%- endif -%}
-{#- Combine extra sections with proper blank line separation -#}
-{%- set extras = [] -%}
-{%- if node_block -%}{%- set _ = extras.append(node_block) -%}{%- endif -%}
-{%- if rust_block -%}{%- set _ = extras.append(rust_block) -%}{%- endif -%}
-{%- set extras_text = extras | join('\n') -%}
 pre-commit:
   commands:
     format:
@@ -118,9 +65,50 @@ pre-commit:
               ;;
           esac
         done
-{% if extras_text %}
-{{ extras_text }}
-{%- endif %}
+{% if has_node and root_pnpm -%}
+
+    {% if monorepo_node_workspace | default(false) -%}
+    # lefthook's default glob uses gobwas/glob without a delimiter, so
+    # '*.{js,ts,...}' also matches nested paths (e.g. frontend/src/foo.ts).
+    # A single root-level eslint covers every workspace package, and running
+    # per-package eslint in parallel would race on --fix / stage_fixed writes.
+    {% endif -%}
+    eslint:
+      glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
+      run: pnpm exec eslint {staged_files}
+{% elif has_node -%}
+    {% for pkg in node_pkgs %}
+    # Non-workspace multi-package monorepo: each subpackage has its own
+    # eslint.config.js and dependencies, so lint per package from its root.
+    eslint-{{ pkg.name }}:
+      glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
+      root: '{{ pkg.name }}/'
+      run: pnpm exec eslint {staged_files}
+    {% endfor -%}
+{% endif -%}
+{% if has_rust %}
+    ast-grep:
+      glob: '*.rs'
+      run: ast-grep scan {staged_files}
+
+    # Using glob instead of file_types because text/x-rust is not supported
+    # by the mimetype library used by lefthook.
+    # See: https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md
+    cargo-fmt:
+      glob: '*.rs'
+      {%- if rust_pkgs | length > 0 %}
+      root: '{{ rust_pkgs[0].name }}/'
+      {%- endif %}
+      run: cargo fmt
+      stage_fixed: true
+
+    cargo-clippy:
+      glob: '*.rs'
+      {%- if rust_pkgs | length > 0 %}
+      root: '{{ rust_pkgs[0].name }}/'
+      {%- endif %}
+      run: cargo clippy --all-targets -- -D warnings
+{% endif %}
 commit-msg:
   commands:
     commitlint:

--- a/template/lefthook.yml.jinja
+++ b/template/lefthook.yml.jinja
@@ -65,28 +65,33 @@ pre-commit:
               ;;
           esac
         done
-{% if has_node and root_pnpm -%}
+{%- if has_node and (monorepo_node_workspace | default(false)) %}
 
-    {% if monorepo_node_workspace | default(false) -%}
     # lefthook's default glob uses gobwas/glob without a delimiter, so
     # '*.{js,ts,...}' also matches nested paths (e.g. frontend/src/foo.ts).
     # A single root-level eslint covers every workspace package, and running
     # per-package eslint in parallel would race on --fix / stage_fixed writes.
-    {% endif -%}
     eslint:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
       run: pnpm exec eslint {staged_files}
-{% elif has_node -%}
-    {% for pkg in node_pkgs %}
+{%- elif has_node and root_pnpm %}
+
+    eslint:
+      glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
+      run: pnpm exec eslint {staged_files}
+{%- elif has_node %}
+{%- for pkg in node_pkgs %}
+
     # Non-workspace multi-package monorepo: each subpackage has its own
     # eslint.config.js and dependencies, so lint per package from its root.
     eslint-{{ pkg.name }}:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
       root: '{{ pkg.name }}/'
       run: pnpm exec eslint {staged_files}
-    {% endfor -%}
-{% endif -%}
-{% if has_rust %}
+{%- endfor %}
+{%- endif %}
+{%- if has_rust %}
+
     ast-grep:
       glob: '*.rs'
       run: ast-grep scan {staged_files}
@@ -108,7 +113,8 @@ pre-commit:
       root: '{{ rust_pkgs[0].name }}/'
       {%- endif %}
       run: cargo clippy --all-targets -- -D warnings
-{% endif %}
+{%- endif %}
+
 commit-msg:
   commands:
     commitlint:

--- a/template/lefthook.yml.jinja
+++ b/template/lefthook.yml.jinja
@@ -47,7 +47,8 @@
 {%-   if rust_pkgs | length > 0 -%}
 {%-     set _ = rust_lines.append('      root: \'' ~ rust_pkgs[0].name ~ '/\'') -%}
 {%-   endif -%}
-{%-   set _ = rust_lines.append('      run: cargo fmt -- {staged_files}') -%}
+{%-   set _ = rust_lines.append('      run: cargo fmt') -%}
+{%-   set _ = rust_lines.append('      stage_fixed: true') -%}
 {%-   set _ = rust_lines.append('') -%}
 {%-   set _ = rust_lines.append('    cargo-clippy:') -%}
 {%-   set _ = rust_lines.append('      glob: \'*.rs\'') -%}
@@ -104,17 +105,18 @@ pre-commit:
         # Renovate does not support the `gh:` prefix in _src_path.
         # See: https://github.com/renovatebot/renovate/issues/39938
         for file in {staged_files}; do
-          if [ -f "$file" ]; then
-            # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
-            if grep -qE "^_src_path:[[:space:]]*['\"]?gh:" "$file"; then
-              src_path=$(grep -E "^_src_path:" "$file" | head -n 1 | sed 's/^_src_path:[[:space:]]*//')
+          [ -f "$file" ] || continue
+          # Handle both quoted and unquoted values (e.g. gh:org/repo or "gh:org/repo")
+          src_path=$(sed -n 's/^_src_path:[[:space:]]*//p' "$file" | head -n 1)
+          case "$src_path" in
+            gh:* | "'gh:"* | '"gh:'*)
               suggested_path=$(echo "$src_path" | sed -e "s|^['\"]\\{0,1\\}gh:|https://github.com/|" -e "s|['\"]\\{0,1\\}$||")
               echo "Error: $file uses 'gh:' prefix in _src_path, which is not supported by Renovate." >&2
               echo "Please use a full 'https://' URL instead." >&2
               printf "  Current:   %s\n  Suggested: %s\n" "$src_path" "$suggested_path" >&2
               exit 1
-            fi
-          fi
+              ;;
+          esac
         done
 {% if extras_text %}
 {{ extras_text }}

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -1,8 +1,22 @@
 {%- set is_workspace = monorepo_node_workspace | default(false) -%}
 {%- set node_pkgs = subpackages | default([]) | selectattr('type', 'equalto', 'node') | list -%}
+{%- set has_node_subpackage = node_pkgs | length > 0 -%}
 {%- set has_storybook = use_storybook | default(false) -%}
-{%- if type != 'node' and not is_workspace -%}
-{#- Non-workspace monorepo: minimal package.json for corepack version pinning -#}
+{%- if type != 'node' and not is_workspace and has_node_subpackage -%}
+{#- Non-workspace monorepo with node subpackages:
+    root package.json hosts tools that run at the repo root
+    (prettier, commitlint) so lefthook can use `pnpm exec`. -#}
+{
+  "name": "{{ project_name }}",
+  "private": true,
+  "packageManager": "pnpm@10.33.0",
+  "devDependencies": {
+    "@commitlint/cli": "20.5.0",
+    "prettier": "3.8.1"
+  }
+}
+{%- elif type != 'node' and not is_workspace -%}
+{#- Non-workspace monorepo without node subpackages: only corepack pinning -#}
 {
   "name": "{{ project_name }}",
   "private": true,

--- a/template/scripts/bootstrap.jinja
+++ b/template/scripts/bootstrap.jinja
@@ -52,7 +52,9 @@ pnpm install
 pnpm install
 {%- elif has_node and not (monorepo_node_workspace | default(false)) %}
 
-# Install Node.js dependencies
+# Install shared dev tools (prettier, commitlint) at the repo root
+pnpm install
+# Install Node.js dependencies for each subpackage
 {%- for pkg in subpackages if pkg.type == 'node' %}
 (cd {{ pkg.name }} && pnpm install)
 {%- endfor %}


### PR DESCRIPTION
## Purpose

- `fohte/lefthook-config` is only consumed through `generic-boilerplate`, so the indirection no longer earns its keep
- Generated repos pick the runner for prettier/commitlint at runtime, but the template already knows which runner fits from `type` and `monorepo_node_workspace`
    - `lefthook-config` had to probe `bun.lock` / `pnpm-lock.yaml` / `package.json` in shell to stay portable
    - Because of that, changes like pnpm support in `lefthook-config` ripple into every generated repo

## Approach

- Move the lefthook configuration into `template` and stop referencing `fohte/lefthook-config`
- Pick the runner at copier render time: `pnpm exec` when any node subpackage is present, `mise x -- ` otherwise
- For non-workspace monorepos, host the shared tooling (prettier, commitlint) in a root-level `package.json` so `pnpm exec` always resolves at the repo root

Rendered YAML (excerpt) for the `monorepo` fixture (`type: base` + node + rust subpackages, non-workspace):

```yaml
prettier:
  run: pnpm exec prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
  stage_fixed: true
```

<details>
<summary>Design decisions</summary>

#### How the template references lefthook-config

| Decision | Design                                       | Pros                                                                                                | Cons                                                                                 |
| -------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| Chosen   | Inline the contents into the template        | No runtime runner probing in the generated file; hook changes live entirely in generic-boilerplate  | Hook updates reach generated repos only through `copier update` (via Renovate)       |
| Rejected | Extend `lefthook-config` via `remotes:`      | Generated repos receive upstream hook updates automatically                                         | `lefthook-config` is effectively generic-boilerplate-only, so the relay adds no value |

#### How the prettier / commitlint runner is chosen

| Decision | Design                                                                                                     | Pros                                                                                   | Cons                                                                                 |
| -------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| Chosen   | Use `pnpm exec` whenever any node subpackage exists; `mise x -- ` otherwise. Render the choice in copier   | Every generated hook is a single line. No runtime package-manager detection required  | Non-workspace monorepos must now keep a root `package.json` with the shared tooling |
| Rejected | Keep `bun.lock` / `pnpm-lock.yaml` / `package.json` probes in the shell at hook time                       | One lefthook config works across any project layout                                    | The set of targets is already fixed, so branching at runtime is idle                 |

#### Where shared dev tooling lives for non-workspace monorepos

| Decision | Design                                                                            | Pros                                                                                                 | Cons                                                                                                      |
| -------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| Chosen   | Host `prettier` and `@commitlint/cli` in a root-level `package.json`              | A single `pnpm install` at the root is enough for root-level hooks. Keeps the tool version in one place | Each subpackage still manages its own lockfile; root pnpm-lock.yaml is added on top                       |
| Rejected | Keep mise-provided `npm:prettier` and `npm:@commitlint/cli` also at the root      | No extra `package.json` surface at the root                                                          | Version drift between mise and subpackage devDependencies, and `pnpm exec` at the root cannot resolve prettier |

#### Which shared devDependencies move to the root

| Decision | Design                                                                                             | Pros                                                                              | Cons                                                                                               |
| -------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| Chosen   | Only lefthook-hook-level tooling (`prettier`, `@commitlint/cli`)                                   | Scope stays small; every other tool (eslint, tsconfig, vitest) keeps its owner    | Subpackage `prettier` versions can still drift if authors add their own; acceptable as an initial step |
| Rejected | Also move eslint config, tsconfig, vitest up to the root                                           | Stronger version alignment across subpackages                                     | Requires redesigning eslint.config.js/tsconfig/vitest layout; out of scope here                    |

#### Intentional differences from the previous extends-based behavior

- `cargo fmt` no longer receives `{staged_files}` and now sets `stage_fixed: true`. Passing individual files was silently ignored and the reformatted bytes were left unstaged
- `copier-src-path` folds the earlier grep + sed double parse into a single `sed -n 's/.../p' | head -n 1` followed by a shell `case`, keeping the script posix-sh compatible

</details>
