### PR TITLE
fix(template): stop leaking mise template-author comments into rendered output

### DIFF
--- a/generated/base-public/.mise.toml
+++ b/generated/base-public/.mise.toml
@@ -6,8 +6,6 @@ actionlint = "1.7.12"
 node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
-# When no node project is present in the repo, prettier and commitlint are
-# provided via mise since there is no package.json to host them.
 "npm:@commitlint/cli" = "20.5.0"
 "npm:prettier" = "3.8.1"
 shellcheck = "0.11.0"

--- a/generated/base-release/.mise.toml
+++ b/generated/base-release/.mise.toml
@@ -6,8 +6,6 @@ actionlint = "1.7.12"
 node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
-# When no node project is present in the repo, prettier and commitlint are
-# provided via mise since there is no package.json to host them.
 "npm:@commitlint/cli" = "20.5.0"
 "npm:prettier" = "3.8.1"
 shellcheck = "0.11.0"

--- a/generated/base/.mise.toml
+++ b/generated/base/.mise.toml
@@ -6,8 +6,6 @@ actionlint = "1.7.12"
 node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
-# When no node project is present in the repo, prettier and commitlint are
-# provided via mise since there is no package.json to host them.
 "npm:@commitlint/cli" = "20.5.0"
 "npm:prettier" = "3.8.1"
 shellcheck = "0.11.0"

--- a/generated/rust-release/.mise.toml
+++ b/generated/rust-release/.mise.toml
@@ -7,8 +7,6 @@ actionlint = "1.7.12"
 node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
-# When no node project is present in the repo, prettier and commitlint are
-# provided via mise since there is no package.json to host them.
 "npm:@commitlint/cli" = "20.5.0"
 "npm:prettier" = "3.8.1"
 shellcheck = "0.11.0"

--- a/generated/rust/.mise.toml
+++ b/generated/rust/.mise.toml
@@ -7,8 +7,6 @@ actionlint = "1.7.12"
 node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
-# When no node project is present in the repo, prettier and commitlint are
-# provided via mise since there is no package.json to host them.
 "npm:@commitlint/cli" = "20.5.0"
 "npm:prettier" = "3.8.1"
 shellcheck = "0.11.0"

--- a/template/.mise.toml.jinja
+++ b/template/.mise.toml.jinja
@@ -12,8 +12,7 @@ node = "24.14.1"
 pinact = "3.9.0"
 "github:fohte/basefmt" = "0.1.0"
 {% if not has_node -%}
-# When no node project is present in the repo, prettier and commitlint are
-# provided via mise since there is no package.json to host them.
+{#- Without a package.json, prettier and commitlint must be hosted by mise. -#}
 "npm:@commitlint/cli" = "20.5.0"
 "npm:prettier" = "3.8.1"
 {% endif -%}


### PR DESCRIPTION
## Purpose

- Generated repositories had a comment in `.mise.toml` that only explained the template's own branching logic and carried no meaning for downstream users

## Approach

- Move the author-oriented note to a Jinja comment (`{# ... #}`) so it no longer survives rendering
    - Swept the rest of `*.jinja` under `template/` and confirmed this was the only leak of its kind
- Before and after for `.mise.toml` (shown for type=base)

    Before:

    ```toml
    "github:fohte/basefmt" = "0.1.0"
    # When no node project is present in the repo, prettier and commitlint are
    # provided via mise since there is no package.json to host them.
    "npm:@commitlint/cli" = "20.5.0"
    ```

    After:

    ```toml
    "github:fohte/basefmt" = "0.1.0"
    "npm:@commitlint/cli" = "20.5.0"
    ```

<details>
<summary>Design decisions</summary>

#### How to handle the author-oriented note

| Decision | Design                                                                          | Pros                                                                                     | Cons                                                                                                  |
| -------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| Chosen   | Replace with a Jinja comment (`{#- ... -#}`) so it is excluded from rendering   | Future template editors can still read the rationale for this branch in the `.jinja`     | Requires remembering when to use `{# ... #}` instead of a TOML `#` comment                            |
| Rejected | Delete the comment entirely                                                     | Smaller template                                                                         | Future editors lose the branch rationale and have to re-derive it                                     |
| Rejected | Keep the TOML comment but shorten its wording                                   | Minimal diff                                                                             | Rendered `.mise.toml` still carries meta-information that is irrelevant to downstream users           |

</details>

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/generic-boilerplate/pull/295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
