### PR TITLE
feat(gemini): add code-comment rules to the code styleguide

### DIFF
--- a/generated/base-public/.gemini/styleguide.md
+++ b/generated/base-public/.gemini/styleguide.md
@@ -5,3 +5,35 @@
 - Changing versions or editions specified in config files
 
 Assume version choices are intentional. Your training data may be outdated.
+
+## Code comment rules
+
+Comments must explain non-obvious WHY, not WHAT. Well-named identifiers already describe what the code does.
+
+### Write only stock information
+
+A comment must carry information that stays true for the lifetime of the code: a non-obvious WHY, an invariant, an external constraint (spec, protocol, hardware quirk), or a workaround tied to a specific upstream bug. If a future reader could delete the comment without losing context, it should not exist.
+
+### Do not write flow information in code comments
+
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+```bash
+# bad: history and rationale that belongs in the PR / commit log
+# Background:
+#   When we put the terraform plugin cache on actions/cache, old providers
+#   accumulate every time the lock file is updated. GitHub's 7-day LRU is
+#   per primary key so daily touches keep stale entries alive forever.
+#   We considered relying on Terraform's built-in cleanup but it does not
+#   exist, so we delete unpinned providers ourselves before save.
+prune_unpinned_providers
+
+# good: only the non-obvious WHY that the reader needs at this line
+# Terraform has no built-in cache cleanup, so prune providers absent from
+# the current lock files before actions/cache save to bound cache size.
+prune_unpinned_providers
+```
+
+### Do not copy task / issue / PR background into code comments
+
+Do not paste the "background" or "context" section of a task instruction, GitHub issue, or PR description into a source file as a header comment. That text exists in the PR description and commit message already; duplicating it in code creates two copies that drift and forces future readers to re-read context that is not needed to understand the code itself. A `Usage:` block or a one-line WHY at the relevant call site is enough.

--- a/generated/base-public/.gemini/styleguide.md
+++ b/generated/base-public/.gemini/styleguide.md
@@ -16,7 +16,9 @@ A comment must carry information that stays true for the lifetime of the code: a
 
 ### Do not write flow information in code comments
 
-Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", or links kept purely as a record of past decisions — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+A link to a PR or issue is fine when it documents an _active_ external constraint the reader needs right now: an upstream bug being worked around, a tracking issue for a TODO, an RFC the code conforms to. The test is whether the link still helps explain the current code; if it only records "this is how we got here", it is flow information and belongs in the commit log.
 
 ```bash
 # bad: history and rationale that belongs in the PR / commit log

--- a/generated/base-release/.gemini/styleguide.md
+++ b/generated/base-release/.gemini/styleguide.md
@@ -5,3 +5,35 @@
 - Changing versions or editions specified in config files
 
 Assume version choices are intentional. Your training data may be outdated.
+
+## Code comment rules
+
+Comments must explain non-obvious WHY, not WHAT. Well-named identifiers already describe what the code does.
+
+### Write only stock information
+
+A comment must carry information that stays true for the lifetime of the code: a non-obvious WHY, an invariant, an external constraint (spec, protocol, hardware quirk), or a workaround tied to a specific upstream bug. If a future reader could delete the comment without losing context, it should not exist.
+
+### Do not write flow information in code comments
+
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+```bash
+# bad: history and rationale that belongs in the PR / commit log
+# Background:
+#   When we put the terraform plugin cache on actions/cache, old providers
+#   accumulate every time the lock file is updated. GitHub's 7-day LRU is
+#   per primary key so daily touches keep stale entries alive forever.
+#   We considered relying on Terraform's built-in cleanup but it does not
+#   exist, so we delete unpinned providers ourselves before save.
+prune_unpinned_providers
+
+# good: only the non-obvious WHY that the reader needs at this line
+# Terraform has no built-in cache cleanup, so prune providers absent from
+# the current lock files before actions/cache save to bound cache size.
+prune_unpinned_providers
+```
+
+### Do not copy task / issue / PR background into code comments
+
+Do not paste the "background" or "context" section of a task instruction, GitHub issue, or PR description into a source file as a header comment. That text exists in the PR description and commit message already; duplicating it in code creates two copies that drift and forces future readers to re-read context that is not needed to understand the code itself. A `Usage:` block or a one-line WHY at the relevant call site is enough.

--- a/generated/base-release/.gemini/styleguide.md
+++ b/generated/base-release/.gemini/styleguide.md
@@ -16,7 +16,9 @@ A comment must carry information that stays true for the lifetime of the code: a
 
 ### Do not write flow information in code comments
 
-Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", or links kept purely as a record of past decisions — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+A link to a PR or issue is fine when it documents an _active_ external constraint the reader needs right now: an upstream bug being worked around, a tracking issue for a TODO, an RFC the code conforms to. The test is whether the link still helps explain the current code; if it only records "this is how we got here", it is flow information and belongs in the commit log.
 
 ```bash
 # bad: history and rationale that belongs in the PR / commit log

--- a/generated/base/.gemini/styleguide.md
+++ b/generated/base/.gemini/styleguide.md
@@ -5,3 +5,35 @@
 - Changing versions or editions specified in config files
 
 Assume version choices are intentional. Your training data may be outdated.
+
+## Code comment rules
+
+Comments must explain non-obvious WHY, not WHAT. Well-named identifiers already describe what the code does.
+
+### Write only stock information
+
+A comment must carry information that stays true for the lifetime of the code: a non-obvious WHY, an invariant, an external constraint (spec, protocol, hardware quirk), or a workaround tied to a specific upstream bug. If a future reader could delete the comment without losing context, it should not exist.
+
+### Do not write flow information in code comments
+
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+```bash
+# bad: history and rationale that belongs in the PR / commit log
+# Background:
+#   When we put the terraform plugin cache on actions/cache, old providers
+#   accumulate every time the lock file is updated. GitHub's 7-day LRU is
+#   per primary key so daily touches keep stale entries alive forever.
+#   We considered relying on Terraform's built-in cleanup but it does not
+#   exist, so we delete unpinned providers ourselves before save.
+prune_unpinned_providers
+
+# good: only the non-obvious WHY that the reader needs at this line
+# Terraform has no built-in cache cleanup, so prune providers absent from
+# the current lock files before actions/cache save to bound cache size.
+prune_unpinned_providers
+```
+
+### Do not copy task / issue / PR background into code comments
+
+Do not paste the "background" or "context" section of a task instruction, GitHub issue, or PR description into a source file as a header comment. That text exists in the PR description and commit message already; duplicating it in code creates two copies that drift and forces future readers to re-read context that is not needed to understand the code itself. A `Usage:` block or a one-line WHY at the relevant call site is enough.

--- a/generated/base/.gemini/styleguide.md
+++ b/generated/base/.gemini/styleguide.md
@@ -16,7 +16,9 @@ A comment must carry information that stays true for the lifetime of the code: a
 
 ### Do not write flow information in code comments
 
-Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", or links kept purely as a record of past decisions — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+A link to a PR or issue is fine when it documents an _active_ external constraint the reader needs right now: an upstream bug being worked around, a tracking issue for a TODO, an RFC the code conforms to. The test is whether the link still helps explain the current code; if it only records "this is how we got here", it is flow information and belongs in the commit log.
 
 ```bash
 # bad: history and rationale that belongs in the PR / commit log

--- a/generated/monorepo-node-workspace/.gemini/styleguide.md
+++ b/generated/monorepo-node-workspace/.gemini/styleguide.md
@@ -5,3 +5,35 @@
 - Changing versions or editions specified in config files
 
 Assume version choices are intentional. Your training data may be outdated.
+
+## Code comment rules
+
+Comments must explain non-obvious WHY, not WHAT. Well-named identifiers already describe what the code does.
+
+### Write only stock information
+
+A comment must carry information that stays true for the lifetime of the code: a non-obvious WHY, an invariant, an external constraint (spec, protocol, hardware quirk), or a workaround tied to a specific upstream bug. If a future reader could delete the comment without losing context, it should not exist.
+
+### Do not write flow information in code comments
+
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+```bash
+# bad: history and rationale that belongs in the PR / commit log
+# Background:
+#   When we put the terraform plugin cache on actions/cache, old providers
+#   accumulate every time the lock file is updated. GitHub's 7-day LRU is
+#   per primary key so daily touches keep stale entries alive forever.
+#   We considered relying on Terraform's built-in cleanup but it does not
+#   exist, so we delete unpinned providers ourselves before save.
+prune_unpinned_providers
+
+# good: only the non-obvious WHY that the reader needs at this line
+# Terraform has no built-in cache cleanup, so prune providers absent from
+# the current lock files before actions/cache save to bound cache size.
+prune_unpinned_providers
+```
+
+### Do not copy task / issue / PR background into code comments
+
+Do not paste the "background" or "context" section of a task instruction, GitHub issue, or PR description into a source file as a header comment. That text exists in the PR description and commit message already; duplicating it in code creates two copies that drift and forces future readers to re-read context that is not needed to understand the code itself. A `Usage:` block or a one-line WHY at the relevant call site is enough.

--- a/generated/monorepo-node-workspace/.gemini/styleguide.md
+++ b/generated/monorepo-node-workspace/.gemini/styleguide.md
@@ -16,7 +16,9 @@ A comment must carry information that stays true for the lifetime of the code: a
 
 ### Do not write flow information in code comments
 
-Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", or links kept purely as a record of past decisions — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+A link to a PR or issue is fine when it documents an _active_ external constraint the reader needs right now: an upstream bug being worked around, a tracking issue for a TODO, an RFC the code conforms to. The test is whether the link still helps explain the current code; if it only records "this is how we got here", it is flow information and belongs in the commit log.
 
 ```bash
 # bad: history and rationale that belongs in the PR / commit log

--- a/generated/monorepo/.gemini/styleguide.md
+++ b/generated/monorepo/.gemini/styleguide.md
@@ -16,7 +16,9 @@ A comment must carry information that stays true for the lifetime of the code: a
 
 ### Do not write flow information in code comments
 
-Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", or links kept purely as a record of past decisions — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+A link to a PR or issue is fine when it documents an _active_ external constraint the reader needs right now: an upstream bug being worked around, a tracking issue for a TODO, an RFC the code conforms to. The test is whether the link still helps explain the current code; if it only records "this is how we got here", it is flow information and belongs in the commit log.
 
 ```bash
 # bad: history and rationale that belongs in the PR / commit log

--- a/generated/monorepo/.gemini/styleguide.md
+++ b/generated/monorepo/.gemini/styleguide.md
@@ -6,6 +6,38 @@
 
 Assume version choices are intentional. Your training data may be outdated.
 
+## Code comment rules
+
+Comments must explain non-obvious WHY, not WHAT. Well-named identifiers already describe what the code does.
+
+### Write only stock information
+
+A comment must carry information that stays true for the lifetime of the code: a non-obvious WHY, an invariant, an external constraint (spec, protocol, hardware quirk), or a workaround tied to a specific upstream bug. If a future reader could delete the comment without losing context, it should not exist.
+
+### Do not write flow information in code comments
+
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+```bash
+# bad: history and rationale that belongs in the PR / commit log
+# Background:
+#   When we put the terraform plugin cache on actions/cache, old providers
+#   accumulate every time the lock file is updated. GitHub's 7-day LRU is
+#   per primary key so daily touches keep stale entries alive forever.
+#   We considered relying on Terraform's built-in cleanup but it does not
+#   exist, so we delete unpinned providers ourselves before save.
+prune_unpinned_providers
+
+# good: only the non-obvious WHY that the reader needs at this line
+# Terraform has no built-in cache cleanup, so prune providers absent from
+# the current lock files before actions/cache save to bound cache size.
+prune_unpinned_providers
+```
+
+### Do not copy task / issue / PR background into code comments
+
+Do not paste the "background" or "context" section of a task instruction, GitHub issue, or PR description into a source file as a header comment. That text exists in the PR description and commit message already; duplicating it in code creates two copies that drift and forces future readers to re-read context that is not needed to understand the code itself. A `Usage:` block or a one-line WHY at the relevant call site is enough.
+
 ## Test code review rules
 
 ### Parameterize similar test cases with rstest

--- a/generated/node/.gemini/styleguide.md
+++ b/generated/node/.gemini/styleguide.md
@@ -5,3 +5,35 @@
 - Changing versions or editions specified in config files
 
 Assume version choices are intentional. Your training data may be outdated.
+
+## Code comment rules
+
+Comments must explain non-obvious WHY, not WHAT. Well-named identifiers already describe what the code does.
+
+### Write only stock information
+
+A comment must carry information that stays true for the lifetime of the code: a non-obvious WHY, an invariant, an external constraint (spec, protocol, hardware quirk), or a workaround tied to a specific upstream bug. If a future reader could delete the comment without losing context, it should not exist.
+
+### Do not write flow information in code comments
+
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+```bash
+# bad: history and rationale that belongs in the PR / commit log
+# Background:
+#   When we put the terraform plugin cache on actions/cache, old providers
+#   accumulate every time the lock file is updated. GitHub's 7-day LRU is
+#   per primary key so daily touches keep stale entries alive forever.
+#   We considered relying on Terraform's built-in cleanup but it does not
+#   exist, so we delete unpinned providers ourselves before save.
+prune_unpinned_providers
+
+# good: only the non-obvious WHY that the reader needs at this line
+# Terraform has no built-in cache cleanup, so prune providers absent from
+# the current lock files before actions/cache save to bound cache size.
+prune_unpinned_providers
+```
+
+### Do not copy task / issue / PR background into code comments
+
+Do not paste the "background" or "context" section of a task instruction, GitHub issue, or PR description into a source file as a header comment. That text exists in the PR description and commit message already; duplicating it in code creates two copies that drift and forces future readers to re-read context that is not needed to understand the code itself. A `Usage:` block or a one-line WHY at the relevant call site is enough.

--- a/generated/node/.gemini/styleguide.md
+++ b/generated/node/.gemini/styleguide.md
@@ -16,7 +16,9 @@ A comment must carry information that stays true for the lifetime of the code: a
 
 ### Do not write flow information in code comments
 
-Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", or links kept purely as a record of past decisions — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+A link to a PR or issue is fine when it documents an _active_ external constraint the reader needs right now: an upstream bug being worked around, a tracking issue for a TODO, an RFC the code conforms to. The test is whether the link still helps explain the current code; if it only records "this is how we got here", it is flow information and belongs in the commit log.
 
 ```bash
 # bad: history and rationale that belongs in the PR / commit log

--- a/generated/rust-release/.gemini/styleguide.md
+++ b/generated/rust-release/.gemini/styleguide.md
@@ -16,7 +16,9 @@ A comment must carry information that stays true for the lifetime of the code: a
 
 ### Do not write flow information in code comments
 
-Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", or links kept purely as a record of past decisions — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+A link to a PR or issue is fine when it documents an _active_ external constraint the reader needs right now: an upstream bug being worked around, a tracking issue for a TODO, an RFC the code conforms to. The test is whether the link still helps explain the current code; if it only records "this is how we got here", it is flow information and belongs in the commit log.
 
 ```bash
 # bad: history and rationale that belongs in the PR / commit log

--- a/generated/rust-release/.gemini/styleguide.md
+++ b/generated/rust-release/.gemini/styleguide.md
@@ -6,6 +6,38 @@
 
 Assume version choices are intentional. Your training data may be outdated.
 
+## Code comment rules
+
+Comments must explain non-obvious WHY, not WHAT. Well-named identifiers already describe what the code does.
+
+### Write only stock information
+
+A comment must carry information that stays true for the lifetime of the code: a non-obvious WHY, an invariant, an external constraint (spec, protocol, hardware quirk), or a workaround tied to a specific upstream bug. If a future reader could delete the comment without losing context, it should not exist.
+
+### Do not write flow information in code comments
+
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+```bash
+# bad: history and rationale that belongs in the PR / commit log
+# Background:
+#   When we put the terraform plugin cache on actions/cache, old providers
+#   accumulate every time the lock file is updated. GitHub's 7-day LRU is
+#   per primary key so daily touches keep stale entries alive forever.
+#   We considered relying on Terraform's built-in cleanup but it does not
+#   exist, so we delete unpinned providers ourselves before save.
+prune_unpinned_providers
+
+# good: only the non-obvious WHY that the reader needs at this line
+# Terraform has no built-in cache cleanup, so prune providers absent from
+# the current lock files before actions/cache save to bound cache size.
+prune_unpinned_providers
+```
+
+### Do not copy task / issue / PR background into code comments
+
+Do not paste the "background" or "context" section of a task instruction, GitHub issue, or PR description into a source file as a header comment. That text exists in the PR description and commit message already; duplicating it in code creates two copies that drift and forces future readers to re-read context that is not needed to understand the code itself. A `Usage:` block or a one-line WHY at the relevant call site is enough.
+
 ## Test code review rules
 
 ### Parameterize similar test cases with rstest

--- a/generated/rust/.gemini/styleguide.md
+++ b/generated/rust/.gemini/styleguide.md
@@ -16,7 +16,9 @@ A comment must carry information that stays true for the lifetime of the code: a
 
 ### Do not write flow information in code comments
 
-Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", or links kept purely as a record of past decisions — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+A link to a PR or issue is fine when it documents an _active_ external constraint the reader needs right now: an upstream bug being worked around, a tracking issue for a TODO, an RFC the code conforms to. The test is whether the link still helps explain the current code; if it only records "this is how we got here", it is flow information and belongs in the commit log.
 
 ```bash
 # bad: history and rationale that belongs in the PR / commit log

--- a/generated/rust/.gemini/styleguide.md
+++ b/generated/rust/.gemini/styleguide.md
@@ -6,6 +6,38 @@
 
 Assume version choices are intentional. Your training data may be outdated.
 
+## Code comment rules
+
+Comments must explain non-obvious WHY, not WHAT. Well-named identifiers already describe what the code does.
+
+### Write only stock information
+
+A comment must carry information that stays true for the lifetime of the code: a non-obvious WHY, an invariant, an external constraint (spec, protocol, hardware quirk), or a workaround tied to a specific upstream bug. If a future reader could delete the comment without losing context, it should not exist.
+
+### Do not write flow information in code comments
+
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+```bash
+# bad: history and rationale that belongs in the PR / commit log
+# Background:
+#   When we put the terraform plugin cache on actions/cache, old providers
+#   accumulate every time the lock file is updated. GitHub's 7-day LRU is
+#   per primary key so daily touches keep stale entries alive forever.
+#   We considered relying on Terraform's built-in cleanup but it does not
+#   exist, so we delete unpinned providers ourselves before save.
+prune_unpinned_providers
+
+# good: only the non-obvious WHY that the reader needs at this line
+# Terraform has no built-in cache cleanup, so prune providers absent from
+# the current lock files before actions/cache save to bound cache size.
+prune_unpinned_providers
+```
+
+### Do not copy task / issue / PR background into code comments
+
+Do not paste the "background" or "context" section of a task instruction, GitHub issue, or PR description into a source file as a header comment. That text exists in the PR description and commit message already; duplicating it in code creates two copies that drift and forces future readers to re-read context that is not needed to understand the code itself. A `Usage:` block or a one-line WHY at the relevant call site is enough.
+
 ## Test code review rules
 
 ### Parameterize similar test cases with rstest

--- a/template/.gemini/styleguide.md.jinja
+++ b/template/.gemini/styleguide.md.jinja
@@ -16,7 +16,9 @@ A comment must carry information that stays true for the lifetime of the code: a
 
 ### Do not write flow information in code comments
 
-Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", or links kept purely as a record of past decisions — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+A link to a PR or issue is fine when it documents an _active_ external constraint the reader needs right now: an upstream bug being worked around, a tracking issue for a TODO, an RFC the code conforms to. The test is whether the link still helps explain the current code; if it only records "this is how we got here", it is flow information and belongs in the commit log.
 
 ```bash
 # bad: history and rationale that belongs in the PR / commit log

--- a/template/.gemini/styleguide.md.jinja
+++ b/template/.gemini/styleguide.md.jinja
@@ -5,6 +5,38 @@
 - Changing versions or editions specified in config files
 
 Assume version choices are intentional. Your training data may be outdated.
+
+## Code comment rules
+
+Comments must explain non-obvious WHY, not WHAT. Well-named identifiers already describe what the code does.
+
+### Write only stock information
+
+A comment must carry information that stays true for the lifetime of the code: a non-obvious WHY, an invariant, an external constraint (spec, protocol, hardware quirk), or a workaround tied to a specific upstream bug. If a future reader could delete the comment without losing context, it should not exist.
+
+### Do not write flow information in code comments
+
+Flow information — change history, alternatives that were considered and rejected, review feedback, "previously we did X / now we do Y", links to past PRs or issues — belongs in commit messages and PR descriptions, not in source files. Code comments are read out of chronological context and rot as the code evolves.
+
+```bash
+# bad: history and rationale that belongs in the PR / commit log
+# Background:
+#   When we put the terraform plugin cache on actions/cache, old providers
+#   accumulate every time the lock file is updated. GitHub's 7-day LRU is
+#   per primary key so daily touches keep stale entries alive forever.
+#   We considered relying on Terraform's built-in cleanup but it does not
+#   exist, so we delete unpinned providers ourselves before save.
+prune_unpinned_providers
+
+# good: only the non-obvious WHY that the reader needs at this line
+# Terraform has no built-in cache cleanup, so prune providers absent from
+# the current lock files before actions/cache save to bound cache size.
+prune_unpinned_providers
+```
+
+### Do not copy task / issue / PR background into code comments
+
+Do not paste the "background" or "context" section of a task instruction, GitHub issue, or PR description into a source file as a header comment. That text exists in the PR description and commit message already; duplicating it in code creates two copies that drift and forces future readers to re-read context that is not needed to understand the code itself. A `Usage:` block or a one-line WHY at the relevant call site is enough.
 {%- if has_rust %}
 
 ## Test code review rules


### PR DESCRIPTION
## Purpose

- Claude Code has lately been leaving flow information (change history and similar narration) inside code comments
  - That kind of content belongs in the PR body or commit message, not in source comments
- Adding the rule to CLAUDE.md alone has not been enough, so back it up with an automated review check as a second line of defense

## Approach

- Add a language-agnostic `Code comment rules` section to the `.gemini/styleguide.md` Copier template so Gemini Code Assist can flag the same violation in downstream repos

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/generic-boilerplate/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
