### PR TITLE
fix(scripts): preserve scripts entry when a devDependencies key has the same name

### DIFF
--- a/scripts/apply-renovate-patch
+++ b/scripts/apply-renovate-patch
@@ -167,8 +167,14 @@ sync_versions_to_template() {
         if grep -F -- "$key" "$template_file" | grep -Fq "\"${version}\""; then
           continue
         fi
-        # Replace version for this key in template (match quoted version string)
-        if sed -i.bak "s#\\(${key}[[:space:]]*[=:][[:space:]]*\"\\)[^\"]*\\(\".*\\)#\\1${version}\\2#" "$template_file"; then
+        # Replace version for this key in template (match quoted version string).
+        # Constrain the existing value to a version-shaped string so that a key
+        # collision with a non-version sibling (e.g. package.json scripts where
+        # "storybook" is both a script name and a devDependencies entry) does
+        # not rewrite the script command. The shape allows an optional package@
+        # prefix (packageManager: "pnpm@1.2.3") and an optional semver range
+        # specifier or "v" prefix.
+        if sed -i.bak -E "s#(${key}[[:space:]]*[=:][[:space:]]*\")([^\"]+@)?([=^~><]{0,2}v?[0-9]+(\.[0-9]+)+[^\"]*)(\")#\\1${version}\\5#" "$template_file"; then
           rm -f "${template_file}.bak"
           ((changes_applied++)) || true
         fi
@@ -179,8 +185,11 @@ sync_versions_to_template() {
         if grep -F -- "$key" "$template_file" | grep -Eq ":[[:space:]]*$(printf '%s' "$version" | sed 's/[].[^$*+?(){}|\\]/\\&/g')([[:space:]]|#|$)"; then
           continue
         fi
-        # Replace version for this key in template (match unquoted version)
-        if sed -i.bak "s#\\(${key}[[:space:]]*:[[:space:]]*\\)[^[:space:]#]*#\\1${version}#" "$template_file"; then
+        # Replace version for this key in template (match unquoted version).
+        # Constrain the existing value to a version-shaped token (digits and
+        # dots, with optional specifier or "v" prefix) so that a non-version
+        # value sharing the key name is not rewritten.
+        if sed -i.bak -E "s#(${key}[[:space:]]*:[[:space:]]*)[=^~><]{0,2}v?[0-9]+(\.[0-9]+)+[^[:space:]#]*#\\1${version}#" "$template_file"; then
           rm -f "${template_file}.bak"
           ((changes_applied++)) || true
         fi

--- a/scripts/apply-renovate-patch
+++ b/scripts/apply-renovate-patch
@@ -173,8 +173,10 @@ sync_versions_to_template() {
         # "storybook" is both a script name and a devDependencies entry) does
         # not rewrite the script command. The shape allows an optional package@
         # prefix (packageManager: "pnpm@1.2.3") and an optional semver range
-        # specifier or "v" prefix.
-        if sed -i.bak -E "s#(${key}[[:space:]]*[=:][[:space:]]*\")([^\"]+@)?([=^~><]{0,2}v?[0-9]+(\.[0-9]+)+[^\"]*)(\")#\\1${version}\\5#" "$template_file"; then
+        # specifier or "v" prefix. The closing quote is hardcoded in the
+        # replacement so capture-group numbering does not depend on whether
+        # ${key} contains parentheses.
+        if sed -i.bak -E "s#(${key}[[:space:]]*[=:][[:space:]]*\")([^\"]+@)?[=^~><]{0,2}v?[0-9]+(\.[0-9]+)+[^\"]*\"#\\1${version}\"#" "$template_file"; then
           rm -f "${template_file}.bak"
           ((changes_applied++)) || true
         fi

--- a/scripts/apply-renovate-patch.bats
+++ b/scripts/apply-renovate-patch.bats
@@ -937,6 +937,72 @@ EOF
 EOF
 }
 
+@test "does not rewrite scripts entry that shares a name with a devDependency" {
+  # Regression: package.json may use the same key in scripts and dependencies
+  # (e.g. storybook). The script value is a shell command, not a version, and
+  # must be preserved when the version of the dependency changes.
+  cat > template/package.json.jinja << 'EOF'
+{
+  "name": "{{ project_name }}",
+  "scripts": {
+    "storybook": "storybook dev -p 6006",
+    "storybook:build": "storybook build"
+  },
+  "devDependencies": {
+    "storybook": "10.3.3"
+  }
+}
+EOF
+
+  cat > generated/base/package.json << 'EOF'
+{
+  "name": "base",
+  "scripts": {
+    "storybook": "storybook dev -p 6006",
+    "storybook:build": "storybook build"
+  },
+  "devDependencies": {
+    "storybook": "10.3.3"
+  }
+}
+EOF
+
+  create_initial_commit
+
+  cat > generated/base/package.json << 'EOF'
+{
+  "name": "base",
+  "scripts": {
+    "storybook": "storybook dev -p 6006",
+    "storybook:build": "storybook build"
+  },
+  "devDependencies": {
+    "storybook": "10.3.5"
+  }
+}
+EOF
+
+  git add .
+  git commit -q -m "chore(deps): update storybook"
+
+  run "$REPO_ROOT/scripts/apply-renovate-patch" HEAD~1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Synced 1 version"* ]]
+
+  diff -u template/package.json.jinja - << 'EOF'
+{
+  "name": "{{ project_name }}",
+  "scripts": {
+    "storybook": "storybook dev -p 6006",
+    "storybook:build": "storybook build"
+  },
+  "devDependencies": {
+    "storybook": "10.3.5"
+  }
+}
+EOF
+}
+
 # ========================================
 # Monorepo subpackage tests
 # ========================================


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/generic-boilerplate/pull/282
- Renovate dependency-update PRs in which the same key exists in both `scripts` and `devDependencies` of `package.json` (e.g. `storybook`) fail at Verify sync completeness in the Sync Generated to Template workflow, blocking every such Renovate PR from being merged.
    > `<     "storybook": "storybook dev -p 6006",`
    > `>     "storybook": "10.3.5",`
    >
    > [Failing job log](https://github.com/fohte/generic-boilerplate/actions/runs/24999415020/job/73205079747)

## Approach

- Restrict the template-side replacement in `scripts/apply-renovate-patch` so it only rewrites a key whose existing value matches the semver shape (`[=^~><]{0,2}v?N.N...` or `pkg@semver`).
    - The previous replacement ignored the value shape and rewrote every line that shared the key name, which clobbered shell commands such as `"storybook": "storybook dev -p 6006"` with the new version string.
    - Section-aware parsing of JSON (`dependencies` / `scripts` and friends) was also considered, but it would require a parser per file format and would not address the same key collision in TOML and YAML, so the value shape is used as the discriminator instead.
