### PR TITLE
docs(update-boilerplate-prs): auto-merge MERGE-READY PRs and drop review waiting

### DIFF
--- a/.claude/skills/update-boilerplate-prs/SKILL.md
+++ b/.claude/skills/update-boilerplate-prs/SKILL.md
@@ -1,18 +1,17 @@
 ---
 name: update-boilerplate-prs
-description: Batch-process generic-boilerplate update PRs (Renovate copier) across fohte org repositories. Validate, triage, resolve conflicts, and prepare PRs for human merge.
+description: Batch-process generic-boilerplate update PRs (Renovate copier) across fohte org repositories. Validate, triage, resolve conflicts, and merge.
 ---
 
 # Batch Processing generic-boilerplate Update PRs
 
-Validate generic-boilerplate update PRs created by Renovate and resolve conflicts via `/delegate-claude` for PRs that need intervention. Final merge is always performed manually by the user -- never merge on their behalf.
+Validate generic-boilerplate update PRs created by Renovate and resolve conflicts via `/delegate-claude` for PRs that need intervention. MERGE-READY PRs are merged automatically once validated.
 
 ## Merge policy (read before doing anything)
 
-- **Never run `gh pr merge`** as part of this skill, including `--auto`. The user reviews and merges every PR manually.
-- The only exception is `scripts/auto-merge-boilerplate-prs` in Step 4, which is a user-sanctioned helper for the narrowly-defined "version-only" case (pre-validated diff shape). Do not generalize this to any other path.
-- For everything else -- including MERGE-READY PRs surfaced in Step 6 -- stop after validation and reporting. Do not enable auto-merge, do not approve, do not merge.
-- This policy must also be passed down to every `/delegate-claude` prompt in Step 7.
+- **MERGE-READY PRs are merged.** Once a PR is validated as MERGE-READY (no conflict markers + CI pass + changes correctly propagated), merge it with `gh pr merge --squash --auto`. No per-PR user confirmation is required.
+- `scripts/auto-merge-boilerplate-prs` in Step 4 is the fast path for the version-only case (pre-validated diff shape).
+- NEEDS-INTERVENTION PRs are merged only after their conflicts are resolved. When a `/delegate-claude` delegate finishes resolving conflicts and CI passes, the PR is MERGE-READY -- the delegate merges it the same way.
 
 ## Overall Flow
 
@@ -21,8 +20,8 @@ Validate generic-boilerplate update PRs created by Renovate and resolve conflict
 3. **Trigger PR creation for repos without PRs**: Check Renovate Dashboard checkboxes to bypass rate limits
 4. **Auto-merge version-only PRs**: Run `scripts/auto-merge-boilerplate-prs` for trivial PRs (the only sanctioned auto-merge path)
 5. **Validate remaining PRs**: Review diff, CI status for PRs with actual template changes
-6. **Report findings**: Present MERGE-READY and NEEDS-INTERVENTION lists to the user. Do not merge; the user merges manually after review
-7. **Delegate template application**: Delegate via `/delegate-claude` for NEEDS-INTERVENTION PRs. Each delegate fixes conflicts, pushes, waits for CI, addresses reviewer comments, then hands the PR back to the user for merge
+6. **Report and merge**: Merge MERGE-READY PRs; present the NEEDS-INTERVENTION list to the user
+7. **Delegate template application**: Delegate via `/delegate-claude` for NEEDS-INTERVENTION PRs. Each delegate fixes conflicts, pushes, waits for CI, then merges the PR once CI passes
 
 ## Step 1: Understand generic-boilerplate changes
 
@@ -136,7 +135,7 @@ Evaluate each PR against these criteria:
 - **MERGE-READY**: No conflict markers + CI pass + changes correctly propagated
 - **NEEDS-INTERVENTION**: Conflict markers present, or propagation issues detected
 
-Report results in a table and hand over to the user. **Do not merge MERGE-READY PRs** -- the user reviews and merges them manually. Proceed to Step 7 only for NEEDS-INTERVENTION PRs, and only after the user confirms delegation.
+Report results in a table. **Merge MERGE-READY PRs** with `gh pr merge --squash --auto`. Proceed to Step 7 only for NEEDS-INTERVENTION PRs, and only after the user confirms delegation.
 
 ## Step 7: Delegate template application
 
@@ -194,7 +193,7 @@ The delegate may need to run `copier update --trust`. Always include these notes
 
 ### Delegation goal
 
-The latest generic-boilerplate template (v<latest>) is correctly applied to the repository and the PR is left in a state where the user can review and merge it. Specifically:
+The latest generic-boilerplate template (v<latest>) is correctly applied to the repository and the PR is merged once CI passes. Specifically:
 
 - All copier conflict markers are resolved
 - Template parameters in `.copier-answers.yml` match the repo's actual usage (e.g., `use_storybook: true` if the repo uses Storybook)
@@ -202,9 +201,8 @@ The latest generic-boilerplate template (v<latest>) is correctly applied to the 
 - Repository-specific customizations are preserved
 - Syntax checks pass (e.g., `jq .` for JSON, appropriate tools for TOML/YAML)
 - Commit and push (no new PR needed; push to the existing PR branch)
-- **Follow the same post-push flow as `/create-pr`**: wait for CI to finish, wait for Gemini Code Assist review via `a ai review wait`, and address reviewer feedback via the `check-pr-review` skill (`a gh pr-review check`) until every unresolved thread is handled
-- If CI fails, investigate the cause, fix, and re-push (same loop as `/create-pr`)
-- **Do NOT merge or approve the PR.** Never run `gh pr merge` (including with `--auto` / `--admin`), do not enable auto-merge, and do not approve the PR (approval can trigger auto-merge in repos where it is wired up). The user merges manually after reviewing. End by reporting the PR URL and current state (CI green, review resolved) back to the caller
+- **Wait for CI to finish.** If CI fails, investigate the cause, fix, and re-push, repeating until CI is green
+- **Merge the PR once CI passes** with `gh pr merge --squash --auto`. End by reporting the PR URL and final state (merged, or CI status if not yet merged) back to the caller
 
 ### Delegation prompt checklist
 
@@ -212,6 +210,6 @@ Every delegation prompt must explicitly state all of the following so the child 
 
 1. **Conflict resolution rule** (copy the "do NOT blindly choose `after updating`" section)
 2. **copier update notes** (clean tree, node_modules workaround, partial-state reset)
-3. **Post-push flow**: wait for CI, `a ai review wait`, `check-pr-review` for reviewer feedback, re-push and re-wait until clean
-4. **Merge prohibition**: do not run `gh pr merge`, do not enable auto-merge, do not approve. Hand the PR back to the user for manual merge. State this in imperative form -- implicit hints are routinely ignored by child sessions
-5. **Completion report format**: PR URL, CI status, review status, any follow-ups the user needs to be aware of
+3. **Post-push flow**: wait for CI; if CI fails, fix and re-push, repeating until CI is green
+4. **Merge**: once CI is green, merge the PR with `gh pr merge --squash --auto`. State this in imperative form -- implicit hints are routinely ignored by child sessions
+5. **Completion report format**: PR URL, merge/CI status, any follow-ups the user needs to be aware of

--- a/.claude/skills/update-boilerplate-prs/SKILL.md
+++ b/.claude/skills/update-boilerplate-prs/SKILL.md
@@ -10,7 +10,7 @@ Validate generic-boilerplate update PRs created by Renovate and resolve conflict
 ## Merge policy (read before doing anything)
 
 - **MERGE-READY PRs are merged.** Once a PR is validated as MERGE-READY (no conflict markers + CI pass + changes correctly propagated), merge it with `gh pr merge --squash --auto`. No per-PR user confirmation is required.
-- `scripts/auto-merge-boilerplate-prs` in Step 4 is the fast path for the version-only case (pre-validated diff shape).
+- `scripts/auto-merge-boilerplate-prs` in Step 4 is the fast path for the version-only case: it batch-merges PRs whose diff shape is pre-validated (only `_commit` bumps), skipping the per-PR validation that Steps 5-6 perform.
 - NEEDS-INTERVENTION PRs are merged only after their conflicts are resolved. When a `/delegate-claude` delegate finishes resolving conflicts and CI passes, the PR is MERGE-READY -- the delegate merges it the same way.
 
 ## Overall Flow
@@ -128,7 +128,7 @@ gh pr view <number> -R fohte/<repo> \
 
 If CI is failing, review logs to identify the cause.
 
-## Step 6: Report findings to user
+## Step 6: Report and merge
 
 Evaluate each PR against these criteria:
 


### PR DESCRIPTION
## Purpose

- A MERGE-READY PR (no conflict markers + CI green + changes correctly propagated) is mechanically mergeable, yet the skill asked the user to merge every one of them by hand
- The development flow does not use code review, but the skill still instructs sending a review request and waiting for review, an unintended flow

## Approach

- Merge MERGE-READY PRs within the skill via `gh pr merge --squash --auto`
- Remove the review-wait (`a ai review wait`) and review-feedback (`check-pr-review`) instructions from the delegation prompt
    - Still instruct the delegate to wait for CI and fix CI failures
- The delegate also merges its own PR after resolving conflicts and CI passes

<details>
<summary>Design decisions</summary>

#### Who merges a delegated PR

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen   | The delegate merges the PR itself after resolving conflicts | A single merge policy across the whole skill / no round-trip to the user | Adds a merge action to the delegate session |
| Rejected | The delegate hands the PR back to the user instead of merging | A human can review once more before the merge | Contradicts the MERGE-READY auto-merge policy and keeps a needless round-trip |

</details>
