### PR TITLE
chore(renovate): extend node.json5 and rust.json5 presets

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,8 @@
   extends: [
     'github>fohte/renovate-config:base.json5',
     'github>fohte/renovate-config:lefthook.json5',
+    'github>fohte/renovate-config:node.json5',
+    'github>fohte/renovate-config:rust.json5',
   ],
   // template/ contains Copier templates (*.jinja), not actual project files
   ignorePaths: ['template/**'],


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/generic-boilerplate/pull/312
- This repository generates Node and Rust projects, so it falls within the scope of the shared presets

## Approach

- Add `github>fohte/renovate-config:node.json5` and `github>fohte/renovate-config:rust.json5` to `extends` in `renovate.json5`
