### PR TITLE
fix(template): install lefthook hooks even in worktrees

### DIFF
--- a/generated/base-public/scripts/bootstrap
+++ b/generated/base-public/scripts/bootstrap
@@ -3,35 +3,19 @@
 # Bootstrap the development environment.
 #
 # Usage:
-#   scripts/bootstrap              # Full setup (mise + lefthook + dependencies)
-#   scripts/bootstrap --worktree   # Worktree setup (mise + dependencies only)
+#   scripts/bootstrap
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
-worktree=false
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --worktree)
-      worktree=true
-      shift
-      ;;
-    *)
-      echo "Error: Unknown argument: $1" >&2
-      echo "Usage: $0 [--worktree]" >&2
-      exit 1
-      ;;
-  esac
-done
-
 # Install tool versions managed by mise
 if command -v mise > /dev/null 2>&1; then
   mise install
 fi
 
-# Install git hooks via lefthook (skip for worktrees — they share the parent's .git/hooks)
-if [ "$worktree" = false ] && command -v lefthook > /dev/null 2>&1; then
+# Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
+if command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi

--- a/generated/base-release/scripts/bootstrap
+++ b/generated/base-release/scripts/bootstrap
@@ -3,35 +3,19 @@
 # Bootstrap the development environment.
 #
 # Usage:
-#   scripts/bootstrap              # Full setup (mise + lefthook + dependencies)
-#   scripts/bootstrap --worktree   # Worktree setup (mise + dependencies only)
+#   scripts/bootstrap
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
-worktree=false
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --worktree)
-      worktree=true
-      shift
-      ;;
-    *)
-      echo "Error: Unknown argument: $1" >&2
-      echo "Usage: $0 [--worktree]" >&2
-      exit 1
-      ;;
-  esac
-done
-
 # Install tool versions managed by mise
 if command -v mise > /dev/null 2>&1; then
   mise install
 fi
 
-# Install git hooks via lefthook (skip for worktrees — they share the parent's .git/hooks)
-if [ "$worktree" = false ] && command -v lefthook > /dev/null 2>&1; then
+# Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
+if command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi

--- a/generated/base/scripts/bootstrap
+++ b/generated/base/scripts/bootstrap
@@ -3,35 +3,19 @@
 # Bootstrap the development environment.
 #
 # Usage:
-#   scripts/bootstrap              # Full setup (mise + lefthook + dependencies)
-#   scripts/bootstrap --worktree   # Worktree setup (mise + dependencies only)
+#   scripts/bootstrap
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
-worktree=false
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --worktree)
-      worktree=true
-      shift
-      ;;
-    *)
-      echo "Error: Unknown argument: $1" >&2
-      echo "Usage: $0 [--worktree]" >&2
-      exit 1
-      ;;
-  esac
-done
-
 # Install tool versions managed by mise
 if command -v mise > /dev/null 2>&1; then
   mise install
 fi
 
-# Install git hooks via lefthook (skip for worktrees — they share the parent's .git/hooks)
-if [ "$worktree" = false ] && command -v lefthook > /dev/null 2>&1; then
+# Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
+if command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi

--- a/generated/monorepo-node-workspace/scripts/bootstrap
+++ b/generated/monorepo-node-workspace/scripts/bootstrap
@@ -3,28 +3,12 @@
 # Bootstrap the development environment.
 #
 # Usage:
-#   scripts/bootstrap              # Full setup (mise + lefthook + dependencies)
-#   scripts/bootstrap --worktree   # Worktree setup (mise + dependencies only)
+#   scripts/bootstrap
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
-
-worktree=false
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --worktree)
-      worktree=true
-      shift
-      ;;
-    *)
-      echo "Error: Unknown argument: $1" >&2
-      echo "Usage: $0 [--worktree]" >&2
-      exit 1
-      ;;
-  esac
-done
 
 # Install tool versions managed by mise
 if command -v mise > /dev/null 2>&1; then
@@ -34,8 +18,8 @@ fi
 # Enable corepack so that pnpm version from package.json packageManager field is used
 corepack enable
 
-# Install git hooks via lefthook (skip for worktrees — they share the parent's .git/hooks)
-if [ "$worktree" = false ] && command -v lefthook > /dev/null 2>&1; then
+# Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
+if command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi
 

--- a/generated/monorepo/scripts/bootstrap
+++ b/generated/monorepo/scripts/bootstrap
@@ -3,28 +3,12 @@
 # Bootstrap the development environment.
 #
 # Usage:
-#   scripts/bootstrap              # Full setup (mise + lefthook + dependencies)
-#   scripts/bootstrap --worktree   # Worktree setup (mise + dependencies only)
+#   scripts/bootstrap
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
-
-worktree=false
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --worktree)
-      worktree=true
-      shift
-      ;;
-    *)
-      echo "Error: Unknown argument: $1" >&2
-      echo "Usage: $0 [--worktree]" >&2
-      exit 1
-      ;;
-  esac
-done
 
 # Install tool versions managed by mise
 if command -v mise > /dev/null 2>&1; then
@@ -34,8 +18,8 @@ fi
 # Enable corepack so that pnpm version from package.json packageManager field is used
 corepack enable
 
-# Install git hooks via lefthook (skip for worktrees — they share the parent's .git/hooks)
-if [ "$worktree" = false ] && command -v lefthook > /dev/null 2>&1; then
+# Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
+if command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi
 

--- a/generated/node/scripts/bootstrap
+++ b/generated/node/scripts/bootstrap
@@ -3,28 +3,12 @@
 # Bootstrap the development environment.
 #
 # Usage:
-#   scripts/bootstrap              # Full setup (mise + lefthook + dependencies)
-#   scripts/bootstrap --worktree   # Worktree setup (mise + dependencies only)
+#   scripts/bootstrap
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
-
-worktree=false
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --worktree)
-      worktree=true
-      shift
-      ;;
-    *)
-      echo "Error: Unknown argument: $1" >&2
-      echo "Usage: $0 [--worktree]" >&2
-      exit 1
-      ;;
-  esac
-done
 
 # Install tool versions managed by mise
 if command -v mise > /dev/null 2>&1; then
@@ -34,8 +18,8 @@ fi
 # Enable corepack so that pnpm version from package.json packageManager field is used
 corepack enable
 
-# Install git hooks via lefthook (skip for worktrees — they share the parent's .git/hooks)
-if [ "$worktree" = false ] && command -v lefthook > /dev/null 2>&1; then
+# Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
+if command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi
 

--- a/generated/rust-release/scripts/bootstrap
+++ b/generated/rust-release/scripts/bootstrap
@@ -3,36 +3,20 @@
 # Bootstrap the development environment.
 #
 # Usage:
-#   scripts/bootstrap              # Full setup (mise + lefthook + dependencies)
-#   scripts/bootstrap --worktree   # Worktree setup (mise + dependencies only)
+#   scripts/bootstrap
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
-worktree=false
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --worktree)
-      worktree=true
-      shift
-      ;;
-    *)
-      echo "Error: Unknown argument: $1" >&2
-      echo "Usage: $0 [--worktree]" >&2
-      exit 1
-      ;;
-  esac
-done
-
 # Install tool versions managed by mise
 if command -v mise > /dev/null 2>&1; then
   mise install
 fi
 
-# Install git hooks via lefthook (skip for worktrees — they share the parent's .git/hooks)
-if [ "$worktree" = false ] && command -v lefthook > /dev/null 2>&1; then
+# Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
+if command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi
 

--- a/generated/rust/scripts/bootstrap
+++ b/generated/rust/scripts/bootstrap
@@ -3,36 +3,20 @@
 # Bootstrap the development environment.
 #
 # Usage:
-#   scripts/bootstrap              # Full setup (mise + lefthook + dependencies)
-#   scripts/bootstrap --worktree   # Worktree setup (mise + dependencies only)
+#   scripts/bootstrap
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
-worktree=false
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --worktree)
-      worktree=true
-      shift
-      ;;
-    *)
-      echo "Error: Unknown argument: $1" >&2
-      echo "Usage: $0 [--worktree]" >&2
-      exit 1
-      ;;
-  esac
-done
-
 # Install tool versions managed by mise
 if command -v mise > /dev/null 2>&1; then
   mise install
 fi
 
-# Install git hooks via lefthook (skip for worktrees — they share the parent's .git/hooks)
-if [ "$worktree" = false ] && command -v lefthook > /dev/null 2>&1; then
+# Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
+if command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi
 

--- a/template/scripts/bootstrap.jinja
+++ b/template/scripts/bootstrap.jinja
@@ -3,28 +3,12 @@
 # Bootstrap the development environment.
 #
 # Usage:
-#   scripts/bootstrap              # Full setup (mise + lefthook + dependencies)
-#   scripts/bootstrap --worktree   # Worktree setup (mise + dependencies only)
+#   scripts/bootstrap
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
-
-worktree=false
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --worktree)
-      worktree=true
-      shift
-      ;;
-    *)
-      echo "Error: Unknown argument: $1" >&2
-      echo "Usage: $0 [--worktree]" >&2
-      exit 1
-      ;;
-  esac
-done
 
 # Install tool versions managed by mise
 if command -v mise > /dev/null 2>&1; then
@@ -36,8 +20,8 @@ fi
 corepack enable
 {%- endif %}
 
-# Install git hooks via lefthook (skip for worktrees — they share the parent's .git/hooks)
-if [ "$worktree" = false ] && command -v lefthook > /dev/null 2>&1; then
+# Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
+if command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi
 {%- if type == 'node' %}


### PR DESCRIPTION
## Purpose

- A worktree-only workflow (running just `scripts/bootstrap --worktree`) never sets up git hooks
    - The full `scripts/bootstrap` that installs hooks never gets a chance to run

## Approach

- Drop the `--worktree` flag so `scripts/bootstrap` always runs `lefthook install`
    - Worktree hooks resolve to the shared `.git/hooks`, so installing from a worktree applies to all worktrees
