### PR TITLE
feat(template): use a matrix + aggregation gate for pnpm workspace monorepo CI

### DIFF
--- a/generated/monorepo-node-workspace/.github/workflows/test.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/test.yml
@@ -86,8 +86,8 @@ jobs:
         if: steps.lefthook.outcome == 'failure'
         run: exit 1
 
-  # Enumerate the workspace packages whose tests should run for this push, and
-  # emit them as a JSON array consumed by the unit-test matrix below.
+  # Build the unit-test matrix at runtime: branch protection pins the fixed-name
+  # `unit-test` gate below, so the per-package legs are enumerated here instead.
   setup:
     runs-on: ubuntu-slim
     outputs:

--- a/generated/monorepo-node-workspace/.github/workflows/test.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/test.yml
@@ -86,51 +86,62 @@ jobs:
         if: steps.lefthook.outcome == 'failure'
         run: exit 1
 
-  detect-changes:
+  # Enumerate the workspace packages whose tests should run for this push, and
+  # emit them as a JSON array consumed by the unit-test matrix below.
+  setup:
     runs-on: ubuntu-slim
     outputs:
-      frontend: ${{ steps.changes-frontend.outputs.any_changed }}
-      backend: ${{ steps.changes-backend.outputs.any_changed }}
-      workflow: ${{ steps.changes-workflow.outputs.any_changed }}
-      root-lockfile: ${{ steps.changes-root-lockfile.outputs.any_changed }}
+      packages: ${{ steps.set-packages.outputs.packages }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 
-      - name: Check for frontend changes
+      - name: Detect changed files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        id: changes-frontend
+        id: changed
         with:
-          files: frontend/**
+          json: true
+          # Emit valid JSON; the default escapes quotes and breaks jq parsing.
+          escape_json: false
 
-      - name: Check for backend changes
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        id: changes-backend
-        with:
-          files: backend/**
+      - name: Build package matrix
+        id: set-packages
+        env:
+          # Changes to these files affect every package, so they trigger the full matrix.
+          GLOBAL_PATHS_REGEX: '^(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|\.github/workflows/test\.yml)$'
+          CHANGED_FILES: ${{ steps.changed.outputs.all_changed_files }}
+        run: |
+          # Workspace packages are the directories holding a non-root package.json.
+          mapfile -t pkgs < <(git ls-files '*/package.json' | grep -v node_modules | sed 's#/package.json$##' | sort -u)
 
-      - name: Check for workflow changes
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        id: changes-workflow
-        with:
-          files: .github/workflows/test.yml
+          if echo "$CHANGED_FILES" | jq -r '.[]' | grep -qE "$GLOBAL_PATHS_REGEX"; then
+            selected=("${pkgs[@]}")
+          else
+            selected=()
+            for dir in "${pkgs[@]}"; do
+              if echo "$CHANGED_FILES" | jq -e --arg d "${dir}/" 'any(.[]; startswith($d))' >/dev/null; then
+                selected+=("$dir")
+              fi
+            done
+          fi
 
-      - name: Check for root lockfile changes
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        id: changes-root-lockfile
-        with:
-          files: |
-            package.json
-            pnpm-lock.yaml
-            pnpm-workspace.yaml
+          if [ ${#selected[@]} -eq 0 ]; then
+            packages='[]'
+          else
+            packages=$(printf '%s\n' "${selected[@]}" | jq -R . | jq -sc .)
+          fi
+          echo "packages=$packages" >> "$GITHUB_OUTPUT"
+          echo "Selected packages: $packages"
 
-  unit-test-frontend:
-    needs: detect-changes
-    if: >-
-      needs.detect-changes.outputs.frontend == 'true' ||
-      needs.detect-changes.outputs.workflow == 'true' ||
-      needs.detect-changes.outputs.root-lockfile == 'true'
+  unit-test-run:
+    needs: setup
+    if: ${{ needs.setup.outputs.packages != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.setup.outputs.packages) }}
+    name: 'unit-test (${{ matrix.package }})'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -149,48 +160,26 @@ jobs:
           path: |
             ${{ steps.pnpm-store.outputs.path }}
             node_modules
-            frontend/node_modules
-            backend/node_modules
+            */node_modules
           key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-
 
       - run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        working-directory: frontend
+        working-directory: ${{ matrix.package }}
         run: pnpm run test
 
-  unit-test-backend:
-    needs: detect-changes
-    if: >-
-      needs.detect-changes.outputs.backend == 'true' ||
-      needs.detect-changes.outputs.workflow == 'true' ||
-      needs.detect-changes.outputs.root-lockfile == 'true'
-    runs-on: ubuntu-latest
+  # Aggregation gate for the unit-test matrix. Matrix leg names are dynamic and
+  # cannot be pinned as a required status check, so this single fixed-name job is
+  # the branch protection gate instead. It fails only when a needed job failed;
+  # when every leg succeeds (or the matrix is skipped because nothing changed) it
+  # is skipped, and a skipped required check counts as success.
+  unit-test:
+    runs-on: ubuntu-slim
+    needs:
+      - setup
+      - unit-test-run
+    if: failure()
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-
-      - run: corepack enable
-
-      - name: Get pnpm store directory
-        id: pnpm-store
-        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache pnpm store
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ${{ steps.pnpm-store.outputs.path }}
-            node_modules
-            frontend/node_modules
-            backend/node_modules
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-pnpm-
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Run tests
-        working-directory: backend
-        run: pnpm run test
+      - run: exit 1

--- a/generated/monorepo-node-workspace/.github/workflows/test.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/test.yml
@@ -164,7 +164,9 @@ jobs:
           key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-
 
-      - run: pnpm install --frozen-lockfile
+      # Install only the matrix package and its workspace dependencies, not the
+      # whole workspace, so each parallel leg skips unrelated packages' installs.
+      - run: pnpm install --filter ./${{ matrix.package }}... --frozen-lockfile
 
       - name: Run tests
         working-directory: ${{ matrix.package }}

--- a/template/.github/workflows/test-release-please.yml.jinja
+++ b/template/.github/workflows/test-release-please.yml.jinja
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Skip tests for release-please PR (only updates CHANGELOG and version)"
-{%- if type in ['node', 'rust'] %}
+{%- if type in ['node', 'rust'] or is_workspace %}
 
   unit-test:
     runs-on: ubuntu-latest

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -326,7 +326,9 @@ jobs:
           key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-
 
-      - run: pnpm install --frozen-lockfile
+      # Install only the matrix package and its workspace dependencies, not the
+      # whole workspace, so each parallel leg skips unrelated packages' installs.
+      - run: pnpm install --filter ./${{ matrix.package }}... --frozen-lockfile
 
       - name: Run tests
         working-directory: ${{ matrix.package }}

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -246,6 +246,107 @@ jobs:
         run: cargo test
 {%- endif %}
 {%- elif subpackages %}
+{%- if is_workspace %}
+{% raw %}
+  # Enumerate the workspace packages whose tests should run for this push, and
+  # emit them as a JSON array consumed by the unit-test matrix below.
+  setup:
+    runs-on: ubuntu-slim
+    outputs:
+      packages: ${{ steps.set-packages.outputs.packages }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        id: changed
+        with:
+          json: true
+          # Emit valid JSON; the default escapes quotes and breaks jq parsing.
+          escape_json: false
+
+      - name: Build package matrix
+        id: set-packages
+        env:
+          # Changes to these files affect every package, so they trigger the full matrix.
+          GLOBAL_PATHS_REGEX: '^(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|\.github/workflows/test\.yml)$'
+          CHANGED_FILES: ${{ steps.changed.outputs.all_changed_files }}
+        run: |
+          # Workspace packages are the directories holding a non-root package.json.
+          mapfile -t pkgs < <(git ls-files '*/package.json' | grep -v node_modules | sed 's#/package.json$##' | sort -u)
+
+          if echo "$CHANGED_FILES" | jq -r '.[]' | grep -qE "$GLOBAL_PATHS_REGEX"; then
+            selected=("${pkgs[@]}")
+          else
+            selected=()
+            for dir in "${pkgs[@]}"; do
+              if echo "$CHANGED_FILES" | jq -e --arg d "${dir}/" 'any(.[]; startswith($d))' >/dev/null; then
+                selected+=("$dir")
+              fi
+            done
+          fi
+
+          if [ ${#selected[@]} -eq 0 ]; then
+            packages='[]'
+          else
+            packages=$(printf '%s\n' "${selected[@]}" | jq -R . | jq -sc .)
+          fi
+          echo "packages=$packages" >> "$GITHUB_OUTPUT"
+          echo "Selected packages: $packages"
+
+  unit-test-run:
+    needs: setup
+    if: ${{ needs.setup.outputs.packages != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.setup.outputs.packages) }}
+    name: 'unit-test (${{ matrix.package }})'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - run: corepack enable
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ${{ steps.pnpm-store.outputs.path }}
+            node_modules
+            */node_modules
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        working-directory: ${{ matrix.package }}
+        run: pnpm run test
+
+  # Aggregation gate for the unit-test matrix. Matrix leg names are dynamic and
+  # cannot be pinned as a required status check, so this single fixed-name job is
+  # the branch protection gate instead. It fails only when a needed job failed;
+  # when every leg succeeds (or the matrix is skipped because nothing changed) it
+  # is skipped, and a skipped required check counts as success.
+  unit-test:
+    runs-on: ubuntu-slim
+    needs:
+      - setup
+      - unit-test-run
+    if: failure()
+    steps:
+      - run: exit 1
+{%- endraw %}
+{%- else %}
 
   detect-changes:
     runs-on: ubuntu-slim
@@ -400,4 +501,5 @@ jobs:
 {%- endif %}
 {%- endif %}
 {%- endfor %}
+{%- endif %}
 {%- endif %}

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -248,8 +248,8 @@ jobs:
 {%- elif subpackages %}
 {%- if is_workspace %}
 {% raw %}
-  # Enumerate the workspace packages whose tests should run for this push, and
-  # emit them as a JSON array consumed by the unit-test matrix below.
+  # Build the unit-test matrix at runtime: branch protection pins the fixed-name
+  # `unit-test` gate below, so the per-package legs are enumerated here instead.
   setup:
     runs-on: ubuntu-slim
     outputs:


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/contracts/pull/14
- pnpm workspace monorepos pin the unit-test required status check per package as `unit-test-<name>`, so every package added or removed forces a matching update to the branch protection config — otherwise the required check slips through or merges get blocked

## Approach

- Switch pnpm workspace monorepo CI to a matrix + aggregation gate, so branch protection only needs to pin a single fixed-name `unit-test` job
    - The affected packages run in parallel as a matrix, and the fixed-name gate that bundles them fails only when a leg fails; when every leg passes or the matrix is skipped (nothing changed) the required check counts as success
- Emit the fixed-name `unit-test` on release-please branches too, so the required check never stays pending forever
