### PR TITLE
ci: switch non-boilerplate workflows to octo-sts

### DIFF
--- a/.github/workflows/sync-generated-to-template.yml
+++ b/.github/workflows/sync-generated-to-template.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  id-token: write
+
 jobs:
   sync:
     # Only run on Renovate PRs that change generated/ files
@@ -11,15 +14,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
-        id: app-token
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          scope: fohte
+          identity: generic-boilerplate-sync-generated-to-template
+          domain: octo-sts.fohte.net
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.octo-sts.outputs.token }}
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Fetch base branch
@@ -62,7 +66,7 @@ jobs:
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
           commit_message: 'chore(template): sync changes from generated/'
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ steps.octo-sts.outputs.token }}
 
       - name: Fail if manual updates required
         if: steps.sync.outputs.success == 'false'

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  id-token: write
 
 jobs:
   list-fixtures:
@@ -38,11 +38,12 @@ jobs:
       rust_changed: ${{ steps.check-rust-changes.outputs.any_changed }}
 
     steps:
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
-        id: app-token
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          scope: fohte
+          identity: generic-boilerplate-validate-template
+          domain: octo-sts.fohte.net
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -86,7 +87,7 @@ jobs:
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
           commit_message: 'chore(generated): regenerate from template'
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ steps.octo-sts.outputs.token }}
 
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Purpose

- Remove the dependency on the long-lived `APP_PRIVATE_KEY` (Actions secret)

## Approach

- Switch `sync-generated-to-template.yml` and `validate-template.yml` to federated tokens via octo-sts (OIDC -> short-lived App token)
    - The matching `OrgTrustPolicy` entries are already in place from [fohte/.github#6](https://github.com/fohte/.github/pull/6) ([sync](https://github.com/fohte/.github/blob/491f3090777b9bb0aa0d2e4bc7cc979594d999b7/.github/chainguard/generic-boilerplate-sync-generated-to-template.sts.yaml) / [validate](https://github.com/fohte/.github/blob/491f3090777b9bb0aa0d2e4bc7cc979594d999b7/.github/chainguard/generic-boilerplate-validate-template.sts.yaml))
