### PR TITLE
feat(template): require whole-output equality in test assertion rule

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -56,8 +56,8 @@ _exclude:
   # Required for any project with a node root package; non-workspace node subpackages
   # get their own pnpm-workspace.yaml under the subpackage directory instead.
   - "{% if not is_workspace and type != 'node' %}/pnpm-workspace.yaml{% endif %}"
-  # Exclude CLAUDE.md when no Rust code (only contains Rust test rules)
-  - '{% if not has_rust %}/CLAUDE.md{% endif %}'
+  # Exclude CLAUDE.md when there is no test code (no Rust and no Node)
+  - '{% if not has_rust and not has_node %}/CLAUDE.md{% endif %}'
   # Exclude Rust specific files when type is not 'rust'
   - "{% if type != 'rust' %}/Cargo.toml{% endif %}"
   - "{% if type != 'rust' %}/rust-toolchain.toml{% endif %}"

--- a/generated/monorepo-node-workspace/CLAUDE.md
+++ b/generated/monorepo-node-workspace/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+## Test code rules
+
+### Assert on the whole output with a single equality check
+
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+
+```ts
+// bad: picks fields one by one — silent on any new/changed field
+const ev = run()
+expect(ev.path).toBe('/a')
+expect(ev.event).toBe('ok')
+expect(ev.message).toContain('done')
+
+// good: one literal, one equality — any drift in shape fails the test
+expect(run()).toEqual({
+  path: '/a',
+  event: 'ok',
+  message: 'done',
+})
+```
+
+```rust
+// bad
+let ev = run();
+assert_eq!(ev["path"], "/a");
+assert_eq!(ev["event"], "ok");
+assert!(ev["message"].as_str().unwrap().contains("done"));
+
+// good
+assert_eq!(
+    run(),
+    json!({
+        "path": "/a",
+        "event": "ok",
+        "message": "done",
+    }),
+);
+```
+
+For dynamic fields (timestamps, UUIDs, random ids), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.

--- a/generated/monorepo-node-workspace/CLAUDE.md
+++ b/generated/monorepo-node-workspace/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Assert on the whole output with a single equality check
 
-Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with` or `startsWith`/`endsWith`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion. Do not split the assertion into per-field checks, and do not use partial matchers (substring contains, `toContain`, `toMatchObject`, prefix/suffix checks, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
 
 ```ts
 // bad: picks fields one by one — silent on any new/changed field
@@ -19,24 +19,6 @@ expect(run()).toEqual({
   event: 'ok',
   message: 'done',
 })
-```
-
-```rust
-// bad
-let ev = run();
-assert_eq!(ev["path"], "/a");
-assert_eq!(ev["event"], "ok");
-assert!(ev["message"].as_str().unwrap().contains("done"));
-
-// good
-assert_eq!(
-    run(),
-    json!({
-        "path": "/a",
-        "event": "ok",
-        "message": "done",
-    }),
-);
 ```
 
 For dynamic fields (timestamps, UUIDs, random IDs), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.

--- a/generated/monorepo-node-workspace/CLAUDE.md
+++ b/generated/monorepo-node-workspace/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Assert on the whole output with a single equality check
 
-Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with` or `startsWith`/`endsWith`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
 
 ```ts
 // bad: picks fields one by one — silent on any new/changed field
@@ -39,4 +39,4 @@ assert_eq!(
 );
 ```
 
-For dynamic fields (timestamps, UUIDs, random ids), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
+For dynamic fields (timestamps, UUIDs, random IDs), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.

--- a/generated/monorepo/CLAUDE.md
+++ b/generated/monorepo/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Assert on the whole output with a single equality check
 
-Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with` or `startsWith`/`endsWith`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
 
 ```ts
 // bad: picks fields one by one — silent on any new/changed field
@@ -39,7 +39,7 @@ assert_eq!(
 );
 ```
 
-For dynamic fields (timestamps, UUIDs, random ids), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
+For dynamic fields (timestamps, UUIDs, random IDs), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
 
 The `no-assert-contains` ast-grep rule rejects `assert!(x.contains(...))` at the expression level; this guideline is the broader principle that the rule is one instance of.
 

--- a/generated/monorepo/CLAUDE.md
+++ b/generated/monorepo/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Assert on the whole output with a single equality check
 
-Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with` or `startsWith`/`endsWith`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion. Do not split the assertion into per-field checks, and do not use partial matchers (substring contains, `toContain`, `toMatchObject`, prefix/suffix checks, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
 
 ```ts
 // bad: picks fields one by one — silent on any new/changed field

--- a/generated/monorepo/CLAUDE.md
+++ b/generated/monorepo/CLAUDE.md
@@ -2,6 +2,47 @@
 
 ## Test code rules
 
+### Assert on the whole output with a single equality check
+
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+
+```ts
+// bad: picks fields one by one — silent on any new/changed field
+const ev = run()
+expect(ev.path).toBe('/a')
+expect(ev.event).toBe('ok')
+expect(ev.message).toContain('done')
+
+// good: one literal, one equality — any drift in shape fails the test
+expect(run()).toEqual({
+  path: '/a',
+  event: 'ok',
+  message: 'done',
+})
+```
+
+```rust
+// bad
+let ev = run();
+assert_eq!(ev["path"], "/a");
+assert_eq!(ev["event"], "ok");
+assert!(ev["message"].as_str().unwrap().contains("done"));
+
+// good
+assert_eq!(
+    run(),
+    json!({
+        "path": "/a",
+        "event": "ok",
+        "message": "done",
+    }),
+);
+```
+
+For dynamic fields (timestamps, UUIDs, random ids), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
+
+The `no-assert-contains` ast-grep rule rejects `assert!(x.contains(...))` at the expression level; this guideline is the broader principle that the rule is one instance of.
+
 ### Parameterize similar test cases with rstest
 
 Do not write multiple test functions that differ only in input/expected values. Use `#[rstest]` with `#[case]`.

--- a/generated/node/CLAUDE.md
+++ b/generated/node/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+## Test code rules
+
+### Assert on the whole output with a single equality check
+
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+
+```ts
+// bad: picks fields one by one — silent on any new/changed field
+const ev = run()
+expect(ev.path).toBe('/a')
+expect(ev.event).toBe('ok')
+expect(ev.message).toContain('done')
+
+// good: one literal, one equality — any drift in shape fails the test
+expect(run()).toEqual({
+  path: '/a',
+  event: 'ok',
+  message: 'done',
+})
+```
+
+```rust
+// bad
+let ev = run();
+assert_eq!(ev["path"], "/a");
+assert_eq!(ev["event"], "ok");
+assert!(ev["message"].as_str().unwrap().contains("done"));
+
+// good
+assert_eq!(
+    run(),
+    json!({
+        "path": "/a",
+        "event": "ok",
+        "message": "done",
+    }),
+);
+```
+
+For dynamic fields (timestamps, UUIDs, random ids), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.

--- a/generated/node/CLAUDE.md
+++ b/generated/node/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Assert on the whole output with a single equality check
 
-Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with` or `startsWith`/`endsWith`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion. Do not split the assertion into per-field checks, and do not use partial matchers (substring contains, `toContain`, `toMatchObject`, prefix/suffix checks, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
 
 ```ts
 // bad: picks fields one by one — silent on any new/changed field
@@ -19,24 +19,6 @@ expect(run()).toEqual({
   event: 'ok',
   message: 'done',
 })
-```
-
-```rust
-// bad
-let ev = run();
-assert_eq!(ev["path"], "/a");
-assert_eq!(ev["event"], "ok");
-assert!(ev["message"].as_str().unwrap().contains("done"));
-
-// good
-assert_eq!(
-    run(),
-    json!({
-        "path": "/a",
-        "event": "ok",
-        "message": "done",
-    }),
-);
 ```
 
 For dynamic fields (timestamps, UUIDs, random IDs), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.

--- a/generated/node/CLAUDE.md
+++ b/generated/node/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Assert on the whole output with a single equality check
 
-Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with` or `startsWith`/`endsWith`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
 
 ```ts
 // bad: picks fields one by one — silent on any new/changed field
@@ -39,4 +39,4 @@ assert_eq!(
 );
 ```
 
-For dynamic fields (timestamps, UUIDs, random ids), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
+For dynamic fields (timestamps, UUIDs, random IDs), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.

--- a/generated/rust-release/CLAUDE.md
+++ b/generated/rust-release/CLAUDE.md
@@ -4,22 +4,7 @@
 
 ### Assert on the whole output with a single equality check
 
-Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with` or `startsWith`/`endsWith`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
-
-```ts
-// bad: picks fields one by one — silent on any new/changed field
-const ev = run()
-expect(ev.path).toBe('/a')
-expect(ev.event).toBe('ok')
-expect(ev.message).toContain('done')
-
-// good: one literal, one equality — any drift in shape fails the test
-expect(run()).toEqual({
-  path: '/a',
-  event: 'ok',
-  message: 'done',
-})
-```
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion. Do not split the assertion into per-field checks, and do not use partial matchers (substring contains, `toContain`, `toMatchObject`, prefix/suffix checks, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
 
 ```rust
 // bad

--- a/generated/rust-release/CLAUDE.md
+++ b/generated/rust-release/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Assert on the whole output with a single equality check
 
-Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with` or `startsWith`/`endsWith`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
 
 ```ts
 // bad: picks fields one by one — silent on any new/changed field
@@ -39,7 +39,7 @@ assert_eq!(
 );
 ```
 
-For dynamic fields (timestamps, UUIDs, random ids), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
+For dynamic fields (timestamps, UUIDs, random IDs), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
 
 The `no-assert-contains` ast-grep rule rejects `assert!(x.contains(...))` at the expression level; this guideline is the broader principle that the rule is one instance of.
 

--- a/generated/rust-release/CLAUDE.md
+++ b/generated/rust-release/CLAUDE.md
@@ -2,6 +2,47 @@
 
 ## Test code rules
 
+### Assert on the whole output with a single equality check
+
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+
+```ts
+// bad: picks fields one by one — silent on any new/changed field
+const ev = run()
+expect(ev.path).toBe('/a')
+expect(ev.event).toBe('ok')
+expect(ev.message).toContain('done')
+
+// good: one literal, one equality — any drift in shape fails the test
+expect(run()).toEqual({
+  path: '/a',
+  event: 'ok',
+  message: 'done',
+})
+```
+
+```rust
+// bad
+let ev = run();
+assert_eq!(ev["path"], "/a");
+assert_eq!(ev["event"], "ok");
+assert!(ev["message"].as_str().unwrap().contains("done"));
+
+// good
+assert_eq!(
+    run(),
+    json!({
+        "path": "/a",
+        "event": "ok",
+        "message": "done",
+    }),
+);
+```
+
+For dynamic fields (timestamps, UUIDs, random ids), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
+
+The `no-assert-contains` ast-grep rule rejects `assert!(x.contains(...))` at the expression level; this guideline is the broader principle that the rule is one instance of.
+
 ### Parameterize similar test cases with rstest
 
 Do not write multiple test functions that differ only in input/expected values. Use `#[rstest]` with `#[case]`.

--- a/generated/rust/CLAUDE.md
+++ b/generated/rust/CLAUDE.md
@@ -4,22 +4,7 @@
 
 ### Assert on the whole output with a single equality check
 
-Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with` or `startsWith`/`endsWith`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
-
-```ts
-// bad: picks fields one by one — silent on any new/changed field
-const ev = run()
-expect(ev.path).toBe('/a')
-expect(ev.event).toBe('ok')
-expect(ev.message).toContain('done')
-
-// good: one literal, one equality — any drift in shape fails the test
-expect(run()).toEqual({
-  path: '/a',
-  event: 'ok',
-  message: 'done',
-})
-```
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion. Do not split the assertion into per-field checks, and do not use partial matchers (substring contains, `toContain`, `toMatchObject`, prefix/suffix checks, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
 
 ```rust
 // bad

--- a/generated/rust/CLAUDE.md
+++ b/generated/rust/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Assert on the whole output with a single equality check
 
-Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with` or `startsWith`/`endsWith`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
 
 ```ts
 // bad: picks fields one by one — silent on any new/changed field
@@ -39,7 +39,7 @@ assert_eq!(
 );
 ```
 
-For dynamic fields (timestamps, UUIDs, random ids), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
+For dynamic fields (timestamps, UUIDs, random IDs), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
 
 The `no-assert-contains` ast-grep rule rejects `assert!(x.contains(...))` at the expression level; this guideline is the broader principle that the rule is one instance of.
 

--- a/generated/rust/CLAUDE.md
+++ b/generated/rust/CLAUDE.md
@@ -2,6 +2,47 @@
 
 ## Test code rules
 
+### Assert on the whole output with a single equality check
+
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+
+```ts
+// bad: picks fields one by one — silent on any new/changed field
+const ev = run()
+expect(ev.path).toBe('/a')
+expect(ev.event).toBe('ok')
+expect(ev.message).toContain('done')
+
+// good: one literal, one equality — any drift in shape fails the test
+expect(run()).toEqual({
+  path: '/a',
+  event: 'ok',
+  message: 'done',
+})
+```
+
+```rust
+// bad
+let ev = run();
+assert_eq!(ev["path"], "/a");
+assert_eq!(ev["event"], "ok");
+assert!(ev["message"].as_str().unwrap().contains("done"));
+
+// good
+assert_eq!(
+    run(),
+    json!({
+        "path": "/a",
+        "event": "ok",
+        "message": "done",
+    }),
+);
+```
+
+For dynamic fields (timestamps, UUIDs, random ids), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
+
+The `no-assert-contains` ast-grep rule rejects `assert!(x.contains(...))` at the expression level; this guideline is the broader principle that the rule is one instance of.
+
 ### Parameterize similar test cases with rstest
 
 Do not write multiple test functions that differ only in input/expected values. Use `#[rstest]` with `#[case]`.

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -4,7 +4,8 @@
 
 ### Assert on the whole output with a single equality check
 
-Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with` or `startsWith`/`endsWith`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion. Do not split the assertion into per-field checks, and do not use partial matchers (substring contains, `toContain`, `toMatchObject`, prefix/suffix checks, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+{%- if has_node %}
 
 ```ts
 // bad: picks fields one by one — silent on any new/changed field
@@ -20,6 +21,8 @@ expect(run()).toEqual({
   message: 'done',
 })
 ```
+{%- endif %}
+{%- if has_rust %}
 
 ```rust
 // bad
@@ -38,6 +41,7 @@ assert_eq!(
     }),
 );
 ```
+{%- endif %}
 
 For dynamic fields (timestamps, UUIDs, random IDs), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
 {%- if has_rust %}

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -4,7 +4,7 @@
 
 ### Assert on the whole output with a single equality check
 
-Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with` or `startsWith`/`endsWith`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
 
 ```ts
 // bad: picks fields one by one — silent on any new/changed field
@@ -39,7 +39,7 @@ assert_eq!(
 );
 ```
 
-For dynamic fields (timestamps, UUIDs, random ids), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
+For dynamic fields (timestamps, UUIDs, random IDs), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
 {%- if has_rust %}
 
 The `no-assert-contains` ast-grep rule rejects `assert!(x.contains(...))` at the expression level; this guideline is the broader principle that the rule is one instance of.

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -1,7 +1,48 @@
 # CLAUDE.md
-{%- if has_rust %}
 
 ## Test code rules
+
+### Assert on the whole output with a single equality check
+
+Treat each test as a spec: build the expected output as one literal value (object, struct, JSON, array, etc.) and compare it to the actual output with a single equality assertion (`assert_eq!`, `expect(...).toEqual(...)`, etc.). Do not split the assertion into per-field checks, and do not use partial matchers (`contains`, `includes`, `toContain`, `toMatchObject`, `starts_with`/`ends_with`, regex-on-substring, etc.). Partial matches silently ignore unexpected fields and extra elements, so the test stops working as a spec the moment the shape of the output changes.
+
+```ts
+// bad: picks fields one by one — silent on any new/changed field
+const ev = run()
+expect(ev.path).toBe('/a')
+expect(ev.event).toBe('ok')
+expect(ev.message).toContain('done')
+
+// good: one literal, one equality — any drift in shape fails the test
+expect(run()).toEqual({
+  path: '/a',
+  event: 'ok',
+  message: 'done',
+})
+```
+
+```rust
+// bad
+let ev = run();
+assert_eq!(ev["path"], "/a");
+assert_eq!(ev["event"], "ok");
+assert!(ev["message"].as_str().unwrap().contains("done"));
+
+// good
+assert_eq!(
+    run(),
+    json!({
+        "path": "/a",
+        "event": "ok",
+        "message": "done",
+    }),
+);
+```
+
+For dynamic fields (timestamps, UUIDs, random ids), normalize them in a helper before the comparison (e.g. replace with a fixed placeholder) so the full output can still be asserted in one equality check. Do not weaken the assertion to dodge the dynamic value.
+{%- if has_rust %}
+
+The `no-assert-contains` ast-grep rule rejects `assert!(x.contains(...))` at the expression level; this guideline is the broader principle that the rule is one instance of.
 
 ### Parameterize similar test cases with rstest
 


### PR DESCRIPTION
## Purpose

- Prevent downstream repositories from producing weak specs where Claude Code asserts on only part of the output and misses shape drift

## Approach

- Add a Test code rules entry requiring tests to build the expected output as a single literal and compare it with one equality assertion
- Ban partial matchers (`contains` / `toContain` / `toMatchObject` / `starts_with`, etc.) and show the intent with bad/good examples in both TS and Rust
- State that dynamic fields (timestamps, UUIDs, etc.) must be normalized in a helper so the full output can still be asserted in one equality check
- Treat the rule as language-agnostic and emit CLAUDE.md for Node-only projects as well
