### PR TITLE
renovate: don't flag tool major bumps as breaking

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,8 +11,6 @@
   packageRules: [
     // Override base.json5's devDependencies (chore:) and github-actions (ci:)
     // prefixes to deps: / deps(ci):.
-    // Use commitMessagePrefix (not semanticCommitType) because it takes
-    // precedence and base.json5 sets these rules via commitMessagePrefix.
     {
       matchDepTypes: ['devDependencies'],
       commitMessagePrefix: 'deps:',

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,9 +11,8 @@
   packageRules: [
     // Override base.json5's devDependencies (chore:) and github-actions (ci:)
     // prefixes to deps: / deps(ci):.
-    // commitMessagePrefix takes precedence over semanticCommitType, and
-    // base.json5 uses commitMessagePrefix for these rules — so override with
-    // the same key.
+    // Use commitMessagePrefix (not semanticCommitType) because it takes
+    // precedence and base.json5 sets these rules via commitMessagePrefix.
     {
       matchDepTypes: ['devDependencies'],
       commitMessagePrefix: 'deps:',

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,23 +9,14 @@
   // template/ contains Copier templates (*.jinja), not actual project files
   ignorePaths: ['template/**'],
   packageRules: [
-    // Override base.json5's devDependencies rule (chore:) and github-actions
-    // rule (ci:) to use deps: instead.
-    // generic-boilerplate manages Copier templates, so package updates here
-    // should propagate to all downstream repos via semantic version bumps.
-    //
-    // Use commitMessagePrefix (not semanticCommitType) because base.json5
-    // uses commitMessagePrefix for these rules, and commitMessagePrefix
-    // takes precedence over semanticCommitType.
+    // Override base.json5's devDependencies (chore:) and github-actions (ci:)
+    // prefixes to deps: / deps(ci):.
+    // commitMessagePrefix takes precedence over semanticCommitType, and
+    // base.json5 uses commitMessagePrefix for these rules — so override with
+    // the same key.
     {
       matchDepTypes: ['devDependencies'],
-      matchUpdateTypes: ['minor', 'patch'],
       commitMessagePrefix: 'deps:',
-    },
-    {
-      matchDepTypes: ['devDependencies'],
-      matchUpdateTypes: ['major'],
-      commitMessagePrefix: 'deps!:',
     },
     {
       matchManagers: ['github-actions'],
@@ -33,13 +24,7 @@
     },
     {
       matchManagers: ['mise'],
-      matchUpdateTypes: ['minor', 'patch'],
       commitMessagePrefix: 'deps:',
-    },
-    {
-      matchManagers: ['mise'],
-      matchUpdateTypes: ['major'],
-      commitMessagePrefix: 'deps!:',
     },
 
     // Group mise npm backend packages with their npm counterparts.


### PR DESCRIPTION
## Purpose

- Tool / devDependency major bumps in the template were committed as `deps!:`, causing release-please to minor-bump this repo itself
  - These are not breaking changes

## Approach

- Treat major updates of devDependencies / mise as non-breaking by using `deps:`
