### PR TITLE
feat: guard against pinning fresh SHAs with pinact min_age

### DIFF
--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
+# `always: true` enforces the check on existing pins as well, not just new ones.
+min_age:
+  value: 7
+  always: true

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -2,8 +2,6 @@
 # pinact - https://github.com/suzuki-shunsuke/pinact
 version: 3
 
-# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
-# `always: true` enforces the check on existing pins as well, not just new ones.
 min_age:
   value: 7
   always: true

--- a/generated/base-public/.pinact.yaml
+++ b/generated/base-public/.pinact.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
+# `always: true` enforces the check on existing pins as well, not just new ones.
+min_age:
+  value: 7
+  always: true

--- a/generated/base-public/.pinact.yaml
+++ b/generated/base-public/.pinact.yaml
@@ -2,8 +2,6 @@
 # pinact - https://github.com/suzuki-shunsuke/pinact
 version: 3
 
-# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
-# `always: true` enforces the check on existing pins as well, not just new ones.
 min_age:
   value: 7
   always: true

--- a/generated/base-release/.pinact.yaml
+++ b/generated/base-release/.pinact.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
+# `always: true` enforces the check on existing pins as well, not just new ones.
+min_age:
+  value: 7
+  always: true

--- a/generated/base-release/.pinact.yaml
+++ b/generated/base-release/.pinact.yaml
@@ -2,8 +2,6 @@
 # pinact - https://github.com/suzuki-shunsuke/pinact
 version: 3
 
-# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
-# `always: true` enforces the check on existing pins as well, not just new ones.
 min_age:
   value: 7
   always: true

--- a/generated/base/.pinact.yaml
+++ b/generated/base/.pinact.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
+# `always: true` enforces the check on existing pins as well, not just new ones.
+min_age:
+  value: 7
+  always: true

--- a/generated/base/.pinact.yaml
+++ b/generated/base/.pinact.yaml
@@ -2,8 +2,6 @@
 # pinact - https://github.com/suzuki-shunsuke/pinact
 version: 3
 
-# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
-# `always: true` enforces the check on existing pins as well, not just new ones.
 min_age:
   value: 7
   always: true

--- a/generated/monorepo-node-workspace/.pinact.yaml
+++ b/generated/monorepo-node-workspace/.pinact.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
+# `always: true` enforces the check on existing pins as well, not just new ones.
+min_age:
+  value: 7
+  always: true

--- a/generated/monorepo-node-workspace/.pinact.yaml
+++ b/generated/monorepo-node-workspace/.pinact.yaml
@@ -2,8 +2,6 @@
 # pinact - https://github.com/suzuki-shunsuke/pinact
 version: 3
 
-# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
-# `always: true` enforces the check on existing pins as well, not just new ones.
 min_age:
   value: 7
   always: true

--- a/generated/monorepo/.pinact.yaml
+++ b/generated/monorepo/.pinact.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
+# `always: true` enforces the check on existing pins as well, not just new ones.
+min_age:
+  value: 7
+  always: true

--- a/generated/monorepo/.pinact.yaml
+++ b/generated/monorepo/.pinact.yaml
@@ -2,8 +2,6 @@
 # pinact - https://github.com/suzuki-shunsuke/pinact
 version: 3
 
-# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
-# `always: true` enforces the check on existing pins as well, not just new ones.
 min_age:
   value: 7
   always: true

--- a/generated/node/.pinact.yaml
+++ b/generated/node/.pinact.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
+# `always: true` enforces the check on existing pins as well, not just new ones.
+min_age:
+  value: 7
+  always: true

--- a/generated/node/.pinact.yaml
+++ b/generated/node/.pinact.yaml
@@ -2,8 +2,6 @@
 # pinact - https://github.com/suzuki-shunsuke/pinact
 version: 3
 
-# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
-# `always: true` enforces the check on existing pins as well, not just new ones.
 min_age:
   value: 7
   always: true

--- a/generated/rust-release/.pinact.yaml
+++ b/generated/rust-release/.pinact.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
+# `always: true` enforces the check on existing pins as well, not just new ones.
+min_age:
+  value: 7
+  always: true

--- a/generated/rust-release/.pinact.yaml
+++ b/generated/rust-release/.pinact.yaml
@@ -2,8 +2,6 @@
 # pinact - https://github.com/suzuki-shunsuke/pinact
 version: 3
 
-# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
-# `always: true` enforces the check on existing pins as well, not just new ones.
 min_age:
   value: 7
   always: true

--- a/generated/rust/.pinact.yaml
+++ b/generated/rust/.pinact.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
+# `always: true` enforces the check on existing pins as well, not just new ones.
+min_age:
+  value: 7
+  always: true

--- a/generated/rust/.pinact.yaml
+++ b/generated/rust/.pinact.yaml
@@ -2,8 +2,6 @@
 # pinact - https://github.com/suzuki-shunsuke/pinact
 version: 3
 
-# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
-# `always: true` enforces the check on existing pins as well, not just new ones.
 min_age:
   value: 7
   always: true

--- a/template/.pinact.yaml
+++ b/template/.pinact.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
+# `always: true` enforces the check on existing pins as well, not just new ones.
+min_age:
+  value: 7
+  always: true

--- a/template/.pinact.yaml
+++ b/template/.pinact.yaml
@@ -2,8 +2,6 @@
 # pinact - https://github.com/suzuki-shunsuke/pinact
 version: 3
 
-# Reduce the risk of pinning a malicious SHA that was retagged shortly after release.
-# `always: true` enforces the check on existing pins as well, not just new ones.
 min_age:
   value: 7
   always: true


### PR DESCRIPTION
## Purpose

- Reduce the supply chain attack risk of pinning a malicious SHA retagged shortly after a release

## Approach

- Add `.pinact.yaml` at the repository root and under `template/`, with `min_age` set to 7 days and `always: true`
    - Downstream projects consume `template/` via copier, so the same guard ships to them
