### PR TITLE
chore(renovate): override upstream packageManager rule to use deps: prefix

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,9 +9,6 @@
   // template/ contains Copier templates (*.jinja), not actual project files
   ignorePaths: ['template/**'],
   packageRules: [
-    // Override base.json5's devDependencies rule (chore:), github-actions
-    // rule (ci:), and node.json5's packageManager rule (chore:) to use
-    // deps: instead.
     // generic-boilerplate manages Copier templates, so package updates here
     // should propagate to all downstream repos via semantic version bumps.
     //

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,8 +9,9 @@
   // template/ contains Copier templates (*.jinja), not actual project files
   ignorePaths: ['template/**'],
   packageRules: [
-    // Override base.json5's devDependencies rule (chore:) and github-actions
-    // rule (ci:) to use deps: instead.
+    // Override base.json5's devDependencies rule (chore:), github-actions
+    // rule (ci:), and node.json5's packageManager rule (chore:) to use
+    // deps: instead.
     // generic-boilerplate manages Copier templates, so package updates here
     // should propagate to all downstream repos via semantic version bumps.
     //
@@ -38,6 +39,18 @@
     },
     {
       matchManagers: ['mise'],
+      matchUpdateTypes: ['major'],
+      commitMessagePrefix: 'deps!:',
+    },
+    {
+      matchManagers: ['npm'],
+      matchDepTypes: ['packageManager'],
+      matchUpdateTypes: ['minor', 'patch'],
+      commitMessagePrefix: 'deps:',
+    },
+    {
+      matchManagers: ['npm'],
+      matchDepTypes: ['packageManager'],
       matchUpdateTypes: ['major'],
       commitMessagePrefix: 'deps!:',
     },

--- a/renovate.json5
+++ b/renovate.json5
@@ -39,6 +39,11 @@
       matchUpdateTypes: ['major'],
       commitMessagePrefix: 'deps!:',
     },
+    // Upstream node.json5 pins packageManager updates to chore: on the basis
+    // that the field is corepack-only and never reaches published artifacts.
+    // That reasoning does not hold here: generic-boilerplate is a Copier
+    // template, so packageManager strings propagate to downstream repos via
+    // copier update and require a release tag to be picked up.
     {
       matchManagers: ['npm'],
       matchDepTypes: ['packageManager'],


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/renovate-config/pull/370
- `packageManager` updates no longer trigger a release-please patch bump, so downstream repos stop receiving propagation
    - Upstream node.json5 pinned `packageManager` updates to `chore:`
    - This repo's `release-please-config.json` hides `chore`, so no tag is cut and the Renovate Copier manager never opens a `copier update` PR downstream

## Approach

- Re-override the upstream rule to `deps:` (minor/patch) and `deps!:` (major)
