### PR TITLE
fix(ci/test-workflow): authenticate pinact's GitHub API calls

### DIFF
--- a/generated/base-public/.github/workflows/test.yml
+++ b/generated/base-public/.github/workflows/test.yml
@@ -45,6 +45,10 @@ jobs:
       - name: Run lefthook
         id: lefthook
         continue-on-error: true
+        env:
+          # pinact's min-age check calls the GitHub API; without a token it hits
+          # the 60 req/h unauthenticated limit shared per IP and fails on CI.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lefthook run pre-commit --all-files
 
       # Formatters configured with `stage_fixed: true` run `git add` after formatting,

--- a/generated/base-release/.github/workflows/test.yml
+++ b/generated/base-release/.github/workflows/test.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Run lefthook
         id: lefthook
         continue-on-error: true
+        env:
+          # pinact's min-age check calls the GitHub API; without a token it hits
+          # the 60 req/h unauthenticated limit shared per IP and fails on CI.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lefthook run pre-commit --all-files
 
       # Formatters configured with `stage_fixed: true` run `git add` after formatting,

--- a/generated/base/.github/workflows/test.yml
+++ b/generated/base/.github/workflows/test.yml
@@ -45,6 +45,10 @@ jobs:
       - name: Run lefthook
         id: lefthook
         continue-on-error: true
+        env:
+          # pinact's min-age check calls the GitHub API; without a token it hits
+          # the 60 req/h unauthenticated limit shared per IP and fails on CI.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lefthook run pre-commit --all-files
 
       # Formatters configured with `stage_fixed: true` run `git add` after formatting,

--- a/generated/monorepo-node-workspace/.github/workflows/test.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/test.yml
@@ -64,6 +64,10 @@ jobs:
       - name: Run lefthook
         id: lefthook
         continue-on-error: true
+        env:
+          # pinact's min-age check calls the GitHub API; without a token it hits
+          # the 60 req/h unauthenticated limit shared per IP and fails on CI.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lefthook run pre-commit --all-files
 
       # Formatters configured with `stage_fixed: true` run `git add` after formatting,

--- a/generated/monorepo/.github/workflows/test.yml
+++ b/generated/monorepo/.github/workflows/test.yml
@@ -83,6 +83,10 @@ jobs:
       - name: Run lefthook
         id: lefthook
         continue-on-error: true
+        env:
+          # pinact's min-age check calls the GitHub API; without a token it hits
+          # the 60 req/h unauthenticated limit shared per IP and fails on CI.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lefthook run pre-commit --all-files
 
       # Formatters configured with `stage_fixed: true` run `git add` after formatting,

--- a/generated/node/.github/workflows/test.yml
+++ b/generated/node/.github/workflows/test.yml
@@ -62,6 +62,10 @@ jobs:
       - name: Run lefthook
         id: lefthook
         continue-on-error: true
+        env:
+          # pinact's min-age check calls the GitHub API; without a token it hits
+          # the 60 req/h unauthenticated limit shared per IP and fails on CI.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lefthook run pre-commit --all-files
 
       # Formatters configured with `stage_fixed: true` run `git add` after formatting,

--- a/generated/rust-release/.github/workflows/test.yml
+++ b/generated/rust-release/.github/workflows/test.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Run lefthook
         id: lefthook
         continue-on-error: true
+        env:
+          # pinact's min-age check calls the GitHub API; without a token it hits
+          # the 60 req/h unauthenticated limit shared per IP and fails on CI.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lefthook run pre-commit --all-files
 
       # Formatters configured with `stage_fixed: true` run `git add` after formatting,

--- a/generated/rust/.github/workflows/test.yml
+++ b/generated/rust/.github/workflows/test.yml
@@ -60,6 +60,10 @@ jobs:
       - name: Run lefthook
         id: lefthook
         continue-on-error: true
+        env:
+          # pinact's min-age check calls the GitHub API; without a token it hits
+          # the 60 req/h unauthenticated limit shared per IP and fails on CI.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lefthook run pre-commit --all-files
 
       # Formatters configured with `stage_fixed: true` run `git add` after formatting,

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -152,6 +152,10 @@ jobs:
       - name: Run lefthook
         id: lefthook
         continue-on-error: true
+        env:
+          # pinact's min-age check calls the GitHub API; without a token it hits
+          # the 60 req/h unauthenticated limit shared per IP and fails on CI.
+          GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
         run: lefthook run pre-commit --all-files
 
       # Formatters configured with `stage_fixed: true` run `git add` after formatting,


### PR DESCRIPTION
## Purpose

- Stop `lefthook run pre-commit` from failing on pinact's min-age check in downstream repositories' CI ([failing CI run](https://github.com/fohte/generic-boilerplate/actions/runs/27060038951))
    - Hitting the unauthenticated rate limit (60 req/h) shared across GitHub Actions runner IPs makes pinact fail to fetch pinned actions' commits, taking the whole job down with it

## Approach

- Run pinact authenticated so its min-age check uses the 5000 req/h limit
