### PR TITLE
ci: authenticate pinact's GitHub API calls in repo workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Run lefthook
         id: lefthook
         continue-on-error: true
+        env:
+          # pinact's min-age check calls the GitHub API; without a token it hits
+          # the 60 req/h unauthenticated limit shared per IP and fails on CI.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lefthook run pre-commit --all-files
 
       # Formatters configured with `stage_fixed: true` run `git add` after formatting,

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -143,6 +143,10 @@ jobs:
 
       - name: Run lefthook
         working-directory: generated/${{ matrix.fixture }}
+        env:
+          # pinact's min-age check calls the GitHub API; without a token it hits
+          # the 60 req/h unauthenticated limit shared per IP and fails on CI.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: lefthook run pre-commit --all-files
 
       - name: Check for diff


### PR DESCRIPTION
## Purpose

- master CI keeps failing due to the GitHub API rate limit
    - from: https://github.com/fohte/generic-boilerplate/actions/runs/27080842896
    - The failing job is `validate` in `validate-template.yml`, but root's `test.yml` runs pinact through lefthook the same way and is also unauthenticated, so it can hit the same symptom
- [#384](https://github.com/fohte/generic-boilerplate/pull/384) already fixed the template side, but landing it on root requires a release first — a chicken-and-egg situation

## Approach

- Authenticate pinact's GitHub API calls in every workflow this repository itself runs
