### PR TITLE
feat(node): set a 7-day minimumReleaseAge in generated projects

### DIFF
--- a/generated/monorepo-node-workspace/pnpm-workspace.yaml
+++ b/generated/monorepo-node-workspace/pnpm-workspace.yaml
@@ -7,3 +7,9 @@ allowBuilds:
   esbuild: true
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
+
+# Reject package versions published less than 7 days ago to dodge
+# short-lived supply-chain attacks (e.g. shai-hulud, tinycolor).
+minimumReleaseAge: 10080
+# Add package names here to bypass the cooldown for specific deps.
+minimumReleaseAgeExclude: []

--- a/generated/monorepo-node-workspace/pnpm-workspace.yaml
+++ b/generated/monorepo-node-workspace/pnpm-workspace.yaml
@@ -8,8 +8,7 @@ allowBuilds:
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
 
-# Reject package versions published less than 7 days ago to dodge
-# short-lived supply-chain attacks (e.g. shai-hulud, tinycolor).
+# Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
+# holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
-# Add package names here to bypass the cooldown for specific deps.
 minimumReleaseAgeExclude: []

--- a/generated/monorepo/frontend/pnpm-workspace.yaml
+++ b/generated/monorepo/frontend/pnpm-workspace.yaml
@@ -4,8 +4,7 @@ allowBuilds:
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
 
-# Reject package versions published less than 7 days ago to dodge
-# short-lived supply-chain attacks (e.g. shai-hulud, tinycolor).
+# Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
+# holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
-# Add package names here to bypass the cooldown for specific deps.
 minimumReleaseAgeExclude: []

--- a/generated/monorepo/frontend/pnpm-workspace.yaml
+++ b/generated/monorepo/frontend/pnpm-workspace.yaml
@@ -3,3 +3,9 @@ allowBuilds:
   esbuild: true
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
+
+# Reject package versions published less than 7 days ago to dodge
+# short-lived supply-chain attacks (e.g. shai-hulud, tinycolor).
+minimumReleaseAge: 10080
+# Add package names here to bypass the cooldown for specific deps.
+minimumReleaseAgeExclude: []

--- a/generated/node/pnpm-workspace.yaml
+++ b/generated/node/pnpm-workspace.yaml
@@ -4,8 +4,7 @@ allowBuilds:
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
 
-# Reject package versions published less than 7 days ago to dodge
-# short-lived supply-chain attacks (e.g. shai-hulud, tinycolor).
+# Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
+# holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
-# Add package names here to bypass the cooldown for specific deps.
 minimumReleaseAgeExclude: []

--- a/generated/node/pnpm-workspace.yaml
+++ b/generated/node/pnpm-workspace.yaml
@@ -3,3 +3,9 @@ allowBuilds:
   esbuild: true
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
+
+# Reject package versions published less than 7 days ago to dodge
+# short-lived supply-chain attacks (e.g. shai-hulud, tinycolor).
+minimumReleaseAge: 10080
+# Add package names here to bypass the cooldown for specific deps.
+minimumReleaseAgeExclude: []

--- a/template/pnpm-workspace.yaml.jinja
+++ b/template/pnpm-workspace.yaml.jinja
@@ -10,3 +10,9 @@ allowBuilds:
   esbuild: true
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
+
+# Reject package versions published less than 7 days ago to dodge
+# short-lived supply-chain attacks (e.g. shai-hulud, tinycolor).
+minimumReleaseAge: 10080
+# Add package names here to bypass the cooldown for specific deps.
+minimumReleaseAgeExclude: []

--- a/template/pnpm-workspace.yaml.jinja
+++ b/template/pnpm-workspace.yaml.jinja
@@ -11,8 +11,7 @@ allowBuilds:
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
 
-# Reject package versions published less than 7 days ago to dodge
-# short-lived supply-chain attacks (e.g. shai-hulud, tinycolor).
+# Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
+# holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
-# Add package names here to bypass the cooldown for specific deps.
 minimumReleaseAgeExclude: []

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and not (monorepo_node_workspace | default(false)) %}pnpm-workspace.yaml{% endif %}
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and not (monorepo_node_workspace | default(false)) %}pnpm-workspace.yaml{% endif %}
@@ -4,8 +4,7 @@ allowBuilds:
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
 
-# Reject package versions published less than 7 days ago to dodge
-# short-lived supply-chain attacks (e.g. shai-hulud, tinycolor).
+# Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
+# holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
-# Add package names here to bypass the cooldown for specific deps.
 minimumReleaseAgeExclude: []

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and not (monorepo_node_workspace | default(false)) %}pnpm-workspace.yaml{% endif %}
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and not (monorepo_node_workspace | default(false)) %}pnpm-workspace.yaml{% endif %}
@@ -3,3 +3,9 @@ allowBuilds:
   esbuild: true
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
+
+# Reject package versions published less than 7 days ago to dodge
+# short-lived supply-chain attacks (e.g. shai-hulud, tinycolor).
+minimumReleaseAge: 10080
+# Add package names here to bypass the cooldown for specific deps.
+minimumReleaseAgeExclude: []


### PR DESCRIPTION
## Purpose

- Block short-lived supply-chain attacks coming through the npm registry

## Approach

- Default the pnpm cooldown to 7 days in generated projects, keeping a per-package bypass path local to each project for emergencies
