### PR TITLE
feat(lefthook): add betterleaks secret scan to pre-commit

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -3,6 +3,7 @@ lefthook = "2.1.9"
 
 # lefthook hooks
 actionlint = "1.7.12"
+"github:betterleaks/betterleaks" = "1.4.1"
 node = "24.16.0"
 pinact = "4.0.0"
 "github:fohte/basefmt" = "0.1.0"

--- a/generated/base-public/.mise.toml
+++ b/generated/base-public/.mise.toml
@@ -3,6 +3,7 @@ lefthook = "2.1.9"
 
 # lefthook hooks
 actionlint = "1.7.12"
+"github:betterleaks/betterleaks" = "1.4.1"
 node = "24.16.0"
 pinact = "4.0.0"
 "github:fohte/basefmt" = "0.1.0"

--- a/generated/base-public/lefthook.yml
+++ b/generated/base-public/lefthook.yml
@@ -34,6 +34,9 @@ pre-commit:
       glob: '.github/workflows/*.{yml,yaml}'
       run: mise x actionlint -- actionlint {staged_files}
 
+    betterleaks:
+      run: mise x betterleaks -- betterleaks git --pre-commit --redact --staged --verbose
+
     copier-src-path:
       glob: '.copier-answers.yml'
       run: |

--- a/generated/base-release/.mise.toml
+++ b/generated/base-release/.mise.toml
@@ -3,6 +3,7 @@ lefthook = "2.1.9"
 
 # lefthook hooks
 actionlint = "1.7.12"
+"github:betterleaks/betterleaks" = "1.4.1"
 node = "24.16.0"
 pinact = "4.0.0"
 "github:fohte/basefmt" = "0.1.0"

--- a/generated/base-release/lefthook.yml
+++ b/generated/base-release/lefthook.yml
@@ -34,6 +34,9 @@ pre-commit:
       glob: '.github/workflows/*.{yml,yaml}'
       run: mise x actionlint -- actionlint {staged_files}
 
+    betterleaks:
+      run: mise x betterleaks -- betterleaks git --pre-commit --redact --staged --verbose
+
     copier-src-path:
       glob: '.copier-answers.yml'
       run: |

--- a/generated/base/.mise.toml
+++ b/generated/base/.mise.toml
@@ -3,6 +3,7 @@ lefthook = "2.1.9"
 
 # lefthook hooks
 actionlint = "1.7.12"
+"github:betterleaks/betterleaks" = "1.4.1"
 node = "24.16.0"
 pinact = "4.0.0"
 "github:fohte/basefmt" = "0.1.0"

--- a/generated/base/lefthook.yml
+++ b/generated/base/lefthook.yml
@@ -34,6 +34,9 @@ pre-commit:
       glob: '.github/workflows/*.{yml,yaml}'
       run: mise x actionlint -- actionlint {staged_files}
 
+    betterleaks:
+      run: mise x betterleaks -- betterleaks git --pre-commit --redact --staged --verbose
+
     copier-src-path:
       glob: '.copier-answers.yml'
       run: |

--- a/generated/monorepo-node-workspace/.mise.toml
+++ b/generated/monorepo-node-workspace/.mise.toml
@@ -3,6 +3,7 @@ lefthook = "2.1.9"
 
 # lefthook hooks
 actionlint = "1.7.12"
+"github:betterleaks/betterleaks" = "1.4.1"
 node = "24.16.0"
 pinact = "4.0.0"
 "github:fohte/basefmt" = "0.1.0"

--- a/generated/monorepo-node-workspace/lefthook.yml
+++ b/generated/monorepo-node-workspace/lefthook.yml
@@ -34,6 +34,9 @@ pre-commit:
       glob: '.github/workflows/*.{yml,yaml}'
       run: mise x actionlint -- actionlint {staged_files}
 
+    betterleaks:
+      run: mise x betterleaks -- betterleaks git --pre-commit --redact --staged --verbose
+
     copier-src-path:
       glob: '.copier-answers.yml'
       run: |

--- a/generated/monorepo/.mise.toml
+++ b/generated/monorepo/.mise.toml
@@ -4,6 +4,7 @@ lefthook = "2.1.9"
 
 # lefthook hooks
 actionlint = "1.7.12"
+"github:betterleaks/betterleaks" = "1.4.1"
 node = "24.16.0"
 pinact = "4.0.0"
 "github:fohte/basefmt" = "0.1.0"

--- a/generated/monorepo/lefthook.yml
+++ b/generated/monorepo/lefthook.yml
@@ -34,6 +34,9 @@ pre-commit:
       glob: '.github/workflows/*.{yml,yaml}'
       run: mise x actionlint -- actionlint {staged_files}
 
+    betterleaks:
+      run: mise x betterleaks -- betterleaks git --pre-commit --redact --staged --verbose
+
     copier-src-path:
       glob: '.copier-answers.yml'
       run: |

--- a/generated/node/.mise.toml
+++ b/generated/node/.mise.toml
@@ -3,6 +3,7 @@ lefthook = "2.1.9"
 
 # lefthook hooks
 actionlint = "1.7.12"
+"github:betterleaks/betterleaks" = "1.4.1"
 node = "24.16.0"
 pinact = "4.0.0"
 "github:fohte/basefmt" = "0.1.0"

--- a/generated/node/lefthook.yml
+++ b/generated/node/lefthook.yml
@@ -34,6 +34,9 @@ pre-commit:
       glob: '.github/workflows/*.{yml,yaml}'
       run: mise x actionlint -- actionlint {staged_files}
 
+    betterleaks:
+      run: mise x betterleaks -- betterleaks git --pre-commit --redact --staged --verbose
+
     copier-src-path:
       glob: '.copier-answers.yml'
       run: |

--- a/generated/rust-release/.mise.toml
+++ b/generated/rust-release/.mise.toml
@@ -4,6 +4,7 @@ lefthook = "2.1.9"
 
 # lefthook hooks
 actionlint = "1.7.12"
+"github:betterleaks/betterleaks" = "1.4.1"
 node = "24.16.0"
 pinact = "4.0.0"
 "github:fohte/basefmt" = "0.1.0"

--- a/generated/rust-release/lefthook.yml
+++ b/generated/rust-release/lefthook.yml
@@ -34,6 +34,9 @@ pre-commit:
       glob: '.github/workflows/*.{yml,yaml}'
       run: mise x actionlint -- actionlint {staged_files}
 
+    betterleaks:
+      run: mise x betterleaks -- betterleaks git --pre-commit --redact --staged --verbose
+
     copier-src-path:
       glob: '.copier-answers.yml'
       run: |

--- a/generated/rust/.mise.toml
+++ b/generated/rust/.mise.toml
@@ -4,6 +4,7 @@ lefthook = "2.1.9"
 
 # lefthook hooks
 actionlint = "1.7.12"
+"github:betterleaks/betterleaks" = "1.4.1"
 node = "24.16.0"
 pinact = "4.0.0"
 "github:fohte/basefmt" = "0.1.0"

--- a/generated/rust/lefthook.yml
+++ b/generated/rust/lefthook.yml
@@ -34,6 +34,9 @@ pre-commit:
       glob: '.github/workflows/*.{yml,yaml}'
       run: mise x actionlint -- actionlint {staged_files}
 
+    betterleaks:
+      run: mise x betterleaks -- betterleaks git --pre-commit --redact --staged --verbose
+
     copier-src-path:
       glob: '.copier-answers.yml'
       run: |

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -36,6 +36,9 @@ pre-commit:
       glob: '.github/workflows/*.{yml,yaml}'
       run: mise x actionlint -- actionlint {staged_files}
 
+    betterleaks:
+      run: mise x betterleaks -- betterleaks git --pre-commit --redact --staged --verbose
+
     copier-src-path:
       glob: '.copier-answers.yml'
       run: |

--- a/template/.mise.toml.jinja
+++ b/template/.mise.toml.jinja
@@ -6,6 +6,7 @@ lefthook = "2.1.9"
 
 # lefthook hooks
 actionlint = "1.7.12"
+"github:betterleaks/betterleaks" = "1.4.1"
 node = "24.16.0"
 pinact = "4.0.0"
 "github:fohte/basefmt" = "0.1.0"

--- a/template/lefthook.yml.jinja
+++ b/template/lefthook.yml.jinja
@@ -35,6 +35,9 @@ pre-commit:
       glob: '.github/workflows/*.{yml,yaml}'
       run: mise x actionlint -- actionlint {staged_files}
 
+    betterleaks:
+      run: mise x betterleaks -- betterleaks git --pre-commit --redact --staged --verbose
+
     copier-src-path:
       glob: '.copier-answers.yml'
       run: |


### PR DESCRIPTION
## Purpose

- Prevent accidental commits of secrets

## Approach

- Add a [betterleaks](https://github.com/betterleaks/betterleaks) secret scan to the pre-commit hook

<details>
<summary>Design decisions</summary>

#### Scanner choice

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen | betterleaks | CEL-based false-positive filters, active secret validation, BPE-tokenizer noise filtering | Newer tool with less adoption than gitleaks |
| Rejected | gitleaks | Widely adopted | The same authors have moved on to betterleaks as its successor, leaving gitleaks behind on features |

#### Install path

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen | mise `github:` backend | Matches the existing tool-pin convention (`github:fohte/basefmt`, `github:ast-grep/ast-grep`) and lets Renovate's mise manager track version updates | Adds a download wait on the first commit |
| Rejected | Homebrew / Docker | Cannot avoid macOS/Linux environment differences or Docker startup cost | Breaks the unified install path used elsewhere in the repo |

</details>
