### PR TITLE
ci(validate-template): skip job on tag push

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -2,6 +2,8 @@ name: Validate Template
 
 on:
   push:
+    branches:
+      - '**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -2,6 +2,9 @@ name: Validate Template
 
 on:
   push:
+    # Skip tag pushes: the octo-sts trust policy only allows branch refs, so
+    # token issuance for tag refs returns 403. The tagged commit has already
+    # been validated on its branch, so re-running on the tag is redundant.
     branches:
       - '**'
 


### PR DESCRIPTION
## Purpose

- Every release tag push by release-please fails [`validate-template`](https://github.com/fohte/generic-boilerplate/blob/cdd6c2e/.github/workflows/validate-template.yml) and turns CI red
    - The octo-sts trust policy allows branch refs only, so token issuance for tag refs returns 403
    - Failing run: https://github.com/fohte/generic-boilerplate/actions/runs/27091484849

## Approach

- Restrict the trigger to branch pushes so tag pushes are excluded

<details>
<summary>Design decisions</summary>

#### Narrow the workflow trigger, or loosen the octo-sts trust policy?

| Decision | Design                                          | Pros                                                                                                                  | Cons                                                                |
| -------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| Chosen   | Exclude tag pushes on the workflow side         | Keeps the bot token's issuance scope narrow. The tagged commit has already been validated on `master`, so re-running is redundant | Adds a trigger condition to the workflow                            |
| Rejected | Allow tag refs in the octo-sts trust policy     | Leaves the workflow trigger configuration untouched                                                                   | Tags cannot be protected and are force-pushable, widening the attack surface |

</details>
