### PR TITLE
fix(scripts): actually tick Renovate Dashboard checkboxes in trigger-renovate-boilerplate-prs

### DIFF
--- a/scripts/trigger-renovate-boilerplate-prs
+++ b/scripts/trigger-renovate-boilerplate-prs
@@ -83,7 +83,7 @@ for repo in "${repos[@]}"; do
   body=$(gh issue view "$issue_number" -R "fohte/$repo" --json body -q .body)
 
   # Check if there's a rate-limited generic-boilerplate checkbox
-  if ! echo "$body" | grep -qF -- "- [ ] <!-- ${CHECKBOX_PATTERN}"; then
+  if ! printf '%s\n' "$body" | grep -qF -- "- [ ] <!-- ${CHECKBOX_PATTERN}"; then
     echo "SKIP $repo: no rate-limited generic-boilerplate entry in Dashboard #$issue_number"
     continue
   fi

--- a/scripts/trigger-renovate-boilerplate-prs
+++ b/scripts/trigger-renovate-boilerplate-prs
@@ -59,9 +59,12 @@ if [[ ${#repos[@]} -eq 0 ]]; then
   exit 0
 fi
 
-CHECKBOX_PATTERN='unlimit-branch=renovate/https-github.com-fohte-generic-boilerplate'
+# `branchNameStrict` normalizes dots in the host to hyphens, so the marker
+# uses `https-github-com-...` rather than `https-github.com-...`.
+CHECKBOX_PATTERN='unlimit-branch=renovate/https-github-com-fohte-generic-boilerplate'
 
 updated_repos=()
+failed_repos=()
 
 for repo in "${repos[@]}"; do
   # Find the Dependency Dashboard issue
@@ -80,7 +83,7 @@ for repo in "${repos[@]}"; do
   body=$(gh issue view "$issue_number" -R "fohte/$repo" --json body -q .body)
 
   # Check if there's a rate-limited generic-boilerplate checkbox
-  if ! echo "$body" | grep -q "\\- \\[ \\] <!-- ${CHECKBOX_PATTERN}"; then
+  if ! echo "$body" | grep -qF -- "- [ ] <!-- ${CHECKBOX_PATTERN}"; then
     echo "SKIP $repo: no rate-limited generic-boilerplate entry in Dashboard #$issue_number"
     continue
   fi
@@ -89,6 +92,11 @@ for repo in "${repos[@]}"; do
     echo "WOULD UPDATE $repo: Dashboard #$issue_number"
   else
     updated_body="${body//- \[ \] <!-- ${CHECKBOX_PATTERN}/- [x] <!-- ${CHECKBOX_PATTERN}}"
+    if [[ "$updated_body" == "$body" ]]; then
+      echo "FAIL $repo: checkbox substitution produced no change (pattern drift?) in Dashboard #$issue_number" >&2
+      failed_repos+=("$repo")
+      continue
+    fi
     gh issue edit "$issue_number" -R "fohte/$repo" --body "$updated_body"
     echo "UPDATED $repo: Dashboard #$issue_number"
     updated_repos+=("$repo")
@@ -96,6 +104,9 @@ for repo in "${repos[@]}"; do
 done
 
 if "$DRY_RUN" || [[ ${#updated_repos[@]} -eq 0 ]]; then
+  if [[ ${#failed_repos[@]} -gt 0 ]]; then
+    exit 1
+  fi
   exit 0
 fi
 

--- a/scripts/trigger-renovate-boilerplate-prs
+++ b/scripts/trigger-renovate-boilerplate-prs
@@ -59,8 +59,8 @@ if [[ ${#repos[@]} -eq 0 ]]; then
   exit 0
 fi
 
-# `branchNameStrict` normalizes dots in the host to hyphens, so the marker
-# uses `https-github-com-...` rather than `https-github.com-...`.
+# `branchNameStrict` normalizes dots in branch names to hyphens, so the
+# checkbox marker contains `https-github-com-...`.
 CHECKBOX_PATTERN='unlimit-branch=renovate/https-github-com-fohte-generic-boilerplate'
 
 updated_repos=()
@@ -103,11 +103,13 @@ for repo in "${repos[@]}"; do
   fi
 done
 
+exit_code=0
+if [[ ${#failed_repos[@]} -gt 0 ]]; then
+  exit_code=1
+fi
+
 if "$DRY_RUN" || [[ ${#updated_repos[@]} -eq 0 ]]; then
-  if [[ ${#failed_repos[@]} -gt 0 ]]; then
-    exit 1
-  fi
-  exit 0
+  exit "$exit_code"
 fi
 
 # Wait for Renovate to create PRs
@@ -135,7 +137,7 @@ for ((attempt = 1; attempt <= max_attempts; attempt++)); do
 
   if [[ ${#remaining[@]} -eq 0 ]]; then
     echo "All PRs created."
-    exit 0
+    exit "$exit_code"
   fi
 
   updated_repos=("${remaining[@]}")


### PR DESCRIPTION
## Purpose

- `scripts/trigger-renovate-boilerplate-prs` reports `UPDATED <repo>` but leaves the Renovate Dependency Dashboard checkbox as `[ ]`, so Renovate never proceeds to create the PR
    - Rate-limited repos remain stuck, and rerunning the script does not recover them

## Approach

- Align the checkbox HTML comment marker with the form Renovate generates today (`https-github-com-...`)
    - Since [renovate-config enabled `branchNameStrict: true`](https://redirect.github.com/fohte/renovate-config/pull/359), dots in branch names are normalized to hyphens, so the old `https-github.com-...` pattern no longer matches the issue body
- Treat a no-op substitution as a failure and make the script exit non-zero
    - Prevents the same silent failure from recurring if Renovate changes the pattern again
