### PR TITLE
fix(scripts): use pnpm install --frozen-lockfile in bootstrap

### DIFF
--- a/generated/monorepo-node-workspace/scripts/bootstrap
+++ b/generated/monorepo-node-workspace/scripts/bootstrap
@@ -18,10 +18,22 @@ fi
 # Enable corepack so that pnpm version from package.json packageManager field is used
 corepack enable
 
+# Use --frozen-lockfile when a lockfile exists so a Renovate-bumped dep still
+# inside the pnpm-workspace.yaml minimumReleaseAge window does not re-trigger
+# the supply-chain policy check and block bootstrap. Fall back to plain
+# `pnpm install` on freshly generated projects without a lockfile yet.
+pnpm_install() {
+  if [ -f pnpm-lock.yaml ]; then
+    pnpm install --frozen-lockfile
+  else
+    pnpm install
+  fi
+}
+
 # Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
 if command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi
 
 # Install Node.js dependencies (workspace)
-pnpm install --frozen-lockfile
+pnpm_install

--- a/generated/monorepo-node-workspace/scripts/bootstrap
+++ b/generated/monorepo-node-workspace/scripts/bootstrap
@@ -24,4 +24,4 @@ if command -v lefthook > /dev/null 2>&1; then
 fi
 
 # Install Node.js dependencies (workspace)
-pnpm install
+pnpm install --frozen-lockfile

--- a/generated/monorepo/scripts/bootstrap
+++ b/generated/monorepo/scripts/bootstrap
@@ -18,15 +18,27 @@ fi
 # Enable corepack so that pnpm version from package.json packageManager field is used
 corepack enable
 
+# Use --frozen-lockfile when a lockfile exists so a Renovate-bumped dep still
+# inside the pnpm-workspace.yaml minimumReleaseAge window does not re-trigger
+# the supply-chain policy check and block bootstrap. Fall back to plain
+# `pnpm install` on freshly generated projects without a lockfile yet.
+pnpm_install() {
+  if [ -f pnpm-lock.yaml ]; then
+    pnpm install --frozen-lockfile
+  else
+    pnpm install
+  fi
+}
+
 # Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
 if command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi
 
 # Install shared dev tools (prettier, commitlint) at the repo root
-pnpm install --frozen-lockfile
+pnpm_install
 # Install Node.js dependencies for each subpackage
-(cd frontend && pnpm install --frozen-lockfile)
+(cd frontend && pnpm_install)
 
 # Fetch Rust dependencies
 cargo fetch --manifest-path backend/Cargo.toml

--- a/generated/monorepo/scripts/bootstrap
+++ b/generated/monorepo/scripts/bootstrap
@@ -24,9 +24,9 @@ if command -v lefthook > /dev/null 2>&1; then
 fi
 
 # Install shared dev tools (prettier, commitlint) at the repo root
-pnpm install
+pnpm install --frozen-lockfile
 # Install Node.js dependencies for each subpackage
-(cd frontend && pnpm install)
+(cd frontend && pnpm install --frozen-lockfile)
 
 # Fetch Rust dependencies
 cargo fetch --manifest-path backend/Cargo.toml

--- a/generated/node/scripts/bootstrap
+++ b/generated/node/scripts/bootstrap
@@ -18,10 +18,22 @@ fi
 # Enable corepack so that pnpm version from package.json packageManager field is used
 corepack enable
 
+# Use --frozen-lockfile when a lockfile exists so a Renovate-bumped dep still
+# inside the pnpm-workspace.yaml minimumReleaseAge window does not re-trigger
+# the supply-chain policy check and block bootstrap. Fall back to plain
+# `pnpm install` on freshly generated projects without a lockfile yet.
+pnpm_install() {
+  if [ -f pnpm-lock.yaml ]; then
+    pnpm install --frozen-lockfile
+  else
+    pnpm install
+  fi
+}
+
 # Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
 if command -v lefthook > /dev/null 2>&1; then
   lefthook install
 fi
 
 # Install Node.js dependencies
-pnpm install --frozen-lockfile
+pnpm_install

--- a/generated/node/scripts/bootstrap
+++ b/generated/node/scripts/bootstrap
@@ -24,4 +24,4 @@ if command -v lefthook > /dev/null 2>&1; then
 fi
 
 # Install Node.js dependencies
-pnpm install
+pnpm install --frozen-lockfile

--- a/template/scripts/bootstrap.jinja
+++ b/template/scripts/bootstrap.jinja
@@ -18,6 +18,18 @@ fi
 
 # Enable corepack so that pnpm version from package.json packageManager field is used
 corepack enable
+
+# Use --frozen-lockfile when a lockfile exists so a Renovate-bumped dep still
+# inside the pnpm-workspace.yaml minimumReleaseAge window does not re-trigger
+# the supply-chain policy check and block bootstrap. Fall back to plain
+# `pnpm install` on freshly generated projects without a lockfile yet.
+pnpm_install() {
+  if [ -f pnpm-lock.yaml ]; then
+    pnpm install --frozen-lockfile
+  else
+    pnpm install
+  fi
+}
 {%- endif %}
 
 # Install git hooks via lefthook (hooks live in the common .git/hooks, shared across worktrees)
@@ -27,18 +39,18 @@ fi
 {%- if type == 'node' %}
 
 # Install Node.js dependencies
-pnpm install --frozen-lockfile
+pnpm_install
 {%- elif is_workspace %}
 
 # Install Node.js dependencies (workspace)
-pnpm install --frozen-lockfile
+pnpm_install
 {%- elif has_node and not is_workspace %}
 
 # Install shared dev tools (prettier, commitlint) at the repo root
-pnpm install --frozen-lockfile
+pnpm_install
 # Install Node.js dependencies for each subpackage
 {%- for pkg in node_pkgs %}
-(cd {{ pkg.name }} && pnpm install --frozen-lockfile)
+(cd {{ pkg.name }} && pnpm_install)
 {%- endfor %}
 {%- endif %}
 {%- if type == 'rust' %}

--- a/template/scripts/bootstrap.jinja
+++ b/template/scripts/bootstrap.jinja
@@ -27,18 +27,18 @@ fi
 {%- if type == 'node' %}
 
 # Install Node.js dependencies
-pnpm install
+pnpm install --frozen-lockfile
 {%- elif is_workspace %}
 
 # Install Node.js dependencies (workspace)
-pnpm install
+pnpm install --frozen-lockfile
 {%- elif has_node and not is_workspace %}
 
 # Install shared dev tools (prettier, commitlint) at the repo root
-pnpm install
+pnpm install --frozen-lockfile
 # Install Node.js dependencies for each subpackage
 {%- for pkg in node_pkgs %}
-(cd {{ pkg.name }} && pnpm install)
+(cd {{ pkg.name }} && pnpm install --frozen-lockfile)
 {%- endfor %}
 {%- endif %}
 {%- if type == 'rust' %}


### PR DESCRIPTION
## Purpose

- For a few days after Renovate bumps an npm package in a derived repo, `scripts/bootstrap` (invoked by `a wm new`) fails its supply-chain policy check in `pnpm install`, blocking new worktree creation
    - Freshly bumped packages do not satisfy [`minimumReleaseAge: 10080`](https://github.com/fohte/generic-boilerplate/blob/0698b09/template/pnpm-workspace.yaml.jinja) (7 days) in `pnpm-workspace.yaml` and `pnpm install` exits with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`
    - Hit recently in `fohte/blog-publisher` after an `@aws-sdk/*` update

## Approach

- Replace `pnpm install` with `pnpm install --frozen-lockfile` in `scripts/bootstrap` so node_modules is materialized from the already-reviewed lockfile without re-running the policy check
- Derived repos pick this up via the Renovate copier flow
