### PR TITLE
fix(template): exempt @fohte/* packages from minimumReleaseAge

### DIFF
--- a/generated/monorepo-node-workspace/pnpm-workspace.yaml
+++ b/generated/monorepo-node-workspace/pnpm-workspace.yaml
@@ -11,5 +11,6 @@ allowBuilds:
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
+# First-party scopes: publisher account is trusted, so skip the release-age delay.
 minimumReleaseAgeExclude:
   - '@fohte/*'

--- a/generated/monorepo-node-workspace/pnpm-workspace.yaml
+++ b/generated/monorepo-node-workspace/pnpm-workspace.yaml
@@ -11,4 +11,5 @@ allowBuilds:
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: []
+minimumReleaseAgeExclude:
+  - '@fohte/*'

--- a/generated/monorepo/frontend/pnpm-workspace.yaml
+++ b/generated/monorepo/frontend/pnpm-workspace.yaml
@@ -7,5 +7,6 @@ allowBuilds:
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
+# First-party scopes: publisher account is trusted, so skip the release-age delay.
 minimumReleaseAgeExclude:
   - '@fohte/*'

--- a/generated/monorepo/frontend/pnpm-workspace.yaml
+++ b/generated/monorepo/frontend/pnpm-workspace.yaml
@@ -7,4 +7,5 @@ allowBuilds:
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: []
+minimumReleaseAgeExclude:
+  - '@fohte/*'

--- a/generated/node/pnpm-workspace.yaml
+++ b/generated/node/pnpm-workspace.yaml
@@ -7,5 +7,6 @@ allowBuilds:
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
+# First-party scopes: publisher account is trusted, so skip the release-age delay.
 minimumReleaseAgeExclude:
   - '@fohte/*'

--- a/generated/node/pnpm-workspace.yaml
+++ b/generated/node/pnpm-workspace.yaml
@@ -7,4 +7,5 @@ allowBuilds:
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: []
+minimumReleaseAgeExclude:
+  - '@fohte/*'

--- a/template/pnpm-workspace.yaml.jinja
+++ b/template/pnpm-workspace.yaml.jinja
@@ -14,4 +14,5 @@ allowBuilds:
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: []
+minimumReleaseAgeExclude:
+  - '@fohte/*'

--- a/template/pnpm-workspace.yaml.jinja
+++ b/template/pnpm-workspace.yaml.jinja
@@ -14,5 +14,6 @@ allowBuilds:
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
+# First-party scopes: publisher account is trusted, so skip the release-age delay.
 minimumReleaseAgeExclude:
   - '@fohte/*'

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and not (monorepo_node_workspace | default(false)) %}pnpm-workspace.yaml{% endif %}
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and not (monorepo_node_workspace | default(false)) %}pnpm-workspace.yaml{% endif %}
@@ -7,5 +7,6 @@ allowBuilds:
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
+# First-party scopes: publisher account is trusted, so skip the release-age delay.
 minimumReleaseAgeExclude:
   - '@fohte/*'

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and not (monorepo_node_workspace | default(false)) %}pnpm-workspace.yaml{% endif %}
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and not (monorepo_node_workspace | default(false)) %}pnpm-workspace.yaml{% endif %}
@@ -7,4 +7,5 @@ allowBuilds:
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: []
+minimumReleaseAgeExclude:
+  - '@fohte/*'


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/generic-boilerplate/pull/395
- Install first-party packages immediately after release in our own repositories

## Approach

- Exclude `@fohte/*` via pnpm's `minimumReleaseAgeExclude` so first-party releases are installable right after publish
