### PR TITLE
feat(template): add bootstrap workflow to generate lockfiles on first push

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -58,6 +58,8 @@ _exclude:
   - "{% if not is_workspace and type != 'node' %}/pnpm-workspace.yaml{% endif %}"
   # Exclude CLAUDE.md when there is no test code (no Rust and no Node)
   - '{% if not has_rust and not has_node %}/CLAUDE.md{% endif %}'
+  # Exclude bootstrap workflow when no lockfile-producing language is involved
+  - '{% if not has_node and not has_rust %}.github/workflows/bootstrap.yml{% endif %}'
   # Exclude Rust specific files when type is not 'rust'
   - "{% if type != 'rust' %}/Cargo.toml{% endif %}"
   - "{% if type != 'rust' %}/rust-toolchain.toml{% endif %}"

--- a/copier.yml
+++ b/copier.yml
@@ -2,6 +2,14 @@ _min_copier_version: '9.5.0'
 _subdirectory: template
 _answers_file: .copier-answers.yml
 
+# Drop the bootstrap workflow when the destination already has lockfiles
+# (existing repos updating via copier — they would otherwise gain a stray
+# self-removal commit on the next push).
+_tasks:
+  - >-
+    sh -c 'if [ -f pnpm-lock.yaml ] || [ -f Cargo.lock ]; then rm -f
+    .github/workflows/bootstrap.yml; fi'
+
 type:
   type: str
   choices:

--- a/generated/monorepo-node-workspace/.github/workflows/bootstrap.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/bootstrap.yml
@@ -18,8 +18,6 @@ permissions:
 jobs:
   bootstrap:
     runs-on: ubuntu-latest
-    # Defensive guard against an infinite loop if GitHub re-evaluates this
-    # workflow at the self-removal commit's new ref.
     if: "github.event.head_commit.message != 'chore: bootstrap lockfiles'"
 
     steps:
@@ -53,7 +51,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git rm .github/workflows/bootstrap.yml
-          git add -A
+          if [ -f pnpm-lock.yaml ]; then git add pnpm-lock.yaml; fi
           if git diff --cached --quiet; then
             echo "Nothing to commit"
             exit 0

--- a/generated/monorepo-node-workspace/.github/workflows/bootstrap.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/bootstrap.yml
@@ -1,0 +1,62 @@
+name: Bootstrap
+
+# Generates lockfiles on the first push after the repository is initialized
+# from the template, then deletes itself so it never runs again.
+
+on:
+  push:
+    # Branch-only to avoid running on tag pushes; the self-removal step's
+    # `git push HEAD:<ref>` is not designed for refs/tags.
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    # Defensive guard against an infinite loop if GitHub re-evaluates this
+    # workflow at the self-removal commit's new ref.
+    if: "github.event.head_commit.message != 'chore: bootstrap lockfiles'"
+
+    steps:
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: fohte
+          identity: ${{ github.event.repository.name }}
+          domain: octo-sts.fohte.net
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Check whether any lockfile is missing
+        id: check
+        run: |
+          missing=false
+          if [ ! -f pnpm-lock.yaml ]; then missing=true; fi
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
+
+      - if: steps.check.outputs.missing == 'true'
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Generate lockfiles
+        if: steps.check.outputs.missing == 'true'
+        run: scripts/bootstrap
+
+      - name: Self-remove and commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm .github/workflows/bootstrap.yml
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore: bootstrap lockfiles"
+          git push origin "HEAD:${GITHUB_REF#refs/heads/}"

--- a/generated/monorepo/.github/workflows/bootstrap.yml
+++ b/generated/monorepo/.github/workflows/bootstrap.yml
@@ -18,8 +18,6 @@ permissions:
 jobs:
   bootstrap:
     runs-on: ubuntu-latest
-    # Defensive guard against an infinite loop if GitHub re-evaluates this
-    # workflow at the self-removal commit's new ref.
     if: "github.event.head_commit.message != 'chore: bootstrap lockfiles'"
     env:
       SCCACHE_GHA_ENABLED: 'true'
@@ -66,7 +64,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git rm .github/workflows/bootstrap.yml
-          git add -A
+          if [ -f pnpm-lock.yaml ]; then git add pnpm-lock.yaml; fi
+          if [ -f frontend/pnpm-lock.yaml ]; then git add frontend/pnpm-lock.yaml; fi
+          if [ -f backend/Cargo.lock ]; then git add backend/Cargo.lock; fi
           if git diff --cached --quiet; then
             echo "Nothing to commit"
             exit 0

--- a/generated/monorepo/.github/workflows/bootstrap.yml
+++ b/generated/monorepo/.github/workflows/bootstrap.yml
@@ -1,0 +1,75 @@
+name: Bootstrap
+
+# Generates lockfiles on the first push after the repository is initialized
+# from the template, then deletes itself so it never runs again.
+
+on:
+  push:
+    # Branch-only to avoid running on tag pushes; the self-removal step's
+    # `git push HEAD:<ref>` is not designed for refs/tags.
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    # Defensive guard against an infinite loop if GitHub re-evaluates this
+    # workflow at the self-removal commit's new ref.
+    if: "github.event.head_commit.message != 'chore: bootstrap lockfiles'"
+    env:
+      SCCACHE_GHA_ENABLED: 'true'
+      RUSTC_WRAPPER: 'sccache'
+
+    steps:
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: fohte
+          identity: ${{ github.event.repository.name }}
+          domain: octo-sts.fohte.net
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Check whether any lockfile is missing
+        id: check
+        run: |
+          missing=false
+          if [ ! -f pnpm-lock.yaml ]; then missing=true; fi
+          if [ ! -f frontend/pnpm-lock.yaml ]; then missing=true; fi
+          if [ ! -f backend/Cargo.lock ]; then missing=true; fi
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
+
+      # Run rustup before mise-action to prevent race condition.
+      - if: steps.check.outputs.missing == 'true'
+        run: rustup show
+
+      - name: Run sccache-cache
+        if: steps.check.outputs.missing == 'true'
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - if: steps.check.outputs.missing == 'true'
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Generate lockfiles
+        if: steps.check.outputs.missing == 'true'
+        run: scripts/bootstrap
+
+      - name: Self-remove and commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm .github/workflows/bootstrap.yml
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore: bootstrap lockfiles"
+          git push origin "HEAD:${GITHUB_REF#refs/heads/}"

--- a/generated/node/.github/workflows/bootstrap.yml
+++ b/generated/node/.github/workflows/bootstrap.yml
@@ -18,8 +18,6 @@ permissions:
 jobs:
   bootstrap:
     runs-on: ubuntu-latest
-    # Defensive guard against an infinite loop if GitHub re-evaluates this
-    # workflow at the self-removal commit's new ref.
     if: "github.event.head_commit.message != 'chore: bootstrap lockfiles'"
 
     steps:
@@ -53,7 +51,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git rm .github/workflows/bootstrap.yml
-          git add -A
+          if [ -f pnpm-lock.yaml ]; then git add pnpm-lock.yaml; fi
           if git diff --cached --quiet; then
             echo "Nothing to commit"
             exit 0

--- a/generated/node/.github/workflows/bootstrap.yml
+++ b/generated/node/.github/workflows/bootstrap.yml
@@ -1,0 +1,62 @@
+name: Bootstrap
+
+# Generates lockfiles on the first push after the repository is initialized
+# from the template, then deletes itself so it never runs again.
+
+on:
+  push:
+    # Branch-only to avoid running on tag pushes; the self-removal step's
+    # `git push HEAD:<ref>` is not designed for refs/tags.
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    # Defensive guard against an infinite loop if GitHub re-evaluates this
+    # workflow at the self-removal commit's new ref.
+    if: "github.event.head_commit.message != 'chore: bootstrap lockfiles'"
+
+    steps:
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: fohte
+          identity: ${{ github.event.repository.name }}
+          domain: octo-sts.fohte.net
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Check whether any lockfile is missing
+        id: check
+        run: |
+          missing=false
+          if [ ! -f pnpm-lock.yaml ]; then missing=true; fi
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
+
+      - if: steps.check.outputs.missing == 'true'
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Generate lockfiles
+        if: steps.check.outputs.missing == 'true'
+        run: scripts/bootstrap
+
+      - name: Self-remove and commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm .github/workflows/bootstrap.yml
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore: bootstrap lockfiles"
+          git push origin "HEAD:${GITHUB_REF#refs/heads/}"

--- a/generated/rust-release/.github/workflows/bootstrap.yml
+++ b/generated/rust-release/.github/workflows/bootstrap.yml
@@ -18,8 +18,6 @@ permissions:
 jobs:
   bootstrap:
     runs-on: ubuntu-latest
-    # Defensive guard against an infinite loop if GitHub re-evaluates this
-    # workflow at the self-removal commit's new ref.
     if: "github.event.head_commit.message != 'chore: bootstrap lockfiles'"
     env:
       SCCACHE_GHA_ENABLED: 'true'
@@ -64,7 +62,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git rm .github/workflows/bootstrap.yml
-          git add -A
+          if [ -f Cargo.lock ]; then git add Cargo.lock; fi
           if git diff --cached --quiet; then
             echo "Nothing to commit"
             exit 0

--- a/generated/rust-release/.github/workflows/bootstrap.yml
+++ b/generated/rust-release/.github/workflows/bootstrap.yml
@@ -1,0 +1,73 @@
+name: Bootstrap
+
+# Generates lockfiles on the first push after the repository is initialized
+# from the template, then deletes itself so it never runs again.
+
+on:
+  push:
+    # Branch-only to avoid running on tag pushes; the self-removal step's
+    # `git push HEAD:<ref>` is not designed for refs/tags.
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    # Defensive guard against an infinite loop if GitHub re-evaluates this
+    # workflow at the self-removal commit's new ref.
+    if: "github.event.head_commit.message != 'chore: bootstrap lockfiles'"
+    env:
+      SCCACHE_GHA_ENABLED: 'true'
+      RUSTC_WRAPPER: 'sccache'
+
+    steps:
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: fohte
+          identity: ${{ github.event.repository.name }}
+          domain: octo-sts.fohte.net
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Check whether any lockfile is missing
+        id: check
+        run: |
+          missing=false
+          if [ ! -f Cargo.lock ]; then missing=true; fi
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
+
+      # Run rustup before mise-action to prevent race condition.
+      - if: steps.check.outputs.missing == 'true'
+        run: rustup show
+
+      - name: Run sccache-cache
+        if: steps.check.outputs.missing == 'true'
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - if: steps.check.outputs.missing == 'true'
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Generate lockfiles
+        if: steps.check.outputs.missing == 'true'
+        run: scripts/bootstrap
+
+      - name: Self-remove and commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm .github/workflows/bootstrap.yml
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore: bootstrap lockfiles"
+          git push origin "HEAD:${GITHUB_REF#refs/heads/}"

--- a/generated/rust-with-node-subpackage/.github/workflows/bootstrap.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/bootstrap.yml
@@ -18,8 +18,6 @@ permissions:
 jobs:
   bootstrap:
     runs-on: ubuntu-latest
-    # Defensive guard against an infinite loop if GitHub re-evaluates this
-    # workflow at the self-removal commit's new ref.
     if: "github.event.head_commit.message != 'chore: bootstrap lockfiles'"
     env:
       SCCACHE_GHA_ENABLED: 'true'
@@ -66,7 +64,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git rm .github/workflows/bootstrap.yml
-          git add -A
+          if [ -f pnpm-lock.yaml ]; then git add pnpm-lock.yaml; fi
+          if [ -f docs/pnpm-lock.yaml ]; then git add docs/pnpm-lock.yaml; fi
+          if [ -f Cargo.lock ]; then git add Cargo.lock; fi
           if git diff --cached --quiet; then
             echo "Nothing to commit"
             exit 0

--- a/generated/rust-with-node-subpackage/.github/workflows/bootstrap.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/bootstrap.yml
@@ -1,0 +1,75 @@
+name: Bootstrap
+
+# Generates lockfiles on the first push after the repository is initialized
+# from the template, then deletes itself so it never runs again.
+
+on:
+  push:
+    # Branch-only to avoid running on tag pushes; the self-removal step's
+    # `git push HEAD:<ref>` is not designed for refs/tags.
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    # Defensive guard against an infinite loop if GitHub re-evaluates this
+    # workflow at the self-removal commit's new ref.
+    if: "github.event.head_commit.message != 'chore: bootstrap lockfiles'"
+    env:
+      SCCACHE_GHA_ENABLED: 'true'
+      RUSTC_WRAPPER: 'sccache'
+
+    steps:
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: fohte
+          identity: ${{ github.event.repository.name }}
+          domain: octo-sts.fohte.net
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Check whether any lockfile is missing
+        id: check
+        run: |
+          missing=false
+          if [ ! -f pnpm-lock.yaml ]; then missing=true; fi
+          if [ ! -f docs/pnpm-lock.yaml ]; then missing=true; fi
+          if [ ! -f Cargo.lock ]; then missing=true; fi
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
+
+      # Run rustup before mise-action to prevent race condition.
+      - if: steps.check.outputs.missing == 'true'
+        run: rustup show
+
+      - name: Run sccache-cache
+        if: steps.check.outputs.missing == 'true'
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - if: steps.check.outputs.missing == 'true'
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Generate lockfiles
+        if: steps.check.outputs.missing == 'true'
+        run: scripts/bootstrap
+
+      - name: Self-remove and commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm .github/workflows/bootstrap.yml
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore: bootstrap lockfiles"
+          git push origin "HEAD:${GITHUB_REF#refs/heads/}"

--- a/generated/rust/.github/workflows/bootstrap.yml
+++ b/generated/rust/.github/workflows/bootstrap.yml
@@ -18,8 +18,6 @@ permissions:
 jobs:
   bootstrap:
     runs-on: ubuntu-latest
-    # Defensive guard against an infinite loop if GitHub re-evaluates this
-    # workflow at the self-removal commit's new ref.
     if: "github.event.head_commit.message != 'chore: bootstrap lockfiles'"
     env:
       SCCACHE_GHA_ENABLED: 'true'
@@ -64,7 +62,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git rm .github/workflows/bootstrap.yml
-          git add -A
+          if [ -f Cargo.lock ]; then git add Cargo.lock; fi
           if git diff --cached --quiet; then
             echo "Nothing to commit"
             exit 0

--- a/generated/rust/.github/workflows/bootstrap.yml
+++ b/generated/rust/.github/workflows/bootstrap.yml
@@ -1,0 +1,73 @@
+name: Bootstrap
+
+# Generates lockfiles on the first push after the repository is initialized
+# from the template, then deletes itself so it never runs again.
+
+on:
+  push:
+    # Branch-only to avoid running on tag pushes; the self-removal step's
+    # `git push HEAD:<ref>` is not designed for refs/tags.
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    # Defensive guard against an infinite loop if GitHub re-evaluates this
+    # workflow at the self-removal commit's new ref.
+    if: "github.event.head_commit.message != 'chore: bootstrap lockfiles'"
+    env:
+      SCCACHE_GHA_ENABLED: 'true'
+      RUSTC_WRAPPER: 'sccache'
+
+    steps:
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: fohte
+          identity: ${{ github.event.repository.name }}
+          domain: octo-sts.fohte.net
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Check whether any lockfile is missing
+        id: check
+        run: |
+          missing=false
+          if [ ! -f Cargo.lock ]; then missing=true; fi
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
+
+      # Run rustup before mise-action to prevent race condition.
+      - if: steps.check.outputs.missing == 'true'
+        run: rustup show
+
+      - name: Run sccache-cache
+        if: steps.check.outputs.missing == 'true'
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - if: steps.check.outputs.missing == 'true'
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Generate lockfiles
+        if: steps.check.outputs.missing == 'true'
+        run: scripts/bootstrap
+
+      - name: Self-remove and commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm .github/workflows/bootstrap.yml
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore: bootstrap lockfiles"
+          git push origin "HEAD:${GITHUB_REF#refs/heads/}"

--- a/template/.github/workflows/bootstrap.yml.jinja
+++ b/template/.github/workflows/bootstrap.yml.jinja
@@ -1,0 +1,91 @@
+{%- set bootstrap_commit_msg = 'chore: bootstrap lockfiles' -%}
+name: Bootstrap
+
+# Generates lockfiles on the first push after the repository is initialized
+# from the template, then deletes itself so it never runs again.
+
+on:
+  push:
+    # Branch-only to avoid running on tag pushes; the self-removal step's
+    # `git push HEAD:<ref>` is not designed for refs/tags.
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    # Defensive guard against an infinite loop if GitHub re-evaluates this
+    # workflow at the self-removal commit's new ref.
+    if: "github.event.head_commit.message != '{{ bootstrap_commit_msg }}'"
+{%- if has_rust %}
+    env:
+      SCCACHE_GHA_ENABLED: 'true'
+      RUSTC_WRAPPER: 'sccache'
+{%- endif %}
+
+    steps:
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: fohte
+          identity: {% raw %}${{ github.event.repository.name }}{% endraw %}
+          domain: octo-sts.fohte.net
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: {% raw %}${{ steps.octo-sts.outputs.token }}{% endraw %}
+
+      - name: Check whether any lockfile is missing
+        id: check
+        run: |
+          missing=false
+{%- if has_node %}
+          if [ ! -f pnpm-lock.yaml ]; then missing=true; fi
+{%- if not is_workspace and type != 'node' %}
+{%- for pkg in node_pkgs %}
+          if [ ! -f {{ pkg.name }}/pnpm-lock.yaml ]; then missing=true; fi
+{%- endfor %}
+{%- endif %}
+{%- endif %}
+{%- if type == 'rust' %}
+          if [ ! -f Cargo.lock ]; then missing=true; fi
+{%- endif %}
+{%- for pkg in rust_pkgs %}
+          if [ ! -f {{ pkg.name }}/Cargo.lock ]; then missing=true; fi
+{%- endfor %}
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
+{%- if has_rust %}
+
+      # Run rustup before mise-action to prevent race condition.
+      - if: steps.check.outputs.missing == 'true'
+        run: rustup show
+
+      - name: Run sccache-cache
+        if: steps.check.outputs.missing == 'true'
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+{%- endif %}
+
+      - if: steps.check.outputs.missing == 'true'
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Generate lockfiles
+        if: steps.check.outputs.missing == 'true'
+        run: scripts/bootstrap
+
+      - name: Self-remove and commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm .github/workflows/bootstrap.yml
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to commit"
+            exit 0
+          fi
+          git commit -m "{{ bootstrap_commit_msg }}"
+          git push origin "HEAD:{% raw %}${GITHUB_REF#refs/heads/}{% endraw %}"

--- a/template/.github/workflows/bootstrap.yml.jinja
+++ b/template/.github/workflows/bootstrap.yml.jinja
@@ -19,8 +19,6 @@ permissions:
 jobs:
   bootstrap:
     runs-on: ubuntu-latest
-    # Defensive guard against an infinite loop if GitHub re-evaluates this
-    # workflow at the self-removal commit's new ref.
     if: "github.event.head_commit.message != '{{ bootstrap_commit_msg }}'"
 {%- if has_rust %}
     env:
@@ -82,7 +80,20 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git rm .github/workflows/bootstrap.yml
-          git add -A
+{%- if has_node %}
+          if [ -f pnpm-lock.yaml ]; then git add pnpm-lock.yaml; fi
+{%- if not is_workspace and type != 'node' %}
+{%- for pkg in node_pkgs %}
+          if [ -f {{ pkg.name }}/pnpm-lock.yaml ]; then git add {{ pkg.name }}/pnpm-lock.yaml; fi
+{%- endfor %}
+{%- endif %}
+{%- endif %}
+{%- if type == 'rust' %}
+          if [ -f Cargo.lock ]; then git add Cargo.lock; fi
+{%- endif %}
+{%- for pkg in rust_pkgs %}
+          if [ -f {{ pkg.name }}/Cargo.lock ]; then git add {{ pkg.name }}/Cargo.lock; fi
+{%- endfor %}
           if git diff --cached --quiet; then
             echo "Nothing to commit"
             exit 0


### PR DESCRIPTION
## Purpose

- The first push of a repository generated from this copier template always fails CI on `pnpm install --frozen-lockfile` / `cargo fetch --locked`
    - Example: [first CI failure in fohte/github-event-hub](https://github.com/fohte/github-event-hub/actions/runs/27208774928/job/80331703374) (`[ERR_PNPM_NO_LOCKFILE] Cannot install with "frozen-lockfile"`)

## Approach

- Add a self-removing workflow that generates lockfiles on the first push and deletes itself with `git rm` in the same commit
- Skip the workflow for template configurations that include neither Node nor Rust

<details>
<summary>Design decisions</summary>

#### Where lockfiles get generated

| Decision | Design                                            | Pros                                                       | Cons                                                                                       |
| -------- | ------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| Chosen   | Self-removing workflow on the template side       | Per-language runtime stays inside the GitHub Actions runner | Adds one workflow to the template                                                          |
| Rejected | Run `pnpm install` inside the infra runner        | No template-side change                                    | Forces Node/pnpm into the infra runner, inflating it even for Rust-only repos              |
| Rejected | Fall back to non-frozen install in `test.yml`     | No new workflow                                            | Loses the `--frozen-lockfile` guarantee                                                    |

</details>
