### PR TITLE
chore(scripts): support rebasing stale Renovate boilerplate PRs

### DIFF
--- a/.claude/skills/update-boilerplate-prs/SKILL.md
+++ b/.claude/skills/update-boilerplate-prs/SKILL.md
@@ -54,25 +54,28 @@ scripts/list-boilerplate-usage --outdated
 
 The output shows each repository's current version, latest version, and whether a Renovate PR exists.
 
-- `renovate PR: #<number> <url>` present -> proceed to Step 4
-- `renovate PR: (none)` -> proceed to Step 3 to trigger PR creation
+- `renovate PR: (none)` -> Step 3 will trigger PR creation via the Dependency Dashboard
+- `renovate PR: #<number> <url>` -> Step 3 will rebase it via the PR's rebase-check box (re-triggers Renovate even if the PR already targets the latest `_commit`); proceed to Step 4 once `REBASED` is printed
 
-## Step 3: Trigger PR creation from Renovate Dashboard
+## Step 3: Trigger PR creation or rebase
 
-Repositories without a Renovate PR may be blocked by Renovate's rate limit (max concurrent PRs). Use the trigger script to check the Renovate Dependency Dashboard checkbox in each repository.
+The trigger script handles two cases per outdated repo:
+
+- No Renovate PR yet (rate-limited): checks the Dependency Dashboard checkbox so Renovate creates the PR.
+- Renovate PR already exists but is stale (e.g. opened against an older boilerplate version and never regenerated): checks the PR's rebase-check box so Renovate force-pushes a fresh branch against the latest version.
 
 ```bash
 # Dry-run first to verify targets
 scripts/trigger-renovate-boilerplate-prs --dry-run
 
-# Update Dashboard checkboxes and wait for PRs to be created (all repos)
+# Trigger create + rebase, then wait for results (all outdated repos)
 scripts/trigger-renovate-boilerplate-prs
 
 # Or target specific repos
 scripts/trigger-renovate-boilerplate-prs <repo1> <repo2>
 ```
 
-The script updates all checkboxes, then polls every 30 seconds (up to 5 minutes) until Renovate creates the PRs, printing each PR URL as it appears.
+Each line is tagged `[create]` or `[rebase]`. The script polls every 30 seconds (up to 5 minutes), printing `CREATED <repo>: <url>` for new PRs and `REBASED <repo>: PR #<n>` once `headRefOid` changes.
 
 ## Step 4: Auto-merge version-only PRs
 

--- a/scripts/list-boilerplate-usage
+++ b/scripts/list-boilerplate-usage
@@ -140,17 +140,26 @@ echo "$result" | jq -c '
   if [[ -n "$pr_json" ]]; then
     pr_url=$(echo "$pr_json" | jq -r '.url')
     pr_number=$(echo "$pr_json" | jq -r '.number')
+    pr_title=$(echo "$pr_json" | jq -r '.title')
+    # Renovate titles look like `... Update generic-boilerplate to v0.8.2`,
+    # so the trailing version reflects which template release the PR targets.
+    pr_target_commit=$(printf '%s' "$pr_title" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+[^[:space:]]*$' || true)
     has_pr=true
   else
     pr_url=""
     pr_number=""
+    pr_target_commit=""
     has_pr=false
   fi
 
   if "$JSON_OUTPUT"; then
     pr_obj="null"
     if "$has_pr"; then
-      pr_obj=$(jq -n --arg url "$pr_url" --argjson number "$pr_number" '{number: $number, url: $url}')
+      pr_obj=$(jq -n \
+        --arg url "$pr_url" \
+        --argjson number "$pr_number" \
+        --arg target_commit "$pr_target_commit" \
+        '{number: $number, url: $url, target_commit: (if $target_commit == "" then null else $target_commit end)}')
     fi
     jq -n \
       --arg name "$name" \

--- a/scripts/trigger-renovate-boilerplate-prs
+++ b/scripts/trigger-renovate-boilerplate-prs
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
-# Trigger Renovate PR creation for outdated repos that are rate-limited.
-# Finds repos without a Renovate PR for generic-boilerplate updates,
-# then checks the corresponding checkbox on each repo's Dependency Dashboard issue.
-# After updating, waits for Renovate to create the PRs and prints their URLs.
+# Trigger Renovate PR creation or rebase for outdated repos.
+#
+# For each outdated repo found via list-boilerplate-usage:
+#   - If no Renovate PR exists (rate-limited): checks the Dependency Dashboard
+#     checkbox so Renovate creates the PR.
+#   - If a Renovate PR already exists: checks the rebase-check checkbox in the
+#     PR body so Renovate force-pushes a fresh branch.
+#
+# After triggering, waits for new PRs to appear and for existing PRs to be
+# rebased (headRefOid change), polling both in the same loop.
 #
 # Usage: scripts/trigger-renovate-boilerplate-prs [--dry-run] [REPO...]
 #
 # Options:
-#   --dry-run    Show what would be updated without actually editing issues
+#   --dry-run    Show what would be triggered without editing issues/PRs
 #
 # Arguments:
-#   REPO...      Specific repo names to process (default: all outdated repos without PRs)
+#   REPO...      Specific repo names to process (default: all outdated repos)
 #
 # Requires: gh, jq
 
@@ -38,68 +44,106 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Collect outdated repos without Renovate PRs
+# Collect outdated repos along with their current Renovate PR (if any).
+# Emit "<repo>\t<pr_number>" rows; pr_number is empty when no PR exists.
 jq_args=(--raw-output)
-jq_filter='.[] | select(.renovate_pr == null)'
+jq_filter='.[]'
 if [[ ${#FILTER_REPOS[@]} -gt 0 ]]; then
   repo_json=$(printf '%s\n' "${FILTER_REPOS[@]}" | jq -R . | jq -s .)
   jq_args+=(--argjson filter_repos "$repo_json")
   # shellcheck disable=SC2016
   jq_filter+=' | select(.repo as $r | $filter_repos | index($r))'
 fi
-jq_filter+=' | .repo'
+jq_filter+=' | [.repo, (.renovate_pr.number // "" | tostring)] | @tsv'
 
-mapfile -t repos < <(
+mapfile -t entries < <(
   "${SCRIPT_DIR}/list-boilerplate-usage" --outdated --json |
     jq "${jq_args[@]}" "$jq_filter"
 )
 
-if [[ ${#repos[@]} -eq 0 ]]; then
-  echo "No outdated repos without Renovate PRs found."
+if [[ ${#entries[@]} -eq 0 ]]; then
+  echo "No outdated repos found."
   exit 0
 fi
 
 # `branchNameStrict` normalizes dots in branch names to hyphens, so the
 # checkbox marker contains `https-github-com-...`.
 CHECKBOX_PATTERN='unlimit-branch=renovate/https-github-com-fohte-generic-boilerplate'
+REBASE_MARKER='<!-- rebase-check -->'
 
-updated_repos=()
+declare -a create_pending=()
+declare -a rebase_repos=()
+declare -a rebase_pr_numbers=()
+declare -a rebase_old_oids=()
 failed_repos=()
 
-for repo in "${repos[@]}"; do
-  # Find the Dependency Dashboard issue
-  issue_number=$(
-    gh issue list -R "fohte/$repo" --search "Dependency Dashboard" --json number,title |
-      jq -r '.[] | select(.title == "Dependency Dashboard") | .number' |
-      head -1
-  )
+for entry in "${entries[@]}"; do
+  IFS=$'\t' read -r repo pr_number <<< "$entry"
+  [[ -z "$repo" ]] && continue
 
-  if [[ -z "$issue_number" ]]; then
-    echo "SKIP $repo: no Dependency Dashboard issue found"
-    continue
-  fi
+  if [[ -z "$pr_number" ]]; then
+    # === Create mode: rate-limited, no PR yet ===
+    issue_number=$(
+      gh issue list -R "fohte/$repo" --search "Dependency Dashboard" --json number,title |
+        jq -r '.[] | select(.title == "Dependency Dashboard") | .number' |
+        head -1
+    )
 
-  # Get the issue body
-  body=$(gh issue view "$issue_number" -R "fohte/$repo" --json body -q .body)
-
-  # Check if there's a rate-limited generic-boilerplate checkbox
-  if ! printf '%s\n' "$body" | grep -qF -- "- [ ] <!-- ${CHECKBOX_PATTERN}"; then
-    echo "SKIP $repo: no rate-limited generic-boilerplate entry in Dashboard #$issue_number"
-    continue
-  fi
-
-  if "$DRY_RUN"; then
-    echo "WOULD UPDATE $repo: Dashboard #$issue_number"
-  else
-    updated_body="${body//- \[ \] <!-- ${CHECKBOX_PATTERN}/- [x] <!-- ${CHECKBOX_PATTERN}}"
-    if [[ "$updated_body" == "$body" ]]; then
-      echo "FAIL $repo: checkbox substitution produced no change (pattern drift?) in Dashboard #$issue_number" >&2
-      failed_repos+=("$repo")
+    if [[ -z "$issue_number" ]]; then
+      echo "SKIP $repo [create]: no Dependency Dashboard issue found"
       continue
     fi
-    gh issue edit "$issue_number" -R "fohte/$repo" --body "$updated_body"
-    echo "UPDATED $repo: Dashboard #$issue_number"
-    updated_repos+=("$repo")
+
+    body=$(gh issue view "$issue_number" -R "fohte/$repo" --json body -q .body)
+
+    if ! printf '%s\n' "$body" | grep -qF -- "- [ ] <!-- ${CHECKBOX_PATTERN}"; then
+      echo "SKIP $repo [create]: no rate-limited generic-boilerplate entry in Dashboard #$issue_number"
+      continue
+    fi
+
+    if "$DRY_RUN"; then
+      echo "WOULD CREATE $repo: check Dashboard #$issue_number"
+    else
+      updated_body="${body//- \[ \] <!-- ${CHECKBOX_PATTERN}/- [x] <!-- ${CHECKBOX_PATTERN}}"
+      if [[ "$updated_body" == "$body" ]]; then
+        echo "FAIL $repo [create]: checkbox substitution produced no change (pattern drift?) in Dashboard #$issue_number" >&2
+        failed_repos+=("$repo")
+        continue
+      fi
+      gh issue edit "$issue_number" -R "fohte/$repo" --body "$updated_body"
+      echo "TRIGGERED $repo [create]: Dashboard #$issue_number"
+      create_pending+=("$repo")
+    fi
+  else
+    # === Rebase mode: stale PR, force a fresh rebase via rebase-check box ===
+    pr_data=$(gh pr view "$pr_number" -R "fohte/$repo" --json body,headRefOid)
+    body=$(printf '%s' "$pr_data" | jq -r '.body')
+    old_oid=$(printf '%s' "$pr_data" | jq -r '.headRefOid')
+
+    if ! printf '%s\n' "$body" | grep -qF -- "- [ ] ${REBASE_MARKER}"; then
+      if printf '%s\n' "$body" | grep -qF -- "- [x] ${REBASE_MARKER}"; then
+        echo "SKIP $repo [rebase]: rebase checkbox already checked in PR #$pr_number"
+      else
+        echo "SKIP $repo [rebase]: no rebase checkbox found in PR #$pr_number"
+      fi
+      continue
+    fi
+
+    if "$DRY_RUN"; then
+      echo "WOULD REBASE $repo: check rebase box in PR #$pr_number"
+    else
+      updated_body="${body//- \[ \] ${REBASE_MARKER}/- [x] ${REBASE_MARKER}}"
+      if [[ "$updated_body" == "$body" ]]; then
+        echo "FAIL $repo [rebase]: rebase checkbox substitution produced no change in PR #$pr_number" >&2
+        failed_repos+=("$repo")
+        continue
+      fi
+      gh pr edit "$pr_number" -R "fohte/$repo" --body "$updated_body" > /dev/null
+      echo "TRIGGERED $repo [rebase]: PR #$pr_number (oid=${old_oid:0:7})"
+      rebase_repos+=("$repo")
+      rebase_pr_numbers+=("$pr_number")
+      rebase_old_oids+=("$old_oid")
+    fi
   fi
 done
 
@@ -108,20 +152,21 @@ if [[ ${#failed_repos[@]} -gt 0 ]]; then
   exit_code=1
 fi
 
-if "$DRY_RUN" || [[ ${#updated_repos[@]} -eq 0 ]]; then
+total_pending=$((${#create_pending[@]} + ${#rebase_repos[@]}))
+if "$DRY_RUN" || [[ $total_pending -eq 0 ]]; then
   exit "$exit_code"
 fi
 
-# Wait for Renovate to create PRs
 echo ""
-echo "Waiting for Renovate to create PRs (checking every 30s, up to 5 min)..."
+echo "Waiting for Renovate (checking every 30s, up to 5 min)..."
 
 max_attempts=10
 for ((attempt = 1; attempt <= max_attempts; attempt++)); do
   sleep 30
 
-  remaining=()
-  for repo in "${updated_repos[@]}"; do
+  # --- Poll create_pending: new PR has appeared ---
+  remaining_create=()
+  for repo in "${create_pending[@]}"; do
     pr_url=$(
       gh search prs --repo "fohte/$repo" "generic-boilerplate" --state open \
         --json url,title \
@@ -131,19 +176,49 @@ for ((attempt = 1; attempt <= max_attempts; attempt++)); do
     if [[ -n "$pr_url" ]]; then
       echo "CREATED $repo: $pr_url"
     else
-      remaining+=("$repo")
+      remaining_create+=("$repo")
     fi
   done
+  create_pending=("${remaining_create[@]}")
 
-  if [[ ${#remaining[@]} -eq 0 ]]; then
-    echo "All PRs created."
+  # --- Poll rebase_repos: headRefOid changed ---
+  remaining_rebase_repos=()
+  remaining_rebase_pr_numbers=()
+  remaining_rebase_old_oids=()
+  for i in "${!rebase_repos[@]}"; do
+    repo="${rebase_repos[$i]}"
+    pr_number="${rebase_pr_numbers[$i]}"
+    old_oid="${rebase_old_oids[$i]}"
+    new_oid=$(
+      gh pr view "$pr_number" -R "fohte/$repo" --json headRefOid \
+        --jq '.headRefOid' 2> /dev/null || true
+    )
+    if [[ -n "$new_oid" && "$new_oid" != "$old_oid" ]]; then
+      echo "REBASED $repo: PR #$pr_number (${old_oid:0:7} -> ${new_oid:0:7})"
+    else
+      remaining_rebase_repos+=("$repo")
+      remaining_rebase_pr_numbers+=("$pr_number")
+      remaining_rebase_old_oids+=("$old_oid")
+    fi
+  done
+  rebase_repos=("${remaining_rebase_repos[@]}")
+  rebase_pr_numbers=("${remaining_rebase_pr_numbers[@]}")
+  rebase_old_oids=("${remaining_rebase_old_oids[@]}")
+
+  remaining_total=$((${#create_pending[@]} + ${#rebase_repos[@]}))
+  if [[ $remaining_total -eq 0 ]]; then
+    echo "All triggers completed."
     exit "$exit_code"
   fi
 
-  updated_repos=("${remaining[@]}")
-  echo "  (${#remaining[@]} remaining, attempt $attempt/$max_attempts)"
+  echo "  ($remaining_total remaining: ${#create_pending[@]} create, ${#rebase_repos[@]} rebase; attempt $attempt/$max_attempts)"
 done
 
 echo ""
-echo "TIMEOUT: PRs not yet created for: ${updated_repos[*]}"
+if [[ ${#create_pending[@]} -gt 0 ]]; then
+  echo "TIMEOUT [create]: PRs not yet created for: ${create_pending[*]}"
+fi
+if [[ ${#rebase_repos[@]} -gt 0 ]]; then
+  echo "TIMEOUT [rebase]: PRs not yet rebased for: ${rebase_repos[*]}"
+fi
 exit 1

--- a/scripts/trigger-renovate-boilerplate-prs
+++ b/scripts/trigger-renovate-boilerplate-prs
@@ -82,7 +82,6 @@ for entry in "${entries[@]}"; do
   [[ -z "$repo" ]] && continue
 
   if [[ -z "$pr_number" ]]; then
-    # === Create mode: rate-limited, no PR yet ===
     issue_number=$(
       gh issue list -R "fohte/$repo" --search "Dependency Dashboard" --json number,title |
         jq -r '.[] | select(.title == "Dependency Dashboard") | .number' |
@@ -115,8 +114,11 @@ for entry in "${entries[@]}"; do
       create_pending+=("$repo")
     fi
   else
-    # === Rebase mode: stale PR, force a fresh rebase via rebase-check box ===
-    pr_data=$(gh pr view "$pr_number" -R "fohte/$repo" --json body,headRefOid)
+    pr_data=$(gh pr view "$pr_number" -R "fohte/$repo" --json body,headRefOid 2> /dev/null || true)
+    if [[ -z "$pr_data" ]]; then
+      echo "SKIP $repo [rebase]: PR #$pr_number no longer accessible"
+      continue
+    fi
     body=$(printf '%s' "$pr_data" | jq -r '.body')
     old_oid=$(printf '%s' "$pr_data" | jq -r '.headRefOid')
 
@@ -164,7 +166,6 @@ max_attempts=10
 for ((attempt = 1; attempt <= max_attempts; attempt++)); do
   sleep 30
 
-  # --- Poll create_pending: new PR has appeared ---
   remaining_create=()
   for repo in "${create_pending[@]}"; do
     pr_url=$(
@@ -181,7 +182,6 @@ for ((attempt = 1; attempt <= max_attempts; attempt++)); do
   done
   create_pending=("${remaining_create[@]}")
 
-  # --- Poll rebase_repos: headRefOid changed ---
   remaining_rebase_repos=()
   remaining_rebase_pr_numbers=()
   remaining_rebase_old_oids=()

--- a/scripts/trigger-renovate-boilerplate-prs
+++ b/scripts/trigger-renovate-boilerplate-prs
@@ -103,7 +103,7 @@ for entry in "${entries[@]}"; do
     if "$DRY_RUN"; then
       echo "WOULD CREATE $repo: check Dashboard #$issue_number"
     else
-      updated_body="${body//- \[ \] <!-- ${CHECKBOX_PATTERN}/- [x] <!-- ${CHECKBOX_PATTERN}}"
+      updated_body="${body//"- [ ] <!-- ${CHECKBOX_PATTERN}"/"- [x] <!-- ${CHECKBOX_PATTERN}"}"
       if [[ "$updated_body" == "$body" ]]; then
         echo "FAIL $repo [create]: checkbox substitution produced no change (pattern drift?) in Dashboard #$issue_number" >&2
         failed_repos+=("$repo")
@@ -134,7 +134,7 @@ for entry in "${entries[@]}"; do
     if "$DRY_RUN"; then
       echo "WOULD REBASE $repo: check rebase box in PR #$pr_number"
     else
-      updated_body="${body//- \[ \] ${REBASE_MARKER}/- [x] ${REBASE_MARKER}}"
+      updated_body="${body//"- [ ] ${REBASE_MARKER}"/"- [x] ${REBASE_MARKER}"}"
       if [[ "$updated_body" == "$body" ]]; then
         echo "FAIL $repo [rebase]: rebase checkbox substitution produced no change in PR #$pr_number" >&2
         failed_repos+=("$repo")

--- a/scripts/trigger-renovate-boilerplate-prs
+++ b/scripts/trigger-renovate-boilerplate-prs
@@ -54,7 +54,9 @@ if [[ ${#FILTER_REPOS[@]} -gt 0 ]]; then
   # shellcheck disable=SC2016
   jq_filter+=' | select(.repo as $r | $filter_repos | index($r))'
 fi
-jq_filter+=' | [.repo, (.renovate_pr.number // "" | tostring)] | @tsv'
+# bash `read` collapses consecutive whitespace IFS characters, so use "-" as a
+# sentinel for empty fields and restore them to "" after splitting.
+jq_filter+=' | [.repo, (.renovate_pr.number // "-" | tostring), (.renovate_pr.target_commit // "-"), .latest] | @tsv'
 
 mapfile -t entries < <(
   "${SCRIPT_DIR}/list-boilerplate-usage" --outdated --json |
@@ -78,7 +80,9 @@ declare -a rebase_old_oids=()
 failed_repos=()
 
 for entry in "${entries[@]}"; do
-  IFS=$'\t' read -r repo pr_number <<< "$entry"
+  IFS=$'\t' read -r repo pr_number pr_target_commit latest_commit <<< "$entry"
+  [[ "$pr_number" == "-" ]] && pr_number=""
+  [[ "$pr_target_commit" == "-" ]] && pr_target_commit=""
   [[ -z "$repo" ]] && continue
 
   if [[ -z "$pr_number" ]]; then
@@ -114,6 +118,10 @@ for entry in "${entries[@]}"; do
       create_pending+=("$repo")
     fi
   else
+    if [[ -n "$pr_target_commit" && "$pr_target_commit" == "$latest_commit" ]]; then
+      echo "SKIP $repo [rebase]: PR #$pr_number already targets $latest_commit (proceed to manual review)"
+      continue
+    fi
     pr_data=$(gh pr view "$pr_number" -R "fohte/$repo" --json body,headRefOid 2> /dev/null || true)
     if [[ -z "$pr_data" ]]; then
       echo "SKIP $repo [rebase]: PR #$pr_number no longer accessible"


### PR DESCRIPTION
## Purpose

- Renovate PRs opened against an older boilerplate version stay stale until time passes or someone manually rebases them, forcing Step 3 of `/update-boilerplate-prs` to tick the rebase-check box on each PR by hand

## Approach

- Extend `scripts/trigger-renovate-boilerplate-prs` to re-kick a rebase on the existing PR when one is already open
