### PR TITLE
fix(copier): skip unused setup for `tests: false` subpackages

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -145,10 +145,12 @@ subpackages:
     Example: [{name: frontend, type: node}, {name: backend, type: rust}]
     Per-entry flags (optional):
       storybook: true  -- enable Storybook for a node subpackage
-      tests: false     -- skip test scaffolding (vitest, tsconfig, src/, eslint)
-                          and the unit-test CI job. Use for node subpackages
-                          that bring their own setup, such as docs sites
-                          (Astro, Starlight) or framework apps (Next.js).
+      tests: false     -- skip test scaffolding (vitest, tsconfig, src/, eslint),
+                          the unit-test CI job, the per-package eslint
+                          lefthook hook, and the pnpm install/cache step in
+                          the lefthook CI job. Use for node subpackages that
+                          bring their own setup, such as docs sites (Astro,
+                          Starlight) or framework apps (Next.js).
   # Set only via --data-file; not promptable (multiline YAML inputs).
   when: false
 

--- a/generated/rust-with-node-subpackage/.github/workflows/test.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/test.yml
@@ -67,15 +67,11 @@ jobs:
           path: |
             ${{ steps.pnpm-store.outputs.path }}
             node_modules
-            docs/node_modules
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml', 'docs/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-
 
       - name: Install pnpm dependencies (root)
         run: pnpm install --frozen-lockfile
-
-      - name: Install pnpm dependencies (docs)
-        run: cd "docs" && pnpm install --frozen-lockfile
 
       - run: cargo fetch
 

--- a/generated/rust-with-node-subpackage/lefthook.yml
+++ b/generated/rust-with-node-subpackage/lefthook.yml
@@ -57,13 +57,6 @@ pre-commit:
           esac
         done
 
-    # Non-workspace multi-package monorepo: each subpackage has its own
-    # eslint.config.js and dependencies, so lint per package from its root.
-    eslint-docs:
-      glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
-      root: 'docs/'
-      run: pnpm exec eslint {staged_files}
-
     ast-grep:
       glob: '*.rs'
       run: ast-grep scan {staged_files}

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -94,6 +94,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
 {%- elif type == 'rust' %}
 {%- if has_node_pkg and not is_workspace %}
+{#- Subpackages with `tests: false` bring their own pnpm setup, so their
+    lockfile is intentionally excluded from the cache key and install step:
+    a lockfile change there must not invalidate this job's cache, and the
+    boilerplate must not install their deps. #}
 
       - run: corepack enable
 
@@ -107,15 +111,15 @@ jobs:
           path: |
             {% raw %}${{ steps.pnpm-store.outputs.path }}{% endraw %}
             node_modules
-{%- for pkg in node_pkgs %}
+{%- for pkg in node_pkgs if pkg.tests | default(true) %}
             {{ pkg.name }}/node_modules
 {%- endfor %}
-          key: {% raw %}${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml', {% endraw %}{% for pkg in node_pkgs %}'{{ pkg.name }}/pnpm-lock.yaml'{{ ', ' if not loop.last else '' }}{% endfor %}{% raw %}) }}{% endraw %}
+          key: {% raw %}${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml'{% endraw %}{% for pkg in node_pkgs if pkg.tests | default(true) %}, '{{ pkg.name }}/pnpm-lock.yaml'{% endfor %}{% raw %}) }}{% endraw %}
           restore-keys: {% raw %}${{ runner.os }}-pnpm-{% endraw %}
 
       - name: Install pnpm dependencies (root)
         run: pnpm install --frozen-lockfile
-{%- for pkg in node_pkgs %}
+{%- for pkg in node_pkgs if pkg.tests | default(true) %}
 
       - name: Install pnpm dependencies ({{ pkg.name }})
         run: cd "{{ pkg.name }}" && pnpm install --frozen-lockfile
@@ -148,7 +152,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 {%- else %}
-{#- Non-workspace mode: root install for shared tools + per-package install #}
+{#- Non-workspace mode: root install for shared tools + per-package install.
+    Subpackages with `tests: false` bring their own pnpm setup, so their
+    lockfile is intentionally excluded from the cache key and install step. #}
 
       - run: corepack enable
 
@@ -162,15 +168,15 @@ jobs:
           path: |
             {% raw %}${{ steps.pnpm-store.outputs.path }}{% endraw %}
             node_modules
-{%- for pkg in node_pkgs %}
+{%- for pkg in node_pkgs if pkg.tests | default(true) %}
             {{ pkg.name }}/node_modules
 {%- endfor %}
-          key: {% raw %}${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml', {% endraw %}{% for pkg in node_pkgs %}'{{ pkg.name }}/pnpm-lock.yaml'{{ ', ' if not loop.last else '' }}{% endfor %}{% raw %}) }}{% endraw %}
+          key: {% raw %}${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml'{% endraw %}{% for pkg in node_pkgs if pkg.tests | default(true) %}, '{{ pkg.name }}/pnpm-lock.yaml'{% endfor %}{% raw %}) }}{% endraw %}
           restore-keys: {% raw %}${{ runner.os }}-pnpm-{% endraw %}
 
       - name: Install pnpm dependencies (root)
         run: pnpm install --frozen-lockfile
-{%- for pkg in node_pkgs %}
+{%- for pkg in node_pkgs if pkg.tests | default(true) %}
 
       - name: Install pnpm dependencies ({{ pkg.name }})
         run: cd "{{ pkg.name }}" && pnpm install --frozen-lockfile

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -95,9 +95,7 @@ jobs:
 {%- elif type == 'rust' %}
 {%- if has_node_pkg and not is_workspace %}
 {#- Subpackages with `tests: false` bring their own pnpm setup, so their
-    lockfile is intentionally excluded from the cache key and install step:
-    a lockfile change there must not invalidate this job's cache, and the
-    boilerplate must not install their deps. #}
+    lockfile is excluded from the cache key and install step. #}
 
       - run: corepack enable
 

--- a/template/lefthook.yml.jinja
+++ b/template/lefthook.yml.jinja
@@ -72,7 +72,9 @@ pre-commit:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
       run: pnpm exec eslint {staged_files}
 {%- elif has_node %}
-{%- for pkg in node_pkgs %}
+{#- Subpackages with `tests: false` bring their own setup and have no
+    generated eslint config, so they're skipped here. -#}
+{%- for pkg in node_pkgs if pkg.tests | default(true) %}
 
     # Non-workspace multi-package monorepo: each subpackage has its own
     # eslint.config.js and dependencies, so lint per package from its root.


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/runok/pull/420
- Repositories that adopt this template with a `tests: false` node subpackage must hand-patch the generated `lefthook.yml` and `.github/workflows/test.yml` after every `copier update` to keep pre-commit and CI green
    - The subpackage brings its own framework setup and has no eslint config, but the generated pre-commit hook runs `pnpm exec eslint` and fails with `command not found`
    - The lefthook CI job installs and caches `node_modules` for the subpackage on every run even though nothing in this job uses them

## Approach

- For `tests: false` node subpackages, stop emitting the per-package eslint lefthook hook and the pnpm install/cache step in the lefthook CI job
