### PR TITLE
fix(copier): restore subpackages prompt to preserve answers on update

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -136,6 +136,12 @@ binary_name:
 # When non-empty, infrastructure files (test.yml, lefthook, renovate, etc.)
 # are generated in monorepo mode.
 # Input via --data-file is recommended for this parameter.
+#
+# Do NOT set `when: false`: copier discards the stored answer for hidden
+# questions (see copier _main.py question loop), which would erase subpackage
+# files on every `copier update` for existing monorepo consumers. Keeping the
+# question askable lets `--skip-answered` preserve the stored list, while
+# `--defaults` (used by Renovate) falls back to `[]` without prompting.
 subpackages:
   type: yaml
   multiline: true
@@ -149,8 +155,6 @@ subpackages:
                           and the unit-test CI job. Use for node subpackages
                           that bring their own setup, such as docs sites
                           (Astro, Starlight) or framework apps (Next.js).
-  # Set only via --data-file; not promptable (multiline YAML inputs).
-  when: false
 
 monorepo_node_workspace:
   type: bool

--- a/copier.yml
+++ b/copier.yml
@@ -136,12 +136,6 @@ binary_name:
 # When non-empty, infrastructure files (test.yml, lefthook, renovate, etc.)
 # are generated in monorepo mode.
 # Input via --data-file is recommended for this parameter.
-#
-# Do NOT set `when: false`: copier discards the stored answer for hidden
-# questions (see copier _main.py question loop), which would erase subpackage
-# files on every `copier update` for existing monorepo consumers. Keeping the
-# question askable lets `--skip-answered` preserve the stored list, while
-# `--defaults` (used by Renovate) falls back to `[]` without prompting.
 subpackages:
   type: yaml
   multiline: true
@@ -157,6 +151,9 @@ subpackages:
                           the lefthook CI job. Use for node subpackages that
                           bring their own setup, such as docs sites (Astro,
                           Starlight) or framework apps (Next.js).
+  # `when: true` is the default but explicit here: hidden questions (when: false)
+  # discard the stored answer, which would erase subpackages on every update.
+  when: true
 
 monorepo_node_workspace:
   type: bool

--- a/tests/fixtures/node.yml
+++ b/tests/fixtures/node.yml
@@ -8,3 +8,4 @@ is_public: false
 use_release_please: false
 use_storybook: true
 repo_language: ja
+subpackages: []

--- a/tests/fixtures/rust-release.yml
+++ b/tests/fixtures/rust-release.yml
@@ -10,3 +10,4 @@ use_coverage: true
 release_binary: true
 binary_name: rust-release
 repo_language: ja
+subpackages: []

--- a/tests/fixtures/rust.yml
+++ b/tests/fixtures/rust.yml
@@ -8,3 +8,4 @@ is_public: false
 use_release_please: false
 use_coverage: false
 repo_language: ja
+subpackages: []


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/contracts/pull/19
- Existing monorepo consumers (e.g. `fohte/contracts`) lose their subpackage directories, root `workspaces`, `CLAUDE.md`, and the `test.yml` matrix on every `copier update`
- Renovate's auto-generated copier update PRs always carry a destructive diff and cannot be merged without manual fixups

### Reproduction steps

1. Render v0.8.0 with `subpackages: [{name: foo, type: node}]` and commit
2. Run `copier update --trust --defaults --skip-answered` against the v0.8.2 template
3. `foo/`, root `package.json`'s `workspaces`, `CLAUDE.md`, and the node matrix in `.github/workflows/test.yml` get deleted

## Approach

- Drop `when: false` from `subpackages` so the question stays askable
    - copier discards the stored answer for hidden questions before reading it, so the stored list was always overwritten with `default: []`
- Under Renovate's `--defaults --skip-answered`, a missing stored answer still falls back to `[]`, and an existing one is preserved
- Set `subpackages: []` explicitly in `tests/fixtures/{node,rust,rust-release}.yml` so snapshot generation does not stall on a non-TTY prompt

<details>
<summary>Design decisions</summary>

#### Hidden vs promptable `subpackages`

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen | Drop `when` and keep the question promptable | `--skip-answered` preserves the stored answer, so existing consumers are not broken | A plain TTY `copier copy` opens the multiline YAML prompt (same behavior as v0.8.0) |
| Rejected | Keep `when: false` and require `--data-file` | No interactive prompt | copier discards the stored answer for hidden questions, so existing consumers' updates are broken by design. Renovate does not pass `--data-file`, so every auto-generated PR is destructive |

</details>
