### PR TITLE
fix(ci): pin mise version to 2026.6.6 in mise-action calls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
           fi
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Run lefthook
         id: lefthook

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -56,6 +56,8 @@ jobs:
         run: git fetch origin master --depth=1
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Save diff before regeneration
         id: save-diff
@@ -109,6 +111,7 @@ jobs:
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
+          version: 2026.6.6
           working_directory: generated/${{ matrix.fixture }}
 
       - name: Enable corepack
@@ -184,6 +187,7 @@ jobs:
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
+          version: 2026.6.6
           working_directory: generated/node
 
       - name: Enable corepack
@@ -229,6 +233,7 @@ jobs:
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
+          version: 2026.6.6
           working_directory: generated/rust
 
       - name: Run tests

--- a/generated/base-public/.github/workflows/test.yml
+++ b/generated/base-public/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
           fi
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Run lefthook
         id: lefthook

--- a/generated/base-release/.github/workflows/test.yml
+++ b/generated/base-release/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
           fi
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Run lefthook
         id: lefthook

--- a/generated/base/.github/workflows/test.yml
+++ b/generated/base/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
           fi
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Run lefthook
         id: lefthook

--- a/generated/monorepo-node-workspace/.github/workflows/bootstrap.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/bootstrap.yml
@@ -41,6 +41,8 @@ jobs:
 
       - if: steps.check.outputs.missing == 'true'
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Generate lockfiles
         if: steps.check.outputs.missing == 'true'

--- a/generated/monorepo-node-workspace/.github/workflows/storybook.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/storybook.yml
@@ -44,6 +44,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 

--- a/generated/monorepo-node-workspace/.github/workflows/test.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
           fi
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 
@@ -157,6 +159,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 

--- a/generated/monorepo/.github/workflows/bootstrap.yml
+++ b/generated/monorepo/.github/workflows/bootstrap.yml
@@ -53,6 +53,8 @@ jobs:
 
       - if: steps.check.outputs.missing == 'true'
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Generate lockfiles
         if: steps.check.outputs.missing == 'true'

--- a/generated/monorepo/.github/workflows/storybook.yml
+++ b/generated/monorepo/.github/workflows/storybook.yml
@@ -41,6 +41,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 

--- a/generated/monorepo/.github/workflows/test.yml
+++ b/generated/monorepo/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 
@@ -143,6 +145,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 
@@ -184,6 +188,8 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e # v2.81.7

--- a/generated/node/.github/workflows/bootstrap.yml
+++ b/generated/node/.github/workflows/bootstrap.yml
@@ -41,6 +41,8 @@ jobs:
 
       - if: steps.check.outputs.missing == 'true'
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Generate lockfiles
         if: steps.check.outputs.missing == 'true'

--- a/generated/node/.github/workflows/storybook.yml
+++ b/generated/node/.github/workflows/storybook.yml
@@ -44,6 +44,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 

--- a/generated/node/.github/workflows/test.yml
+++ b/generated/node/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
           fi
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 
@@ -94,6 +96,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 

--- a/generated/rust-release/.github/workflows/bootstrap.yml
+++ b/generated/rust-release/.github/workflows/bootstrap.yml
@@ -52,6 +52,8 @@ jobs:
 
       - if: steps.check.outputs.missing == 'true'
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Generate lockfiles
         if: steps.check.outputs.missing == 'true'

--- a/generated/rust-release/.github/workflows/test.yml
+++ b/generated/rust-release/.github/workflows/test.yml
@@ -57,6 +57,8 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: cargo fetch
 
@@ -106,6 +108,8 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e # v2.81.7

--- a/generated/rust-with-node-subpackage/.github/workflows/bootstrap.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/bootstrap.yml
@@ -53,6 +53,8 @@ jobs:
 
       - if: steps.check.outputs.missing == 'true'
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Generate lockfiles
         if: steps.check.outputs.missing == 'true'

--- a/generated/rust-with-node-subpackage/.github/workflows/test.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: cargo fetch
 
@@ -103,6 +105,8 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Run tests
         run: cargo test

--- a/generated/rust/.github/workflows/bootstrap.yml
+++ b/generated/rust/.github/workflows/bootstrap.yml
@@ -52,6 +52,8 @@ jobs:
 
       - if: steps.check.outputs.missing == 'true'
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Generate lockfiles
         if: steps.check.outputs.missing == 'true'

--- a/generated/rust/.github/workflows/test.yml
+++ b/generated/rust/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: cargo fetch
 
@@ -103,6 +105,8 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Run tests
         run: cargo test

--- a/template/.github/workflows/bootstrap.yml.jinja
+++ b/template/.github/workflows/bootstrap.yml.jinja
@@ -75,6 +75,8 @@ jobs:
 
       - if: steps.check.outputs.missing == 'true'
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - name: Generate lockfiles
         if: steps.check.outputs.missing == 'true'

--- a/template/.github/workflows/storybook.yml.jinja
+++ b/template/.github/workflows/storybook.yml.jinja
@@ -52,6 +52,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 {%- if is_workspace %}
@@ -145,6 +147,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -80,6 +80,8 @@ jobs:
 {%- endif %}
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 {%- if type == 'node' %}
 
       - run: corepack enable
@@ -218,6 +220,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 
@@ -256,6 +260,8 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 {%- if use_coverage %}
 
       - name: Install cargo-llvm-cov
@@ -289,6 +295,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 
@@ -384,6 +392,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 
@@ -495,6 +505,8 @@ jobs:
 {%- endif %}
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.6
 {%- if pkg.type == 'node' %}
 {%- if is_workspace %}
 {#- Workspace mode: install from root (pnpm only) #}


### PR DESCRIPTION
## Purpose

- Pin to an older mise version because mise v2026.6.7 shipped without the `linux-x64` asset, so `jdx/mise-action`'s latest resolution fails with 404
- Also hardens against supply chain attacks on mise itself

## Approach

- Set `with.version` on every `jdx/mise-action` invocation, in both the root workflows and the `template/` workflows
- The `generated/` snapshots are regenerated to match
