### PR TITLE
chore(scripts): trigger Renovate full-repo scan via Dependency Dashboard

### DIFF
--- a/.claude/skills/update-boilerplate-prs/SKILL.md
+++ b/.claude/skills/update-boilerplate-prs/SKILL.md
@@ -54,28 +54,29 @@ scripts/list-boilerplate-usage --outdated
 
 The output shows each repository's current version, latest version, and whether a Renovate PR exists.
 
-- `renovate PR: (none)` -> Step 3 will trigger PR creation via the Dependency Dashboard
+- `renovate PR: (none)` -> Step 3 will either trigger PR creation via the Dependency Dashboard (when a rate-limited entry exists) or request a full repository scan (when Renovate has not yet noticed the new boilerplate release)
 - `renovate PR: #<number> <url>` -> Step 3 will rebase it via the PR's rebase-check box (re-triggers Renovate even if the PR already targets the latest `_commit`); proceed to Step 4 once `REBASED` is printed
 
-## Step 3: Trigger PR creation or rebase
+## Step 3: Trigger PR creation, rebase, or full-repo scan
 
-The trigger script handles two cases per outdated repo:
+The trigger script picks one action per outdated repo by priority:
 
-- No Renovate PR yet (rate-limited): checks the Dependency Dashboard checkbox so Renovate creates the PR.
-- Renovate PR already exists but is stale (e.g. opened against an older boilerplate version and never regenerated): checks the PR's rebase-check box so Renovate force-pushes a fresh branch against the latest version.
+1. `[rebase]` -- Renovate PR already exists but is stale (e.g. opened against an older boilerplate version): checks the PR's rebase-check box so Renovate force-pushes a fresh branch against the latest version.
+2. `[create]` -- No PR, but the Dependency Dashboard has a rate-limited entry for the generic-boilerplate branch: checks that entry so Renovate creates the PR.
+3. `[scan]` -- No PR and no rate-limited entry (typical immediately after a new boilerplate release): checks the Dashboard's `<!-- manual job -->` checkbox so Renovate re-scans the repository. Once the scan completes, the repo will either gain a new PR or a rate-limited entry; re-run the script in the rate-limited case to convert the entry into a `[create]`.
 
 ```bash
 # Dry-run first to verify targets
 scripts/trigger-renovate-boilerplate-prs --dry-run
 
-# Trigger create + rebase, then wait for results (all outdated repos)
+# Trigger create + rebase + scan, then wait for results (all outdated repos)
 scripts/trigger-renovate-boilerplate-prs
 
 # Or target specific repos
 scripts/trigger-renovate-boilerplate-prs <repo1> <repo2>
 ```
 
-Each line is tagged `[create]` or `[rebase]`. The script polls every 30 seconds (up to 5 minutes), printing `CREATED <repo>: <url>` for new PRs and `REBASED <repo>: PR #<n>` once `headRefOid` changes.
+Each line is tagged `[create]`, `[rebase]`, or `[scan]`. The script polls every 30 seconds (up to 5 minutes), printing `CREATED <repo>: <url>` for new PRs, `REBASED <repo>: PR #<n>` once `headRefOid` changes, and `SCANNED <repo>: ...` once a scan request produces a PR, a new rate-limited entry, or is acknowledged by Renovate (the manual-job checkbox returns to unchecked).
 
 ## Step 4: Auto-merge version-only PRs
 

--- a/.claude/skills/update-boilerplate-prs/SKILL.md
+++ b/.claude/skills/update-boilerplate-prs/SKILL.md
@@ -63,7 +63,7 @@ The trigger script picks one action per outdated repo by priority:
 
 1. `[rebase]` -- Renovate PR already exists but is stale (e.g. opened against an older boilerplate version): checks the PR's rebase-check box so Renovate force-pushes a fresh branch against the latest version.
 2. `[create]` -- No PR, but the Dependency Dashboard has a rate-limited entry for the generic-boilerplate branch: checks that entry so Renovate creates the PR.
-3. `[scan]` -- No PR and no rate-limited entry (typical immediately after a new boilerplate release): checks the Dashboard's `<!-- manual job -->` checkbox so Renovate re-scans the repository. Once the scan completes, the repo will either gain a new PR or a rate-limited entry; re-run the script in the rate-limited case to convert the entry into a `[create]`.
+3. `[scan]` -- No PR and no rate-limited entry (typical immediately after a new boilerplate release): checks the Dashboard's `<!-- manual job -->` checkbox so Renovate re-scans the repository. While polling, the script automatically chains into `[create]` if Renovate surfaces a rate-limited entry, so no manual re-run is needed.
 
 ```bash
 # Dry-run first to verify targets

--- a/scripts/trigger-renovate-boilerplate-prs
+++ b/scripts/trigger-renovate-boilerplate-prs
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-# Trigger Renovate PR creation or rebase for outdated repos.
+# Trigger Renovate PR creation, rebase, or full-repo scan for outdated repos.
 #
-# For each outdated repo found via list-boilerplate-usage:
-#   - If no Renovate PR exists (rate-limited): checks the Dependency Dashboard
-#     checkbox so Renovate creates the PR.
-#   - If a Renovate PR already exists: checks the rebase-check checkbox in the
-#     PR body so Renovate force-pushes a fresh branch.
+# For each outdated repo found via list-boilerplate-usage, picks one action by
+# priority:
+#   1. [rebase] if a Renovate PR already exists: checks the rebase-check
+#      checkbox in the PR body so Renovate force-pushes a fresh branch.
+#   2. [create] if the Dependency Dashboard has a rate-limited entry for the
+#      generic-boilerplate branch: checks that entry so Renovate creates the
+#      PR.
+#   3. [scan]  otherwise: checks the Dashboard's `<!-- manual job -->`
+#      checkbox to request a full repository re-scan (useful immediately after
+#      a new boilerplate release, before Renovate has noticed the update).
 #
-# After triggering, waits for new PRs to appear and for existing PRs to be
-# rebased (headRefOid change), polling both in the same loop.
+# After triggering, waits for new PRs to appear, existing PRs to be rebased
+# (headRefOid change), and scan requests to produce a new PR, a new
+# rate-limited entry, or to be acknowledged (checkbox unchecked again).
 #
 # Usage: scripts/trigger-renovate-boilerplate-prs [--dry-run] [REPO...]
 #
@@ -72,11 +78,14 @@ fi
 # checkbox marker contains `https-github-com-...`.
 CHECKBOX_PATTERN='unlimit-branch=renovate/https-github-com-fohte-generic-boilerplate'
 REBASE_MARKER='<!-- rebase-check -->'
+MANUAL_JOB_MARKER='<!-- manual job -->'
 
 declare -a create_pending=()
 declare -a rebase_repos=()
 declare -a rebase_pr_numbers=()
 declare -a rebase_old_oids=()
+declare -a scan_repos=()
+declare -a scan_issue_numbers=()
 failed_repos=()
 
 for entry in "${entries[@]}"; do
@@ -99,23 +108,49 @@ for entry in "${entries[@]}"; do
 
     body=$(gh issue view "$issue_number" -R "fohte/$repo" --json body -q .body)
 
-    if ! printf '%s\n' "$body" | grep -qF -- "- [ ] <!-- ${CHECKBOX_PATTERN}"; then
-      echo "SKIP $repo [create]: no rate-limited generic-boilerplate entry in Dashboard #$issue_number"
+    if printf '%s\n' "$body" | grep -qF -- "- [ ] <!-- ${CHECKBOX_PATTERN}"; then
+      if "$DRY_RUN"; then
+        echo "WOULD CREATE $repo: check Dashboard #$issue_number"
+      else
+        updated_body="${body//"- [ ] <!-- ${CHECKBOX_PATTERN}"/"- [x] <!-- ${CHECKBOX_PATTERN}"}"
+        if [[ "$updated_body" == "$body" ]]; then
+          echo "FAIL $repo [create]: checkbox substitution produced no change (pattern drift?) in Dashboard #$issue_number" >&2
+          failed_repos+=("$repo")
+          continue
+        fi
+        gh issue edit "$issue_number" -R "fohte/$repo" --body "$updated_body"
+        echo "TRIGGERED $repo [create]: Dashboard #$issue_number"
+        create_pending+=("$repo")
+      fi
+      continue
+    fi
+
+    # No PR and no rate-limited entry: request a full-repo scan via the
+    # `<!-- manual job -->` checkbox so Renovate notices the new boilerplate
+    # release and either creates a PR or adds a rate-limited entry.
+    if printf '%s\n' "$body" | grep -qF -- "- [x] ${MANUAL_JOB_MARKER}"; then
+      echo "SKIP $repo [scan]: manual job checkbox already checked in Dashboard #$issue_number"
+      continue
+    fi
+
+    if ! printf '%s\n' "$body" | grep -qF -- "- [ ] ${MANUAL_JOB_MARKER}"; then
+      echo "SKIP $repo [scan]: no manual job checkbox found in Dashboard #$issue_number"
       continue
     fi
 
     if "$DRY_RUN"; then
-      echo "WOULD CREATE $repo: check Dashboard #$issue_number"
+      echo "WOULD SCAN $repo: check manual job box in Dashboard #$issue_number"
     else
-      updated_body="${body//"- [ ] <!-- ${CHECKBOX_PATTERN}"/"- [x] <!-- ${CHECKBOX_PATTERN}"}"
+      updated_body="${body//"- [ ] ${MANUAL_JOB_MARKER}"/"- [x] ${MANUAL_JOB_MARKER}"}"
       if [[ "$updated_body" == "$body" ]]; then
-        echo "FAIL $repo [create]: checkbox substitution produced no change (pattern drift?) in Dashboard #$issue_number" >&2
+        echo "FAIL $repo [scan]: manual job checkbox substitution produced no change in Dashboard #$issue_number" >&2
         failed_repos+=("$repo")
         continue
       fi
       gh issue edit "$issue_number" -R "fohte/$repo" --body "$updated_body"
-      echo "TRIGGERED $repo [create]: Dashboard #$issue_number"
-      create_pending+=("$repo")
+      echo "TRIGGERED $repo [scan]: Dashboard #$issue_number"
+      scan_repos+=("$repo")
+      scan_issue_numbers+=("$issue_number")
     fi
   else
     if [[ -n "$pr_target_commit" && "$pr_target_commit" == "$latest_commit" ]]; then
@@ -162,7 +197,7 @@ if [[ ${#failed_repos[@]} -gt 0 ]]; then
   exit_code=1
 fi
 
-total_pending=$((${#create_pending[@]} + ${#rebase_repos[@]}))
+total_pending=$((${#create_pending[@]} + ${#rebase_repos[@]} + ${#scan_repos[@]}))
 if "$DRY_RUN" || [[ $total_pending -eq 0 ]]; then
   exit "$exit_code"
 fi
@@ -213,13 +248,52 @@ for ((attempt = 1; attempt <= max_attempts; attempt++)); do
   rebase_pr_numbers=("${remaining_rebase_pr_numbers[@]}")
   rebase_old_oids=("${remaining_rebase_old_oids[@]}")
 
-  remaining_total=$((${#create_pending[@]} + ${#rebase_repos[@]}))
+  remaining_scan_repos=()
+  remaining_scan_issue_numbers=()
+  for i in "${!scan_repos[@]}"; do
+    repo="${scan_repos[$i]}"
+    issue_number="${scan_issue_numbers[$i]}"
+    scan_pr_data=$(
+      gh search prs --repo "fohte/$repo" "generic-boilerplate" --state open \
+        --json number,url,title,headRefOid \
+        --jq '[.[] | select(.title | test("generic-boilerplate"))][0]' \
+        2> /dev/null || true
+    )
+    scan_pr_url=$(printf '%s' "$scan_pr_data" | jq -r '.url // empty' 2> /dev/null || true)
+    scan_body=$(gh issue view "$issue_number" -R "fohte/$repo" --json body -q .body 2> /dev/null || true)
+
+    if [[ -n "$scan_pr_url" ]]; then
+      echo "SCANNED $repo: PR created $scan_pr_url"
+    elif [[ -n "$scan_body" ]] && printf '%s\n' "$scan_body" | grep -qF -- "- [ ] <!-- ${CHECKBOX_PATTERN}"; then
+      # Scan surfaced a rate-limited entry instead of a PR; flip it here to
+      # avoid a second invocation of the script.
+      updated_body="${scan_body//"- [ ] <!-- ${CHECKBOX_PATTERN}"/"- [x] <!-- ${CHECKBOX_PATTERN}"}"
+      if [[ "$updated_body" == "$scan_body" ]]; then
+        echo "FAIL $repo [scan->create]: rate-limited entry detected but substitution produced no change in Dashboard #$issue_number" >&2
+        failed_repos+=("$repo")
+        exit_code=1
+      else
+        gh issue edit "$issue_number" -R "fohte/$repo" --body "$updated_body"
+        echo "SCANNED $repo: rate-limited entry added; chained to [create] in Dashboard #$issue_number"
+        create_pending+=("$repo")
+      fi
+    elif [[ -n "$scan_body" ]] && printf '%s\n' "$scan_body" | grep -qF -- "- [ ] ${MANUAL_JOB_MARKER}"; then
+      echo "SCANNED $repo: manual job processed (no PR or rate-limited entry produced) in Dashboard #$issue_number"
+    else
+      remaining_scan_repos+=("$repo")
+      remaining_scan_issue_numbers+=("$issue_number")
+    fi
+  done
+  scan_repos=("${remaining_scan_repos[@]}")
+  scan_issue_numbers=("${remaining_scan_issue_numbers[@]}")
+
+  remaining_total=$((${#create_pending[@]} + ${#rebase_repos[@]} + ${#scan_repos[@]}))
   if [[ $remaining_total -eq 0 ]]; then
     echo "All triggers completed."
     exit "$exit_code"
   fi
 
-  echo "  ($remaining_total remaining: ${#create_pending[@]} create, ${#rebase_repos[@]} rebase; attempt $attempt/$max_attempts)"
+  echo "  ($remaining_total remaining: ${#create_pending[@]} create, ${#rebase_repos[@]} rebase, ${#scan_repos[@]} scan; attempt $attempt/$max_attempts)"
 done
 
 echo ""
@@ -228,5 +302,8 @@ if [[ ${#create_pending[@]} -gt 0 ]]; then
 fi
 if [[ ${#rebase_repos[@]} -gt 0 ]]; then
   echo "TIMEOUT [rebase]: PRs not yet rebased for: ${rebase_repos[*]}"
+fi
+if [[ ${#scan_repos[@]} -gt 0 ]]; then
+  echo "TIMEOUT [scan]: scans not yet acknowledged for: ${scan_repos[*]}"
 fi
 exit 1


### PR DESCRIPTION
## Purpose

- Cover scan, PR creation, and existing-PR rebase across all outdated repos with a single command right after a boilerplate release
    - `scripts/trigger-renovate-boilerplate-prs` only handled `[create]` / `[rebase]`, so repos with neither a Dashboard entry nor an open PR were dropped as `SKIP`

## Approach

- Add a `[scan]` action
    - Check the `<!-- manual job -->` checkbox in the Dashboard issue body to request a Renovate re-scan of the repository
    - Action priority is `[rebase]` > `[create]` > `[scan]`
- After requesting a scan, poll for whichever arrives first: a new PR, a rate-limited entry, or the manual-job checkbox returning to unchecked
    - When a rate-limited entry surfaces, chain into `[create]` in the same loop so a second invocation is not required
