### PR TITLE
fix(template): use <repo>-bootstrap identity for octo-sts in bootstrap.yml

### DIFF
--- a/generated/monorepo-node-workspace/.github/workflows/bootstrap.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/bootstrap.yml
@@ -25,7 +25,7 @@ jobs:
         id: octo-sts
         with:
           scope: fohte
-          identity: ${{ github.event.repository.name }}
+          identity: ${{ github.event.repository.name }}-bootstrap
           domain: octo-sts.fohte.net
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/generated/monorepo/.github/workflows/bootstrap.yml
+++ b/generated/monorepo/.github/workflows/bootstrap.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         with:
           scope: fohte
-          identity: ${{ github.event.repository.name }}
+          identity: ${{ github.event.repository.name }}-bootstrap
           domain: octo-sts.fohte.net
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/generated/node/.github/workflows/bootstrap.yml
+++ b/generated/node/.github/workflows/bootstrap.yml
@@ -25,7 +25,7 @@ jobs:
         id: octo-sts
         with:
           scope: fohte
-          identity: ${{ github.event.repository.name }}
+          identity: ${{ github.event.repository.name }}-bootstrap
           domain: octo-sts.fohte.net
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/generated/rust-release/.github/workflows/bootstrap.yml
+++ b/generated/rust-release/.github/workflows/bootstrap.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         with:
           scope: fohte
-          identity: ${{ github.event.repository.name }}
+          identity: ${{ github.event.repository.name }}-bootstrap
           domain: octo-sts.fohte.net
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/generated/rust-with-node-subpackage/.github/workflows/bootstrap.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/bootstrap.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         with:
           scope: fohte
-          identity: ${{ github.event.repository.name }}
+          identity: ${{ github.event.repository.name }}-bootstrap
           domain: octo-sts.fohte.net
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/generated/rust/.github/workflows/bootstrap.yml
+++ b/generated/rust/.github/workflows/bootstrap.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         with:
           scope: fohte
-          identity: ${{ github.event.repository.name }}
+          identity: ${{ github.event.repository.name }}-bootstrap
           domain: octo-sts.fohte.net
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/template/.github/workflows/bootstrap.yml.jinja
+++ b/template/.github/workflows/bootstrap.yml.jinja
@@ -35,7 +35,7 @@ jobs:
         id: octo-sts
         with:
           scope: fohte
-          identity: {% raw %}${{ github.event.repository.name }}{% endraw %}
+          identity: {% raw %}${{ github.event.repository.name }}-bootstrap{% endraw %}
           domain: octo-sts.fohte.net
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/.github/pull/20
- The `workflows: write` scope that bootstrap requires also leaks to `test.yml`, which shares the same trust policy, breaking least privilege

## Approach

- Exchange tokens for the bootstrap workflow under a dedicated octo-sts identity so its scope stays inside a bootstrap-only trust policy
- Depends on [the matching `<repo>-bootstrap` trust policy already landed in `fohte/.github`](https://github.com/fohte/.github/pull/20)
