### PR TITLE
feat(template): auto-resolve copier conflicts with mergiraf

### DIFF
--- a/generated/base-public/.github/workflows/renovate-copier.yml
+++ b/generated/base-public/.github/workflows/renovate-copier.yml
@@ -47,36 +47,29 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mergiraf
+      - name: Install mise
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
-        env:
-          MERGIRAF_VERSION: v0.17.0
-          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
-        run: |
-          set -euo pipefail
-          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
-          tmpdir=$(mktemp -d)
-          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
-          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
-          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
-          mkdir -p "$HOME/.local/bin"
-          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mergiraf" --version
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.10
+          install: false
 
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
+        env:
+          # renovate: datasource=gitea-tags depName=mergiraf/mergiraf registryUrl=https://codeberg.org
+          MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mergiraf > /dev/null; then
-            echo "mergiraf not installed; leaving conflict markers in place."
+          if ! command -v mise > /dev/null; then
+            echo "mise not installed; leaving conflict markers in place."
             exit 0
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/base-public/.github/workflows/renovate-copier.yml
+++ b/generated/base-public/.github/workflows/renovate-copier.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Detect copier conflicts
         id: detect
         run: |
-          # copier-specific marker (not git's `<<<<<<< HEAD`)
-          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+          # copier-specific marker (not git's `<<<<<<< HEAD`).
+          # The pattern is split (`'before '` + `updating`) so this workflow
+          # does not self-match when checked into the repo.
+          if git grep --untracked -l '<<<<<<< before '"updating" > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"

--- a/generated/base-public/.github/workflows/renovate-copier.yml
+++ b/generated/base-public/.github/workflows/renovate-copier.yml
@@ -35,12 +35,10 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
-      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
-      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
-      # to copier's literal label.
       - name: Detect copier conflicts
         id: detect
         run: |
+          # copier-specific marker (not git's `<<<<<<< HEAD`)
           if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else

--- a/generated/base-public/.github/workflows/renovate-copier.yml
+++ b/generated/base-public/.github/workflows/renovate-copier.yml
@@ -35,9 +35,55 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
+      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
+      # to copier's literal label.
+      - name: Detect copier conflicts
+        id: detect
+        run: |
+          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        env:
+          MERGIRAF_VERSION: v0.17.0
+          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
+        run: |
+          set -euo pipefail
+          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
+          tmpdir=$(mktemp -d)
+          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
+          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
+          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mergiraf" --version
+
+      - name: Resolve copier conflicts with mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if ! command -v mergiraf > /dev/null; then
+            echo "mergiraf not installed; leaving conflict markers in place."
+            exit 0
+          fi
+          while IFS= read -r f; do
+            echo "mergiraf solve: $f"
+            if ! mergiraf solve "$f"; then
+              echo "  -> mergiraf left conflicts in $f"
+            fi
+          done < /tmp/copier-conflicts.txt
+
       - name: Commit and push changes
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
-          commit_message: 'chore: restore executable bit on scripts/bootstrap'
+          commit_message: 'chore: post-process copier update'
           workflow: deny
           github_token: ${{ steps.octo-sts.outputs.token }}

--- a/generated/base-release/.github/workflows/renovate-copier.yml
+++ b/generated/base-release/.github/workflows/renovate-copier.yml
@@ -47,36 +47,29 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mergiraf
+      - name: Install mise
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
-        env:
-          MERGIRAF_VERSION: v0.17.0
-          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
-        run: |
-          set -euo pipefail
-          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
-          tmpdir=$(mktemp -d)
-          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
-          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
-          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
-          mkdir -p "$HOME/.local/bin"
-          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mergiraf" --version
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.10
+          install: false
 
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
+        env:
+          # renovate: datasource=gitea-tags depName=mergiraf/mergiraf registryUrl=https://codeberg.org
+          MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mergiraf > /dev/null; then
-            echo "mergiraf not installed; leaving conflict markers in place."
+          if ! command -v mise > /dev/null; then
+            echo "mise not installed; leaving conflict markers in place."
             exit 0
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/base-release/.github/workflows/renovate-copier.yml
+++ b/generated/base-release/.github/workflows/renovate-copier.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Detect copier conflicts
         id: detect
         run: |
-          # copier-specific marker (not git's `<<<<<<< HEAD`)
-          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+          # copier-specific marker (not git's `<<<<<<< HEAD`).
+          # The pattern is split (`'before '` + `updating`) so this workflow
+          # does not self-match when checked into the repo.
+          if git grep --untracked -l '<<<<<<< before '"updating" > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"

--- a/generated/base-release/.github/workflows/renovate-copier.yml
+++ b/generated/base-release/.github/workflows/renovate-copier.yml
@@ -35,12 +35,10 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
-      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
-      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
-      # to copier's literal label.
       - name: Detect copier conflicts
         id: detect
         run: |
+          # copier-specific marker (not git's `<<<<<<< HEAD`)
           if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else

--- a/generated/base-release/.github/workflows/renovate-copier.yml
+++ b/generated/base-release/.github/workflows/renovate-copier.yml
@@ -35,9 +35,55 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
+      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
+      # to copier's literal label.
+      - name: Detect copier conflicts
+        id: detect
+        run: |
+          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        env:
+          MERGIRAF_VERSION: v0.17.0
+          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
+        run: |
+          set -euo pipefail
+          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
+          tmpdir=$(mktemp -d)
+          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
+          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
+          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mergiraf" --version
+
+      - name: Resolve copier conflicts with mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if ! command -v mergiraf > /dev/null; then
+            echo "mergiraf not installed; leaving conflict markers in place."
+            exit 0
+          fi
+          while IFS= read -r f; do
+            echo "mergiraf solve: $f"
+            if ! mergiraf solve "$f"; then
+              echo "  -> mergiraf left conflicts in $f"
+            fi
+          done < /tmp/copier-conflicts.txt
+
       - name: Commit and push changes
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
-          commit_message: 'chore: restore executable bit on scripts/bootstrap'
+          commit_message: 'chore: post-process copier update'
           workflow: deny
           github_token: ${{ steps.octo-sts.outputs.token }}

--- a/generated/base/.github/workflows/renovate-copier.yml
+++ b/generated/base/.github/workflows/renovate-copier.yml
@@ -47,36 +47,29 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mergiraf
+      - name: Install mise
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
-        env:
-          MERGIRAF_VERSION: v0.17.0
-          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
-        run: |
-          set -euo pipefail
-          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
-          tmpdir=$(mktemp -d)
-          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
-          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
-          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
-          mkdir -p "$HOME/.local/bin"
-          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mergiraf" --version
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.10
+          install: false
 
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
+        env:
+          # renovate: datasource=gitea-tags depName=mergiraf/mergiraf registryUrl=https://codeberg.org
+          MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mergiraf > /dev/null; then
-            echo "mergiraf not installed; leaving conflict markers in place."
+          if ! command -v mise > /dev/null; then
+            echo "mise not installed; leaving conflict markers in place."
             exit 0
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/base/.github/workflows/renovate-copier.yml
+++ b/generated/base/.github/workflows/renovate-copier.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Detect copier conflicts
         id: detect
         run: |
-          # copier-specific marker (not git's `<<<<<<< HEAD`)
-          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+          # copier-specific marker (not git's `<<<<<<< HEAD`).
+          # The pattern is split (`'before '` + `updating`) so this workflow
+          # does not self-match when checked into the repo.
+          if git grep --untracked -l '<<<<<<< before '"updating" > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"

--- a/generated/base/.github/workflows/renovate-copier.yml
+++ b/generated/base/.github/workflows/renovate-copier.yml
@@ -35,12 +35,10 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
-      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
-      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
-      # to copier's literal label.
       - name: Detect copier conflicts
         id: detect
         run: |
+          # copier-specific marker (not git's `<<<<<<< HEAD`)
           if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else

--- a/generated/base/.github/workflows/renovate-copier.yml
+++ b/generated/base/.github/workflows/renovate-copier.yml
@@ -35,9 +35,55 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
+      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
+      # to copier's literal label.
+      - name: Detect copier conflicts
+        id: detect
+        run: |
+          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        env:
+          MERGIRAF_VERSION: v0.17.0
+          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
+        run: |
+          set -euo pipefail
+          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
+          tmpdir=$(mktemp -d)
+          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
+          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
+          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mergiraf" --version
+
+      - name: Resolve copier conflicts with mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if ! command -v mergiraf > /dev/null; then
+            echo "mergiraf not installed; leaving conflict markers in place."
+            exit 0
+          fi
+          while IFS= read -r f; do
+            echo "mergiraf solve: $f"
+            if ! mergiraf solve "$f"; then
+              echo "  -> mergiraf left conflicts in $f"
+            fi
+          done < /tmp/copier-conflicts.txt
+
       - name: Commit and push changes
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
-          commit_message: 'chore: restore executable bit on scripts/bootstrap'
+          commit_message: 'chore: post-process copier update'
           workflow: deny
           github_token: ${{ steps.octo-sts.outputs.token }}

--- a/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
@@ -47,36 +47,29 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mergiraf
+      - name: Install mise
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
-        env:
-          MERGIRAF_VERSION: v0.17.0
-          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
-        run: |
-          set -euo pipefail
-          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
-          tmpdir=$(mktemp -d)
-          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
-          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
-          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
-          mkdir -p "$HOME/.local/bin"
-          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mergiraf" --version
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.10
+          install: false
 
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
+        env:
+          # renovate: datasource=gitea-tags depName=mergiraf/mergiraf registryUrl=https://codeberg.org
+          MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mergiraf > /dev/null; then
-            echo "mergiraf not installed; leaving conflict markers in place."
+          if ! command -v mise > /dev/null; then
+            echo "mise not installed; leaving conflict markers in place."
             exit 0
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Detect copier conflicts
         id: detect
         run: |
-          # copier-specific marker (not git's `<<<<<<< HEAD`)
-          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+          # copier-specific marker (not git's `<<<<<<< HEAD`).
+          # The pattern is split (`'before '` + `updating`) so this workflow
+          # does not self-match when checked into the repo.
+          if git grep --untracked -l '<<<<<<< before '"updating" > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"

--- a/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
@@ -35,12 +35,10 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
-      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
-      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
-      # to copier's literal label.
       - name: Detect copier conflicts
         id: detect
         run: |
+          # copier-specific marker (not git's `<<<<<<< HEAD`)
           if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else

--- a/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
@@ -35,9 +35,55 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
+      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
+      # to copier's literal label.
+      - name: Detect copier conflicts
+        id: detect
+        run: |
+          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        env:
+          MERGIRAF_VERSION: v0.17.0
+          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
+        run: |
+          set -euo pipefail
+          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
+          tmpdir=$(mktemp -d)
+          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
+          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
+          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mergiraf" --version
+
+      - name: Resolve copier conflicts with mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if ! command -v mergiraf > /dev/null; then
+            echo "mergiraf not installed; leaving conflict markers in place."
+            exit 0
+          fi
+          while IFS= read -r f; do
+            echo "mergiraf solve: $f"
+            if ! mergiraf solve "$f"; then
+              echo "  -> mergiraf left conflicts in $f"
+            fi
+          done < /tmp/copier-conflicts.txt
+
       - name: Commit and push changes
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
-          commit_message: 'chore: restore executable bit on scripts/bootstrap'
+          commit_message: 'chore: post-process copier update'
           workflow: deny
           github_token: ${{ steps.octo-sts.outputs.token }}

--- a/generated/monorepo/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo/.github/workflows/renovate-copier.yml
@@ -47,36 +47,29 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mergiraf
+      - name: Install mise
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
-        env:
-          MERGIRAF_VERSION: v0.17.0
-          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
-        run: |
-          set -euo pipefail
-          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
-          tmpdir=$(mktemp -d)
-          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
-          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
-          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
-          mkdir -p "$HOME/.local/bin"
-          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mergiraf" --version
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.10
+          install: false
 
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
+        env:
+          # renovate: datasource=gitea-tags depName=mergiraf/mergiraf registryUrl=https://codeberg.org
+          MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mergiraf > /dev/null; then
-            echo "mergiraf not installed; leaving conflict markers in place."
+          if ! command -v mise > /dev/null; then
+            echo "mise not installed; leaving conflict markers in place."
             exit 0
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/monorepo/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo/.github/workflows/renovate-copier.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Detect copier conflicts
         id: detect
         run: |
-          # copier-specific marker (not git's `<<<<<<< HEAD`)
-          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+          # copier-specific marker (not git's `<<<<<<< HEAD`).
+          # The pattern is split (`'before '` + `updating`) so this workflow
+          # does not self-match when checked into the repo.
+          if git grep --untracked -l '<<<<<<< before '"updating" > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"

--- a/generated/monorepo/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo/.github/workflows/renovate-copier.yml
@@ -35,12 +35,10 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
-      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
-      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
-      # to copier's literal label.
       - name: Detect copier conflicts
         id: detect
         run: |
+          # copier-specific marker (not git's `<<<<<<< HEAD`)
           if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else

--- a/generated/monorepo/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo/.github/workflows/renovate-copier.yml
@@ -35,9 +35,55 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
+      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
+      # to copier's literal label.
+      - name: Detect copier conflicts
+        id: detect
+        run: |
+          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        env:
+          MERGIRAF_VERSION: v0.17.0
+          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
+        run: |
+          set -euo pipefail
+          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
+          tmpdir=$(mktemp -d)
+          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
+          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
+          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mergiraf" --version
+
+      - name: Resolve copier conflicts with mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if ! command -v mergiraf > /dev/null; then
+            echo "mergiraf not installed; leaving conflict markers in place."
+            exit 0
+          fi
+          while IFS= read -r f; do
+            echo "mergiraf solve: $f"
+            if ! mergiraf solve "$f"; then
+              echo "  -> mergiraf left conflicts in $f"
+            fi
+          done < /tmp/copier-conflicts.txt
+
       - name: Commit and push changes
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
-          commit_message: 'chore: restore executable bit on scripts/bootstrap'
+          commit_message: 'chore: post-process copier update'
           workflow: deny
           github_token: ${{ steps.octo-sts.outputs.token }}

--- a/generated/node/.github/workflows/renovate-copier.yml
+++ b/generated/node/.github/workflows/renovate-copier.yml
@@ -47,36 +47,29 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mergiraf
+      - name: Install mise
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
-        env:
-          MERGIRAF_VERSION: v0.17.0
-          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
-        run: |
-          set -euo pipefail
-          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
-          tmpdir=$(mktemp -d)
-          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
-          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
-          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
-          mkdir -p "$HOME/.local/bin"
-          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mergiraf" --version
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.10
+          install: false
 
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
+        env:
+          # renovate: datasource=gitea-tags depName=mergiraf/mergiraf registryUrl=https://codeberg.org
+          MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mergiraf > /dev/null; then
-            echo "mergiraf not installed; leaving conflict markers in place."
+          if ! command -v mise > /dev/null; then
+            echo "mise not installed; leaving conflict markers in place."
             exit 0
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/node/.github/workflows/renovate-copier.yml
+++ b/generated/node/.github/workflows/renovate-copier.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Detect copier conflicts
         id: detect
         run: |
-          # copier-specific marker (not git's `<<<<<<< HEAD`)
-          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+          # copier-specific marker (not git's `<<<<<<< HEAD`).
+          # The pattern is split (`'before '` + `updating`) so this workflow
+          # does not self-match when checked into the repo.
+          if git grep --untracked -l '<<<<<<< before '"updating" > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"

--- a/generated/node/.github/workflows/renovate-copier.yml
+++ b/generated/node/.github/workflows/renovate-copier.yml
@@ -35,12 +35,10 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
-      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
-      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
-      # to copier's literal label.
       - name: Detect copier conflicts
         id: detect
         run: |
+          # copier-specific marker (not git's `<<<<<<< HEAD`)
           if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else

--- a/generated/node/.github/workflows/renovate-copier.yml
+++ b/generated/node/.github/workflows/renovate-copier.yml
@@ -35,9 +35,55 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
+      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
+      # to copier's literal label.
+      - name: Detect copier conflicts
+        id: detect
+        run: |
+          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        env:
+          MERGIRAF_VERSION: v0.17.0
+          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
+        run: |
+          set -euo pipefail
+          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
+          tmpdir=$(mktemp -d)
+          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
+          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
+          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mergiraf" --version
+
+      - name: Resolve copier conflicts with mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if ! command -v mergiraf > /dev/null; then
+            echo "mergiraf not installed; leaving conflict markers in place."
+            exit 0
+          fi
+          while IFS= read -r f; do
+            echo "mergiraf solve: $f"
+            if ! mergiraf solve "$f"; then
+              echo "  -> mergiraf left conflicts in $f"
+            fi
+          done < /tmp/copier-conflicts.txt
+
       - name: Commit and push changes
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
-          commit_message: 'chore: restore executable bit on scripts/bootstrap'
+          commit_message: 'chore: post-process copier update'
           workflow: deny
           github_token: ${{ steps.octo-sts.outputs.token }}

--- a/generated/rust-release/.github/workflows/renovate-copier.yml
+++ b/generated/rust-release/.github/workflows/renovate-copier.yml
@@ -47,36 +47,29 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mergiraf
+      - name: Install mise
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
-        env:
-          MERGIRAF_VERSION: v0.17.0
-          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
-        run: |
-          set -euo pipefail
-          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
-          tmpdir=$(mktemp -d)
-          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
-          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
-          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
-          mkdir -p "$HOME/.local/bin"
-          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mergiraf" --version
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.10
+          install: false
 
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
+        env:
+          # renovate: datasource=gitea-tags depName=mergiraf/mergiraf registryUrl=https://codeberg.org
+          MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mergiraf > /dev/null; then
-            echo "mergiraf not installed; leaving conflict markers in place."
+          if ! command -v mise > /dev/null; then
+            echo "mise not installed; leaving conflict markers in place."
             exit 0
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/rust-release/.github/workflows/renovate-copier.yml
+++ b/generated/rust-release/.github/workflows/renovate-copier.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Detect copier conflicts
         id: detect
         run: |
-          # copier-specific marker (not git's `<<<<<<< HEAD`)
-          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+          # copier-specific marker (not git's `<<<<<<< HEAD`).
+          # The pattern is split (`'before '` + `updating`) so this workflow
+          # does not self-match when checked into the repo.
+          if git grep --untracked -l '<<<<<<< before '"updating" > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"

--- a/generated/rust-release/.github/workflows/renovate-copier.yml
+++ b/generated/rust-release/.github/workflows/renovate-copier.yml
@@ -35,12 +35,10 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
-      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
-      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
-      # to copier's literal label.
       - name: Detect copier conflicts
         id: detect
         run: |
+          # copier-specific marker (not git's `<<<<<<< HEAD`)
           if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else

--- a/generated/rust-release/.github/workflows/renovate-copier.yml
+++ b/generated/rust-release/.github/workflows/renovate-copier.yml
@@ -35,9 +35,55 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
+      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
+      # to copier's literal label.
+      - name: Detect copier conflicts
+        id: detect
+        run: |
+          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        env:
+          MERGIRAF_VERSION: v0.17.0
+          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
+        run: |
+          set -euo pipefail
+          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
+          tmpdir=$(mktemp -d)
+          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
+          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
+          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mergiraf" --version
+
+      - name: Resolve copier conflicts with mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if ! command -v mergiraf > /dev/null; then
+            echo "mergiraf not installed; leaving conflict markers in place."
+            exit 0
+          fi
+          while IFS= read -r f; do
+            echo "mergiraf solve: $f"
+            if ! mergiraf solve "$f"; then
+              echo "  -> mergiraf left conflicts in $f"
+            fi
+          done < /tmp/copier-conflicts.txt
+
       - name: Commit and push changes
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
-          commit_message: 'chore: restore executable bit on scripts/bootstrap'
+          commit_message: 'chore: post-process copier update'
           workflow: deny
           github_token: ${{ steps.octo-sts.outputs.token }}

--- a/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
@@ -47,36 +47,29 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mergiraf
+      - name: Install mise
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
-        env:
-          MERGIRAF_VERSION: v0.17.0
-          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
-        run: |
-          set -euo pipefail
-          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
-          tmpdir=$(mktemp -d)
-          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
-          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
-          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
-          mkdir -p "$HOME/.local/bin"
-          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mergiraf" --version
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.10
+          install: false
 
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
+        env:
+          # renovate: datasource=gitea-tags depName=mergiraf/mergiraf registryUrl=https://codeberg.org
+          MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mergiraf > /dev/null; then
-            echo "mergiraf not installed; leaving conflict markers in place."
+          if ! command -v mise > /dev/null; then
+            echo "mise not installed; leaving conflict markers in place."
             exit 0
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Detect copier conflicts
         id: detect
         run: |
-          # copier-specific marker (not git's `<<<<<<< HEAD`)
-          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+          # copier-specific marker (not git's `<<<<<<< HEAD`).
+          # The pattern is split (`'before '` + `updating`) so this workflow
+          # does not self-match when checked into the repo.
+          if git grep --untracked -l '<<<<<<< before '"updating" > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"

--- a/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
@@ -35,12 +35,10 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
-      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
-      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
-      # to copier's literal label.
       - name: Detect copier conflicts
         id: detect
         run: |
+          # copier-specific marker (not git's `<<<<<<< HEAD`)
           if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else

--- a/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
@@ -35,9 +35,55 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
+      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
+      # to copier's literal label.
+      - name: Detect copier conflicts
+        id: detect
+        run: |
+          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        env:
+          MERGIRAF_VERSION: v0.17.0
+          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
+        run: |
+          set -euo pipefail
+          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
+          tmpdir=$(mktemp -d)
+          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
+          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
+          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mergiraf" --version
+
+      - name: Resolve copier conflicts with mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if ! command -v mergiraf > /dev/null; then
+            echo "mergiraf not installed; leaving conflict markers in place."
+            exit 0
+          fi
+          while IFS= read -r f; do
+            echo "mergiraf solve: $f"
+            if ! mergiraf solve "$f"; then
+              echo "  -> mergiraf left conflicts in $f"
+            fi
+          done < /tmp/copier-conflicts.txt
+
       - name: Commit and push changes
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
-          commit_message: 'chore: restore executable bit on scripts/bootstrap'
+          commit_message: 'chore: post-process copier update'
           workflow: deny
           github_token: ${{ steps.octo-sts.outputs.token }}

--- a/generated/rust/.github/workflows/renovate-copier.yml
+++ b/generated/rust/.github/workflows/renovate-copier.yml
@@ -47,36 +47,29 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mergiraf
+      - name: Install mise
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
-        env:
-          MERGIRAF_VERSION: v0.17.0
-          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
-        run: |
-          set -euo pipefail
-          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
-          tmpdir=$(mktemp -d)
-          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
-          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
-          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
-          mkdir -p "$HOME/.local/bin"
-          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mergiraf" --version
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.10
+          install: false
 
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
+        env:
+          # renovate: datasource=gitea-tags depName=mergiraf/mergiraf registryUrl=https://codeberg.org
+          MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mergiraf > /dev/null; then
-            echo "mergiraf not installed; leaving conflict markers in place."
+          if ! command -v mise > /dev/null; then
+            echo "mise not installed; leaving conflict markers in place."
             exit 0
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/rust/.github/workflows/renovate-copier.yml
+++ b/generated/rust/.github/workflows/renovate-copier.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Detect copier conflicts
         id: detect
         run: |
-          # copier-specific marker (not git's `<<<<<<< HEAD`)
-          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+          # copier-specific marker (not git's `<<<<<<< HEAD`).
+          # The pattern is split (`'before '` + `updating`) so this workflow
+          # does not self-match when checked into the repo.
+          if git grep --untracked -l '<<<<<<< before '"updating" > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"

--- a/generated/rust/.github/workflows/renovate-copier.yml
+++ b/generated/rust/.github/workflows/renovate-copier.yml
@@ -35,12 +35,10 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
-      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
-      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
-      # to copier's literal label.
       - name: Detect copier conflicts
         id: detect
         run: |
+          # copier-specific marker (not git's `<<<<<<< HEAD`)
           if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else

--- a/generated/rust/.github/workflows/renovate-copier.yml
+++ b/generated/rust/.github/workflows/renovate-copier.yml
@@ -35,9 +35,55 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
+      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
+      # to copier's literal label.
+      - name: Detect copier conflicts
+        id: detect
+        run: |
+          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        env:
+          MERGIRAF_VERSION: v0.17.0
+          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
+        run: |
+          set -euo pipefail
+          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
+          tmpdir=$(mktemp -d)
+          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
+          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
+          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mergiraf" --version
+
+      - name: Resolve copier conflicts with mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if ! command -v mergiraf > /dev/null; then
+            echo "mergiraf not installed; leaving conflict markers in place."
+            exit 0
+          fi
+          while IFS= read -r f; do
+            echo "mergiraf solve: $f"
+            if ! mergiraf solve "$f"; then
+              echo "  -> mergiraf left conflicts in $f"
+            fi
+          done < /tmp/copier-conflicts.txt
+
       - name: Commit and push changes
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
-          commit_message: 'chore: restore executable bit on scripts/bootstrap'
+          commit_message: 'chore: post-process copier update'
           workflow: deny
           github_token: ${{ steps.octo-sts.outputs.token }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,9 @@
     'github>fohte/renovate-config:lefthook.json5',
     'github>fohte/renovate-config:node.json5',
     'github>fohte/renovate-config:rust.json5',
+    // Picks up `# renovate: datasource=... depName=...` on `*_VERSION` env
+    // vars inside generated/*/.github/workflows/.
+    'customManagers:githubActionsVersions',
   ],
   // template/ contains Copier templates (*.jinja), not actual project files
   ignorePaths: ['template/**'],

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,9 +5,6 @@
     'github>fohte/renovate-config:lefthook.json5',
     'github>fohte/renovate-config:node.json5',
     'github>fohte/renovate-config:rust.json5',
-    // Picks up `# renovate: datasource=... depName=...` on `*_VERSION` env
-    // vars inside generated/*/.github/workflows/.
-    'customManagers:githubActionsVersions',
   ],
   // template/ contains Copier templates (*.jinja), not actual project files
   ignorePaths: ['template/**'],

--- a/template/.github/workflows/renovate-copier.yml.jinja
+++ b/template/.github/workflows/renovate-copier.yml.jinja
@@ -35,9 +35,55 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
+      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
+      # to copier's literal label.
+      - name: Detect copier conflicts
+        id: detect
+        run: |
+          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+            echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        env:
+          MERGIRAF_VERSION: v0.17.0
+          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
+        run: |
+          set -euo pipefail
+          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
+          tmpdir=$(mktemp -d)
+          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
+          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
+          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/mergiraf" --version
+
+      - name: Resolve copier conflicts with mergiraf
+        if: steps.detect.outputs.has_conflicts == 'true'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          if ! command -v mergiraf > /dev/null; then
+            echo "mergiraf not installed; leaving conflict markers in place."
+            exit 0
+          fi
+          while IFS= read -r f; do
+            echo "mergiraf solve: $f"
+            if ! mergiraf solve "$f"; then
+              echo "  -> mergiraf left conflicts in $f"
+            fi
+          done < /tmp/copier-conflicts.txt
+
       - name: Commit and push changes
         uses: suzuki-shunsuke/commit-action@06e3b49d4706498d325d29bd85adc82ecf2f5d8f # v1.0.0
         with:
-          commit_message: 'chore: restore executable bit on scripts/bootstrap'
+          commit_message: 'chore: post-process copier update'
           workflow: deny
           github_token: {% raw %}${{ steps.octo-sts.outputs.token }}{% endraw %}

--- a/template/.github/workflows/renovate-copier.yml.jinja
+++ b/template/.github/workflows/renovate-copier.yml.jinja
@@ -47,36 +47,29 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mergiraf
+      - name: Install mise
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
-        env:
-          MERGIRAF_VERSION: v0.17.0
-          MERGIRAF_SHA256: 2c75cc3a6ed013fa3993009d11ebf69d845ae20afa78684e27665ef376fc5780
-        run: |
-          set -euo pipefail
-          url="https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_x86_64-unknown-linux-gnu.tar.gz"
-          tmpdir=$(mktemp -d)
-          curl -fsSL "$url" -o "$tmpdir/mergiraf.tar.gz"
-          echo "${MERGIRAF_SHA256}  $tmpdir/mergiraf.tar.gz" | sha256sum -c -
-          tar -xzf "$tmpdir/mergiraf.tar.gz" -C "$tmpdir"
-          mkdir -p "$HOME/.local/bin"
-          install -m 0755 "$tmpdir/mergiraf" "$HOME/.local/bin/mergiraf"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/mergiraf" --version
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.6.10
+          install: false
 
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
+        env:
+          # renovate: datasource=gitea-tags depName=mergiraf/mergiraf registryUrl=https://codeberg.org
+          MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mergiraf > /dev/null; then
-            echo "mergiraf not installed; leaving conflict markers in place."
+          if ! command -v mise > /dev/null; then
+            echo "mise not installed; leaving conflict markers in place."
             exit 0
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/template/.github/workflows/renovate-copier.yml.jinja
+++ b/template/.github/workflows/renovate-copier.yml.jinja
@@ -38,8 +38,10 @@ jobs:
       - name: Detect copier conflicts
         id: detect
         run: |
-          # copier-specific marker (not git's `<<<<<<< HEAD`)
-          if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
+          # copier-specific marker (not git's `<<<<<<< HEAD`).
+          # The pattern is split (`'before '` + `updating`) so this workflow
+          # does not self-match when checked into the repo.
+          if git grep --untracked -l '<<<<<<< before '"updating" > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"

--- a/template/.github/workflows/renovate-copier.yml.jinja
+++ b/template/.github/workflows/renovate-copier.yml.jinja
@@ -35,12 +35,10 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
-      # Copier emits non-standard conflict markers (`<<<<<<< before updating`
-      # instead of git's `<<<<<<< HEAD`), so the grep pattern below is anchored
-      # to copier's literal label.
       - name: Detect copier conflicts
         id: detect
         run: |
+          # copier-specific marker (not git's `<<<<<<< HEAD`)
           if git grep --untracked -l '<<<<<<< before updating' > /tmp/copier-conflicts.txt && [ -s /tmp/copier-conflicts.txt ]; then
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Purpose

- Stop the copier-style conflict markers (`<<<<<<< before updating`) in `.mise.toml` / `package.json` and similar files from piling up across the ~25 downstream repositories every time Renovate bumps `_commit` in generic-boilerplate

## Approach

- Add a post-process step to `template/.github/workflows/renovate-copier.yml.jinja` that runs [mergiraf](https://mergiraf.org/) `solve` over the marker-bearing files left by Renovate's copier update PRs, re-merging them syntax-aware
