### PR TITLE
fix(template): add aggregate unit-test gate for non-workspace monorepo

### DIFF
--- a/generated/monorepo/.github/workflows/test.yml
+++ b/generated/monorepo/.github/workflows/test.yml
@@ -210,3 +210,18 @@ jobs:
           files: backend/lcov.info
           flags: backend
           fail_ci_if_error: false
+
+  # Aggregation gate for the per-package unit-test jobs. The dynamic per-package
+  # job names cannot be pinned as required status checks, so this single
+  # fixed-name job is the branch protection gate instead. It fails only when a
+  # needed job failed; when every leg succeeds (or is skipped because nothing
+  # changed) it is skipped, and a skipped required check counts as success.
+  unit-test:
+    runs-on: ubuntu-slim
+    needs:
+      - detect-changes
+      - unit-test-frontend
+      - unit-test-backend
+    if: failure()
+    steps:
+      - run: exit 1

--- a/template/.github/workflows/test-release-please.yml.jinja
+++ b/template/.github/workflows/test-release-please.yml.jinja
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Skip tests for release-please PR (only updates CHANGELOG and version)"
-{%- if type in ['node', 'rust'] or is_workspace %}
+{%- if type in ['node', 'rust'] or is_workspace or subpackages %}
 
   unit-test:
     runs-on: ubuntu-latest

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -583,5 +583,21 @@ jobs:
 {%- endif %}
 {%- endif %}
 {%- endfor %}
+
+  # Aggregation gate for the per-package unit-test jobs. The dynamic per-package
+  # job names cannot be pinned as required status checks, so this single
+  # fixed-name job is the branch protection gate instead. It fails only when a
+  # needed job failed; when every leg succeeds (or is skipped because nothing
+  # changed) it is skipped, and a skipped required check counts as success.
+  unit-test:
+    runs-on: ubuntu-slim
+    needs:
+      - detect-changes
+{%- for pkg in testable_subpackages %}
+      - unit-test-{{ pkg.name }}
+{%- endfor %}
+    if: failure()
+    steps:
+      - run: exit 1
 {%- endif %}
 {%- endif %}


### PR DESCRIPTION
## Purpose

- Consumer repos generated as non-workspace monorepos (e.g. node and rust under separate roots) cannot merge release-please PRs because their required checks never report
    - Observed on [fohte/service-kit#9](https://github.com/fohte/service-kit/pull/9): `mergeStateStatus: BLOCKED`, with required checks `unit-test-node` / `unit-test-rust` never reported

## Approach

- Add a fixed-name `unit-test` aggregation gate to the non-workspace `subpackages` branch
- Emit a dummy `unit-test` job in `test-release-please.yml` when `subpackages` is set
