### PR TITLE
fix(template): track branchNameStrict in renovate-copier branch prefix

### DIFF
--- a/.github/workflows/renovate-copier.yml
+++ b/.github/workflows/renovate-copier.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.actor == 'renovate[bot]' &&
-      startsWith(github.head_ref, 'renovate/https-github.com-fohte-generic-boilerplate-')
+      startsWith(github.head_ref, 'renovate/https-github-com-fohte-generic-boilerplate-')
 
     steps:
       - name: Federate GitHub token via octo-sts

--- a/generated/base-public/.github/workflows/renovate-copier.yml
+++ b/generated/base-public/.github/workflows/renovate-copier.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.actor == 'renovate[bot]' &&
-      startsWith(github.head_ref, 'renovate/https-github.com-fohte-generic-boilerplate-')
+      startsWith(github.head_ref, 'renovate/https-github-com-fohte-generic-boilerplate-')
 
     steps:
       - name: Federate GitHub token via octo-sts

--- a/generated/base-release/.github/workflows/renovate-copier.yml
+++ b/generated/base-release/.github/workflows/renovate-copier.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.actor == 'renovate[bot]' &&
-      startsWith(github.head_ref, 'renovate/https-github.com-fohte-generic-boilerplate-')
+      startsWith(github.head_ref, 'renovate/https-github-com-fohte-generic-boilerplate-')
 
     steps:
       - name: Federate GitHub token via octo-sts

--- a/generated/base/.github/workflows/renovate-copier.yml
+++ b/generated/base/.github/workflows/renovate-copier.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.actor == 'renovate[bot]' &&
-      startsWith(github.head_ref, 'renovate/https-github.com-fohte-generic-boilerplate-')
+      startsWith(github.head_ref, 'renovate/https-github-com-fohte-generic-boilerplate-')
 
     steps:
       - name: Federate GitHub token via octo-sts

--- a/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.actor == 'renovate[bot]' &&
-      startsWith(github.head_ref, 'renovate/https-github.com-fohte-generic-boilerplate-')
+      startsWith(github.head_ref, 'renovate/https-github-com-fohte-generic-boilerplate-')
 
     steps:
       - name: Federate GitHub token via octo-sts

--- a/generated/monorepo/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo/.github/workflows/renovate-copier.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.actor == 'renovate[bot]' &&
-      startsWith(github.head_ref, 'renovate/https-github.com-fohte-generic-boilerplate-')
+      startsWith(github.head_ref, 'renovate/https-github-com-fohte-generic-boilerplate-')
 
     steps:
       - name: Federate GitHub token via octo-sts

--- a/generated/node/.github/workflows/renovate-copier.yml
+++ b/generated/node/.github/workflows/renovate-copier.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.actor == 'renovate[bot]' &&
-      startsWith(github.head_ref, 'renovate/https-github.com-fohte-generic-boilerplate-')
+      startsWith(github.head_ref, 'renovate/https-github-com-fohte-generic-boilerplate-')
 
     steps:
       - name: Federate GitHub token via octo-sts

--- a/generated/rust-release/.github/workflows/renovate-copier.yml
+++ b/generated/rust-release/.github/workflows/renovate-copier.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.actor == 'renovate[bot]' &&
-      startsWith(github.head_ref, 'renovate/https-github.com-fohte-generic-boilerplate-')
+      startsWith(github.head_ref, 'renovate/https-github-com-fohte-generic-boilerplate-')
 
     steps:
       - name: Federate GitHub token via octo-sts

--- a/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.actor == 'renovate[bot]' &&
-      startsWith(github.head_ref, 'renovate/https-github.com-fohte-generic-boilerplate-')
+      startsWith(github.head_ref, 'renovate/https-github-com-fohte-generic-boilerplate-')
 
     steps:
       - name: Federate GitHub token via octo-sts

--- a/generated/rust/.github/workflows/renovate-copier.yml
+++ b/generated/rust/.github/workflows/renovate-copier.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.actor == 'renovate[bot]' &&
-      startsWith(github.head_ref, 'renovate/https-github.com-fohte-generic-boilerplate-')
+      startsWith(github.head_ref, 'renovate/https-github-com-fohte-generic-boilerplate-')
 
     steps:
       - name: Federate GitHub token via octo-sts

--- a/template/.github/workflows/renovate-copier.yml.jinja
+++ b/template/.github/workflows/renovate-copier.yml.jinja
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     if: >-
       github.actor == 'renovate[bot]' &&
-      {% raw %}startsWith(github.head_ref, 'renovate/https-github.com-fohte-generic-boilerplate-'){% endraw %}
+      {% raw %}startsWith(github.head_ref, 'renovate/https-github-com-fohte-generic-boilerplate-'){% endraw %}
 
     steps:
       - name: Federate GitHub token via octo-sts


### PR DESCRIPTION
## Purpose

- Renovate PRs that update generic-boilerplate in downstream repos skip the `copier-update` job, so post-processing (conflict resolution, executable bit restoration) does not run
    - Observed: `copier-update` shows skipping in [fohte/dotfiles#243](https://github.com/fohte/dotfiles/pull/243)
    - [fohte/renovate-config#359](https://github.com/fohte/renovate-config/pull/359) enabled `branchNameStrict`, which strips `.` from Renovate branch names and no longer matches the `startsWith` prefix in the workflow `if`

## Approach

- Update the `startsWith` argument from `renovate/https-github.com-fohte-...` to `renovate/https-github-com-fohte-...`
