### PR TITLE
fix(template): drop mergiraf .orig backups in renovate-copier workflow

### DIFF
--- a/generated/base-public/.github/workflows/renovate-copier.yml
+++ b/generated/base-public/.github/workflows/renovate-copier.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/base-release/.github/workflows/renovate-copier.yml
+++ b/generated/base-release/.github/workflows/renovate-copier.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/base/.github/workflows/renovate-copier.yml
+++ b/generated/base/.github/workflows/renovate-copier.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/monorepo/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo/.github/workflows/renovate-copier.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/node/.github/workflows/renovate-copier.yml
+++ b/generated/node/.github/workflows/renovate-copier.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/rust-release/.github/workflows/renovate-copier.yml
+++ b/generated/rust-release/.github/workflows/renovate-copier.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/rust/.github/workflows/renovate-copier.yml
+++ b/generated/rust/.github/workflows/renovate-copier.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/template/.github/workflows/renovate-copier.yml.jinja
+++ b/template/.github/workflows/renovate-copier.yml.jinja
@@ -69,7 +69,7 @@ jobs:
           fi
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve "$f"; then
+            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt


### PR DESCRIPTION
## Purpose

- Renovate-driven copier update PRs accidentally commit mergiraf `.orig` backups (e.g. [the `.claude/skills/update-boilerplate-prs/SKILL.md.orig` added in PR #454](https://github.com/fohte/generic-boilerplate/commit/d8abddb527d3f55f3cb881d8b55e9ba54d4e1e20))

## Approach

- [`mergiraf solve`](https://codeberg.org/mergiraf/mergiraf) defaults `--keep-backup` to `true` and writes a `<file>.orig` per resolved file, so pass `--keep-backup=false` explicitly to suppress the backups
