### PR TITLE
fix(template): bootstrap mergiraf without mise in renovate-copier

### DIFF
--- a/generated/base-public/.github/workflows/renovate-copier.yml
+++ b/generated/base-public/.github/workflows/renovate-copier.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
-          # mergiraf reconstructs pre-update revisions from git history; the
-          # default shallow clone leaves them unreachable.
-          fetch-depth: 0
+          # mergiraf reconstructs the pre-update revision from HEAD~1; the
+          # default shallow clone (depth 1) leaves it unreachable.
+          fetch-depth: 2
 
       - name: Restore executable bit on scripts/bootstrap
         run: |

--- a/generated/base-public/.github/workflows/renovate-copier.yml
+++ b/generated/base-public/.github/workflows/renovate-copier.yml
@@ -62,6 +62,7 @@ jobs:
           # Going through mise/aqua would re-read the repo's .mise.toml, which
           # is itself often a copier conflict file and fails to parse.
           tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
           case "$(uname -m)" in
             x86_64) target=x86_64-unknown-linux-musl ;;
             aarch64) target=aarch64-unknown-linux-musl ;;

--- a/generated/base-public/.github/workflows/renovate-copier.yml
+++ b/generated/base-public/.github/workflows/renovate-copier.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
+          # mergiraf reconstructs pre-update revisions from git history; the
+          # default shallow clone leaves them unreachable.
+          fetch-depth: 0
 
       - name: Restore executable bit on scripts/bootstrap
         run: |
@@ -47,14 +50,6 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mise
-        if: steps.detect.outputs.has_conflicts == 'true'
-        continue-on-error: true
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: 2026.6.10
-          install: false
-
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
@@ -63,13 +58,22 @@ jobs:
           MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mise > /dev/null; then
-            echo "mise not installed; leaving conflict markers in place."
-            exit 0
-          fi
+          # Download the mergiraf binary directly from the upstream release.
+          # Going through mise/aqua would re-read the repo's .mise.toml, which
+          # is itself often a copier conflict file and fails to parse.
+          tmpdir="$(mktemp -d)"
+          case "$(uname -m)" in
+            x86_64) target=x86_64-unknown-linux-musl ;;
+            aarch64) target=aarch64-unknown-linux-musl ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -sSfL \
+            "https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_${target}.tar.gz" \
+            | tar -xz -C "$tmpdir"
+          chmod +x "$tmpdir/mergiraf"
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
+            if ! "$tmpdir/mergiraf" solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/base-release/.github/workflows/renovate-copier.yml
+++ b/generated/base-release/.github/workflows/renovate-copier.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
-          # mergiraf reconstructs pre-update revisions from git history; the
-          # default shallow clone leaves them unreachable.
-          fetch-depth: 0
+          # mergiraf reconstructs the pre-update revision from HEAD~1; the
+          # default shallow clone (depth 1) leaves it unreachable.
+          fetch-depth: 2
 
       - name: Restore executable bit on scripts/bootstrap
         run: |

--- a/generated/base-release/.github/workflows/renovate-copier.yml
+++ b/generated/base-release/.github/workflows/renovate-copier.yml
@@ -62,6 +62,7 @@ jobs:
           # Going through mise/aqua would re-read the repo's .mise.toml, which
           # is itself often a copier conflict file and fails to parse.
           tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
           case "$(uname -m)" in
             x86_64) target=x86_64-unknown-linux-musl ;;
             aarch64) target=aarch64-unknown-linux-musl ;;

--- a/generated/base-release/.github/workflows/renovate-copier.yml
+++ b/generated/base-release/.github/workflows/renovate-copier.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
+          # mergiraf reconstructs pre-update revisions from git history; the
+          # default shallow clone leaves them unreachable.
+          fetch-depth: 0
 
       - name: Restore executable bit on scripts/bootstrap
         run: |
@@ -47,14 +50,6 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mise
-        if: steps.detect.outputs.has_conflicts == 'true'
-        continue-on-error: true
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: 2026.6.10
-          install: false
-
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
@@ -63,13 +58,22 @@ jobs:
           MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mise > /dev/null; then
-            echo "mise not installed; leaving conflict markers in place."
-            exit 0
-          fi
+          # Download the mergiraf binary directly from the upstream release.
+          # Going through mise/aqua would re-read the repo's .mise.toml, which
+          # is itself often a copier conflict file and fails to parse.
+          tmpdir="$(mktemp -d)"
+          case "$(uname -m)" in
+            x86_64) target=x86_64-unknown-linux-musl ;;
+            aarch64) target=aarch64-unknown-linux-musl ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -sSfL \
+            "https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_${target}.tar.gz" \
+            | tar -xz -C "$tmpdir"
+          chmod +x "$tmpdir/mergiraf"
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
+            if ! "$tmpdir/mergiraf" solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/base/.github/workflows/renovate-copier.yml
+++ b/generated/base/.github/workflows/renovate-copier.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
-          # mergiraf reconstructs pre-update revisions from git history; the
-          # default shallow clone leaves them unreachable.
-          fetch-depth: 0
+          # mergiraf reconstructs the pre-update revision from HEAD~1; the
+          # default shallow clone (depth 1) leaves it unreachable.
+          fetch-depth: 2
 
       - name: Restore executable bit on scripts/bootstrap
         run: |

--- a/generated/base/.github/workflows/renovate-copier.yml
+++ b/generated/base/.github/workflows/renovate-copier.yml
@@ -62,6 +62,7 @@ jobs:
           # Going through mise/aqua would re-read the repo's .mise.toml, which
           # is itself often a copier conflict file and fails to parse.
           tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
           case "$(uname -m)" in
             x86_64) target=x86_64-unknown-linux-musl ;;
             aarch64) target=aarch64-unknown-linux-musl ;;

--- a/generated/base/.github/workflows/renovate-copier.yml
+++ b/generated/base/.github/workflows/renovate-copier.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
+          # mergiraf reconstructs pre-update revisions from git history; the
+          # default shallow clone leaves them unreachable.
+          fetch-depth: 0
 
       - name: Restore executable bit on scripts/bootstrap
         run: |
@@ -47,14 +50,6 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mise
-        if: steps.detect.outputs.has_conflicts == 'true'
-        continue-on-error: true
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: 2026.6.10
-          install: false
-
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
@@ -63,13 +58,22 @@ jobs:
           MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mise > /dev/null; then
-            echo "mise not installed; leaving conflict markers in place."
-            exit 0
-          fi
+          # Download the mergiraf binary directly from the upstream release.
+          # Going through mise/aqua would re-read the repo's .mise.toml, which
+          # is itself often a copier conflict file and fails to parse.
+          tmpdir="$(mktemp -d)"
+          case "$(uname -m)" in
+            x86_64) target=x86_64-unknown-linux-musl ;;
+            aarch64) target=aarch64-unknown-linux-musl ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -sSfL \
+            "https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_${target}.tar.gz" \
+            | tar -xz -C "$tmpdir"
+          chmod +x "$tmpdir/mergiraf"
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
+            if ! "$tmpdir/mergiraf" solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
-          # mergiraf reconstructs pre-update revisions from git history; the
-          # default shallow clone leaves them unreachable.
-          fetch-depth: 0
+          # mergiraf reconstructs the pre-update revision from HEAD~1; the
+          # default shallow clone (depth 1) leaves it unreachable.
+          fetch-depth: 2
 
       - name: Restore executable bit on scripts/bootstrap
         run: |

--- a/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
@@ -62,6 +62,7 @@ jobs:
           # Going through mise/aqua would re-read the repo's .mise.toml, which
           # is itself often a copier conflict file and fails to parse.
           tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
           case "$(uname -m)" in
             x86_64) target=x86_64-unknown-linux-musl ;;
             aarch64) target=aarch64-unknown-linux-musl ;;

--- a/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/renovate-copier.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
+          # mergiraf reconstructs pre-update revisions from git history; the
+          # default shallow clone leaves them unreachable.
+          fetch-depth: 0
 
       - name: Restore executable bit on scripts/bootstrap
         run: |
@@ -47,14 +50,6 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mise
-        if: steps.detect.outputs.has_conflicts == 'true'
-        continue-on-error: true
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: 2026.6.10
-          install: false
-
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
@@ -63,13 +58,22 @@ jobs:
           MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mise > /dev/null; then
-            echo "mise not installed; leaving conflict markers in place."
-            exit 0
-          fi
+          # Download the mergiraf binary directly from the upstream release.
+          # Going through mise/aqua would re-read the repo's .mise.toml, which
+          # is itself often a copier conflict file and fails to parse.
+          tmpdir="$(mktemp -d)"
+          case "$(uname -m)" in
+            x86_64) target=x86_64-unknown-linux-musl ;;
+            aarch64) target=aarch64-unknown-linux-musl ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -sSfL \
+            "https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_${target}.tar.gz" \
+            | tar -xz -C "$tmpdir"
+          chmod +x "$tmpdir/mergiraf"
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
+            if ! "$tmpdir/mergiraf" solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/monorepo/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo/.github/workflows/renovate-copier.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
-          # mergiraf reconstructs pre-update revisions from git history; the
-          # default shallow clone leaves them unreachable.
-          fetch-depth: 0
+          # mergiraf reconstructs the pre-update revision from HEAD~1; the
+          # default shallow clone (depth 1) leaves it unreachable.
+          fetch-depth: 2
 
       - name: Restore executable bit on scripts/bootstrap
         run: |

--- a/generated/monorepo/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo/.github/workflows/renovate-copier.yml
@@ -62,6 +62,7 @@ jobs:
           # Going through mise/aqua would re-read the repo's .mise.toml, which
           # is itself often a copier conflict file and fails to parse.
           tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
           case "$(uname -m)" in
             x86_64) target=x86_64-unknown-linux-musl ;;
             aarch64) target=aarch64-unknown-linux-musl ;;

--- a/generated/monorepo/.github/workflows/renovate-copier.yml
+++ b/generated/monorepo/.github/workflows/renovate-copier.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
+          # mergiraf reconstructs pre-update revisions from git history; the
+          # default shallow clone leaves them unreachable.
+          fetch-depth: 0
 
       - name: Restore executable bit on scripts/bootstrap
         run: |
@@ -47,14 +50,6 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mise
-        if: steps.detect.outputs.has_conflicts == 'true'
-        continue-on-error: true
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: 2026.6.10
-          install: false
-
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
@@ -63,13 +58,22 @@ jobs:
           MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mise > /dev/null; then
-            echo "mise not installed; leaving conflict markers in place."
-            exit 0
-          fi
+          # Download the mergiraf binary directly from the upstream release.
+          # Going through mise/aqua would re-read the repo's .mise.toml, which
+          # is itself often a copier conflict file and fails to parse.
+          tmpdir="$(mktemp -d)"
+          case "$(uname -m)" in
+            x86_64) target=x86_64-unknown-linux-musl ;;
+            aarch64) target=aarch64-unknown-linux-musl ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -sSfL \
+            "https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_${target}.tar.gz" \
+            | tar -xz -C "$tmpdir"
+          chmod +x "$tmpdir/mergiraf"
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
+            if ! "$tmpdir/mergiraf" solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/node/.github/workflows/renovate-copier.yml
+++ b/generated/node/.github/workflows/renovate-copier.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
-          # mergiraf reconstructs pre-update revisions from git history; the
-          # default shallow clone leaves them unreachable.
-          fetch-depth: 0
+          # mergiraf reconstructs the pre-update revision from HEAD~1; the
+          # default shallow clone (depth 1) leaves it unreachable.
+          fetch-depth: 2
 
       - name: Restore executable bit on scripts/bootstrap
         run: |

--- a/generated/node/.github/workflows/renovate-copier.yml
+++ b/generated/node/.github/workflows/renovate-copier.yml
@@ -62,6 +62,7 @@ jobs:
           # Going through mise/aqua would re-read the repo's .mise.toml, which
           # is itself often a copier conflict file and fails to parse.
           tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
           case "$(uname -m)" in
             x86_64) target=x86_64-unknown-linux-musl ;;
             aarch64) target=aarch64-unknown-linux-musl ;;

--- a/generated/node/.github/workflows/renovate-copier.yml
+++ b/generated/node/.github/workflows/renovate-copier.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
+          # mergiraf reconstructs pre-update revisions from git history; the
+          # default shallow clone leaves them unreachable.
+          fetch-depth: 0
 
       - name: Restore executable bit on scripts/bootstrap
         run: |
@@ -47,14 +50,6 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mise
-        if: steps.detect.outputs.has_conflicts == 'true'
-        continue-on-error: true
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: 2026.6.10
-          install: false
-
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
@@ -63,13 +58,22 @@ jobs:
           MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mise > /dev/null; then
-            echo "mise not installed; leaving conflict markers in place."
-            exit 0
-          fi
+          # Download the mergiraf binary directly from the upstream release.
+          # Going through mise/aqua would re-read the repo's .mise.toml, which
+          # is itself often a copier conflict file and fails to parse.
+          tmpdir="$(mktemp -d)"
+          case "$(uname -m)" in
+            x86_64) target=x86_64-unknown-linux-musl ;;
+            aarch64) target=aarch64-unknown-linux-musl ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -sSfL \
+            "https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_${target}.tar.gz" \
+            | tar -xz -C "$tmpdir"
+          chmod +x "$tmpdir/mergiraf"
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
+            if ! "$tmpdir/mergiraf" solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/rust-release/.github/workflows/renovate-copier.yml
+++ b/generated/rust-release/.github/workflows/renovate-copier.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
-          # mergiraf reconstructs pre-update revisions from git history; the
-          # default shallow clone leaves them unreachable.
-          fetch-depth: 0
+          # mergiraf reconstructs the pre-update revision from HEAD~1; the
+          # default shallow clone (depth 1) leaves it unreachable.
+          fetch-depth: 2
 
       - name: Restore executable bit on scripts/bootstrap
         run: |

--- a/generated/rust-release/.github/workflows/renovate-copier.yml
+++ b/generated/rust-release/.github/workflows/renovate-copier.yml
@@ -62,6 +62,7 @@ jobs:
           # Going through mise/aqua would re-read the repo's .mise.toml, which
           # is itself often a copier conflict file and fails to parse.
           tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
           case "$(uname -m)" in
             x86_64) target=x86_64-unknown-linux-musl ;;
             aarch64) target=aarch64-unknown-linux-musl ;;

--- a/generated/rust-release/.github/workflows/renovate-copier.yml
+++ b/generated/rust-release/.github/workflows/renovate-copier.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
+          # mergiraf reconstructs pre-update revisions from git history; the
+          # default shallow clone leaves them unreachable.
+          fetch-depth: 0
 
       - name: Restore executable bit on scripts/bootstrap
         run: |
@@ -47,14 +50,6 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mise
-        if: steps.detect.outputs.has_conflicts == 'true'
-        continue-on-error: true
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: 2026.6.10
-          install: false
-
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
@@ -63,13 +58,22 @@ jobs:
           MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mise > /dev/null; then
-            echo "mise not installed; leaving conflict markers in place."
-            exit 0
-          fi
+          # Download the mergiraf binary directly from the upstream release.
+          # Going through mise/aqua would re-read the repo's .mise.toml, which
+          # is itself often a copier conflict file and fails to parse.
+          tmpdir="$(mktemp -d)"
+          case "$(uname -m)" in
+            x86_64) target=x86_64-unknown-linux-musl ;;
+            aarch64) target=aarch64-unknown-linux-musl ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -sSfL \
+            "https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_${target}.tar.gz" \
+            | tar -xz -C "$tmpdir"
+          chmod +x "$tmpdir/mergiraf"
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
+            if ! "$tmpdir/mergiraf" solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
-          # mergiraf reconstructs pre-update revisions from git history; the
-          # default shallow clone leaves them unreachable.
-          fetch-depth: 0
+          # mergiraf reconstructs the pre-update revision from HEAD~1; the
+          # default shallow clone (depth 1) leaves it unreachable.
+          fetch-depth: 2
 
       - name: Restore executable bit on scripts/bootstrap
         run: |

--- a/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
@@ -62,6 +62,7 @@ jobs:
           # Going through mise/aqua would re-read the repo's .mise.toml, which
           # is itself often a copier conflict file and fails to parse.
           tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
           case "$(uname -m)" in
             x86_64) target=x86_64-unknown-linux-musl ;;
             aarch64) target=aarch64-unknown-linux-musl ;;

--- a/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/renovate-copier.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
+          # mergiraf reconstructs pre-update revisions from git history; the
+          # default shallow clone leaves them unreachable.
+          fetch-depth: 0
 
       - name: Restore executable bit on scripts/bootstrap
         run: |
@@ -47,14 +50,6 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mise
-        if: steps.detect.outputs.has_conflicts == 'true'
-        continue-on-error: true
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: 2026.6.10
-          install: false
-
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
@@ -63,13 +58,22 @@ jobs:
           MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mise > /dev/null; then
-            echo "mise not installed; leaving conflict markers in place."
-            exit 0
-          fi
+          # Download the mergiraf binary directly from the upstream release.
+          # Going through mise/aqua would re-read the repo's .mise.toml, which
+          # is itself often a copier conflict file and fails to parse.
+          tmpdir="$(mktemp -d)"
+          case "$(uname -m)" in
+            x86_64) target=x86_64-unknown-linux-musl ;;
+            aarch64) target=aarch64-unknown-linux-musl ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -sSfL \
+            "https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_${target}.tar.gz" \
+            | tar -xz -C "$tmpdir"
+          chmod +x "$tmpdir/mergiraf"
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
+            if ! "$tmpdir/mergiraf" solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/generated/rust/.github/workflows/renovate-copier.yml
+++ b/generated/rust/.github/workflows/renovate-copier.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
-          # mergiraf reconstructs pre-update revisions from git history; the
-          # default shallow clone leaves them unreachable.
-          fetch-depth: 0
+          # mergiraf reconstructs the pre-update revision from HEAD~1; the
+          # default shallow clone (depth 1) leaves it unreachable.
+          fetch-depth: 2
 
       - name: Restore executable bit on scripts/bootstrap
         run: |

--- a/generated/rust/.github/workflows/renovate-copier.yml
+++ b/generated/rust/.github/workflows/renovate-copier.yml
@@ -62,6 +62,7 @@ jobs:
           # Going through mise/aqua would re-read the repo's .mise.toml, which
           # is itself often a copier conflict file and fails to parse.
           tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
           case "$(uname -m)" in
             x86_64) target=x86_64-unknown-linux-musl ;;
             aarch64) target=aarch64-unknown-linux-musl ;;

--- a/generated/rust/.github/workflows/renovate-copier.yml
+++ b/generated/rust/.github/workflows/renovate-copier.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.octo-sts.outputs.token }}
+          # mergiraf reconstructs pre-update revisions from git history; the
+          # default shallow clone leaves them unreachable.
+          fetch-depth: 0
 
       - name: Restore executable bit on scripts/bootstrap
         run: |
@@ -47,14 +50,6 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mise
-        if: steps.detect.outputs.has_conflicts == 'true'
-        continue-on-error: true
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: 2026.6.10
-          install: false
-
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
@@ -63,13 +58,22 @@ jobs:
           MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mise > /dev/null; then
-            echo "mise not installed; leaving conflict markers in place."
-            exit 0
-          fi
+          # Download the mergiraf binary directly from the upstream release.
+          # Going through mise/aqua would re-read the repo's .mise.toml, which
+          # is itself often a copier conflict file and fails to parse.
+          tmpdir="$(mktemp -d)"
+          case "$(uname -m)" in
+            x86_64) target=x86_64-unknown-linux-musl ;;
+            aarch64) target=aarch64-unknown-linux-musl ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -sSfL \
+            "https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_${target}.tar.gz" \
+            | tar -xz -C "$tmpdir"
+          chmod +x "$tmpdir/mergiraf"
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
+            if ! "$tmpdir/mergiraf" solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/template/.github/workflows/renovate-copier.yml.jinja
+++ b/template/.github/workflows/renovate-copier.yml.jinja
@@ -62,6 +62,7 @@ jobs:
           # Going through mise/aqua would re-read the repo's .mise.toml, which
           # is itself often a copier conflict file and fails to parse.
           tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
           case "$(uname -m)" in
             x86_64) target=x86_64-unknown-linux-musl ;;
             aarch64) target=aarch64-unknown-linux-musl ;;

--- a/template/.github/workflows/renovate-copier.yml.jinja
+++ b/template/.github/workflows/renovate-copier.yml.jinja
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: {% raw %}${{ github.head_ref }}{% endraw %}
           token: {% raw %}${{ steps.octo-sts.outputs.token }}{% endraw %}
+          # mergiraf reconstructs pre-update revisions from git history; the
+          # default shallow clone leaves them unreachable.
+          fetch-depth: 0
 
       - name: Restore executable bit on scripts/bootstrap
         run: |
@@ -47,14 +50,6 @@ jobs:
             echo "has_conflicts=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install mise
-        if: steps.detect.outputs.has_conflicts == 'true'
-        continue-on-error: true
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: 2026.6.10
-          install: false
-
       - name: Resolve copier conflicts with mergiraf
         if: steps.detect.outputs.has_conflicts == 'true'
         continue-on-error: true
@@ -63,13 +58,22 @@ jobs:
           MERGIRAF_VERSION: v0.17.0
         run: |
           set -uo pipefail
-          if ! command -v mise > /dev/null; then
-            echo "mise not installed; leaving conflict markers in place."
-            exit 0
-          fi
+          # Download the mergiraf binary directly from the upstream release.
+          # Going through mise/aqua would re-read the repo's .mise.toml, which
+          # is itself often a copier conflict file and fails to parse.
+          tmpdir="$(mktemp -d)"
+          case "$(uname -m)" in
+            x86_64) target=x86_64-unknown-linux-musl ;;
+            aarch64) target=aarch64-unknown-linux-musl ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          curl -sSfL \
+            "https://codeberg.org/mergiraf/mergiraf/releases/download/${MERGIRAF_VERSION}/mergiraf_${target}.tar.gz" \
+            | tar -xz -C "$tmpdir"
+          chmod +x "$tmpdir/mergiraf"
           while IFS= read -r f; do
             echo "mergiraf solve: $f"
-            if ! mise exec "aqua:codeberg.org/mergiraf/mergiraf@${MERGIRAF_VERSION}" -- mergiraf solve --keep-backup=false "$f"; then
+            if ! "$tmpdir/mergiraf" solve --keep-backup=false "$f"; then
               echo "  -> mergiraf left conflicts in $f"
             fi
           done < /tmp/copier-conflicts.txt

--- a/template/.github/workflows/renovate-copier.yml.jinja
+++ b/template/.github/workflows/renovate-copier.yml.jinja
@@ -28,9 +28,9 @@ jobs:
         with:
           ref: {% raw %}${{ github.head_ref }}{% endraw %}
           token: {% raw %}${{ steps.octo-sts.outputs.token }}{% endraw %}
-          # mergiraf reconstructs pre-update revisions from git history; the
-          # default shallow clone leaves them unreachable.
-          fetch-depth: 0
+          # mergiraf reconstructs the pre-update revision from HEAD~1; the
+          # default shallow clone (depth 1) leaves it unreachable.
+          fetch-depth: 2
 
       - name: Restore executable bit on scripts/bootstrap
         run: |


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/generic-boilerplate/pull/453
- Mergiraf could not install when `.mise.toml` itself was in conflict during a boilerplate update, so the automatic conflict resolution never ran.

## Approach

- Fetch the mergiraf binary directly from the [Codeberg release assets](https://codeberg.org/mergiraf/mergiraf/releases) instead of going through mise, so mergiraf runs even when `.mise.toml` is part of the conflict.
- Deepen the checkout enough to reach the pre-update revision that mergiraf needs for the 3-way merge.
