### PR TITLE
feat(copier): add is_web_app gate for node web app bootstrap

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -80,7 +80,7 @@ _exclude:
   # Monorepo subpackages declare their own web app status via `web_app: true`
   # on the subpackages entry; the per-pkg bootstrap path is gated separately
   # in the subpackage filename template.
-  - "{% if type != 'node' or not is_web_app %}/src/bootstrap.ts{% endif %}"
+  - "{% if type != 'node' or not is_web_app | default(false) %}/src/bootstrap.ts{% endif %}"
   # Exclude coverage files when coverage is disabled
   - '{% if not use_coverage %}/codecov.yml{% endif %}'
   # Exclude Storybook files when storybook is disabled or no storybook packages exist
@@ -214,6 +214,11 @@ storybook_pkgs:
   default: "{{ subpackages | default([]) | selectattr('storybook', 'defined') | selectattr('storybook', 'equalto', true) | list }}"
   when: false
 
+web_app_pkgs:
+  type: yaml
+  default: "{{ subpackages | default([]) | selectattr('web_app', 'defined') | selectattr('web_app', 'equalto', true) | list }}"
+  when: false
+
 has_node_pkg:
   type: bool
   default: '{{ node_pkgs | length > 0 }}'
@@ -229,9 +234,19 @@ has_storybook_pkg:
   default: '{{ storybook_pkgs | length > 0 }}'
   when: false
 
+has_web_app_pkg:
+  type: bool
+  default: '{{ web_app_pkgs | length > 0 }}'
+  when: false
+
 has_node:
   type: bool
   default: "{{ type == 'node' or has_node_pkg }}"
+  when: false
+
+has_web_app:
+  type: bool
+  default: '{{ is_web_app | default(false) or has_web_app_pkg }}'
   when: false
 
 has_rust:

--- a/copier.yml
+++ b/copier.yml
@@ -76,6 +76,8 @@ _exclude:
   # Exclude Node.js specific src files when type is not 'node'
   - "{% if type != 'node' %}/src/index.ts{% endif %}"
   - "{% if type != 'node' %}/src/index.test.ts{% endif %}"
+  # Exclude observability bootstrap when not a node web app
+  - "{% if type != 'node' or not use_observability %}/src/bootstrap.ts{% endif %}"
   # Exclude coverage files when coverage is disabled
   - '{% if not use_coverage %}/codecov.yml{% endif %}'
   # Exclude Storybook files when storybook is disabled or no storybook packages exist
@@ -178,6 +180,13 @@ use_storybook:
   default: false
   help: Enable Storybook deployment to Cloudflare Pages?
   when: "{{ type == 'node' or (subpackages | selectattr('type', 'equalto', 'node') | list | length > 0) }}"
+
+# Observability settings
+use_observability:
+  type: bool
+  default: false
+  help: Enable observability (OpenTelemetry + Sentry) bootstrap? Set true only for a web app (a long-running process exposing an HTTP server).
+  when: "{{ type == 'node' }}"
 
 # Computed variables (not asked, derived from other answers).
 # Centralized here so individual templates can reference them directly

--- a/copier.yml
+++ b/copier.yml
@@ -76,8 +76,11 @@ _exclude:
   # Exclude Node.js specific src files when type is not 'node'
   - "{% if type != 'node' %}/src/index.ts{% endif %}"
   - "{% if type != 'node' %}/src/index.test.ts{% endif %}"
-  # Exclude observability bootstrap when not a node web app
-  - "{% if type != 'node' or not use_observability %}/src/bootstrap.ts{% endif %}"
+  # Exclude observability bootstrap when the root project is not a node web app.
+  # Monorepo subpackages declare their own web app status via `web_app: true`
+  # on the subpackages entry; the per-pkg bootstrap path is gated separately
+  # in the subpackage filename template.
+  - "{% if type != 'node' or not is_web_app %}/src/bootstrap.ts{% endif %}"
   # Exclude coverage files when coverage is disabled
   - '{% if not use_coverage %}/codecov.yml{% endif %}'
   # Exclude Storybook files when storybook is disabled or no storybook packages exist
@@ -149,6 +152,9 @@ subpackages:
     Example: [{name: frontend, type: node}, {name: backend, type: rust}]
     Per-entry flags (optional):
       storybook: true  -- enable Storybook for a node subpackage
+      web_app: true    -- mark a node subpackage as a web app (long-running
+                          HTTP server). Gates the observability bootstrap
+                          emission for that subpackage.
       tests: false     -- skip test scaffolding (vitest, tsconfig, src/, eslint),
                           the unit-test CI job, the per-package eslint
                           lefthook hook, and the pnpm install/cache step in
@@ -181,11 +187,13 @@ use_storybook:
   help: Enable Storybook deployment to Cloudflare Pages?
   when: "{{ type == 'node' or (subpackages | selectattr('type', 'equalto', 'node') | list | length > 0) }}"
 
-# Observability settings
-use_observability:
+# Web app flag. Drives the observability bootstrap emission (and is intended
+# to gate any future long-running-service scaffolding). For monorepos, set
+# `web_app: true` on the relevant subpackages entry instead.
+is_web_app:
   type: bool
   default: false
-  help: Enable observability (OpenTelemetry + Sentry) bootstrap? Set true only for a web app (a long-running process exposing an HTTP server).
+  help: Is this project a web app (a long-running process exposing an HTTP server)?
   when: "{{ type == 'node' }}"
 
 # Computed variables (not asked, derived from other answers).

--- a/tests/fixtures/node.yml
+++ b/tests/fixtures/node.yml
@@ -7,5 +7,6 @@ description: Test Node.js project description
 is_public: false
 use_release_please: false
 use_storybook: true
+use_observability: false
 repo_language: ja
 subpackages: []

--- a/tests/fixtures/node.yml
+++ b/tests/fixtures/node.yml
@@ -7,6 +7,6 @@ description: Test Node.js project description
 is_public: false
 use_release_please: false
 use_storybook: true
-use_observability: false
+is_web_app: false
 repo_language: ja
 subpackages: []


### PR DESCRIPTION
## Purpose

- Let only web app derivatives receive the `@fohte/service-kit/observability` bootstrap skeleton from the template

## Approach

- Add `is_web_app` for node projects and a per-pkg `web_app` flag for monorepo subpackages, and gate `/src/bootstrap.ts` on them (the body file lands in a follow-up)
