### PR TITLE
feat(template): emit observability bootstrap for node web apps

### DIFF
--- a/generated/monorepo-node-workspace/backend/package.json
+++ b/generated/monorepo-node-workspace/backend/package.json
@@ -8,7 +8,7 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
-    "@fohte/service-kit": "0.1.0",
+    "@fohte/service-kit": "0.1.1",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.77.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",

--- a/generated/monorepo-node-workspace/backend/package.json
+++ b/generated/monorepo-node-workspace/backend/package.json
@@ -6,5 +6,17 @@
     "test": "conc pnpm:test:type pnpm:test:unit",
     "test:type": "tsc --noEmit",
     "test:unit": "vitest run"
+  },
+  "dependencies": {
+    "@fohte/service-kit": "0.1.0",
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/auto-instrumentations-node": "0.77.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",
+    "@opentelemetry/resources": "2.8.0",
+    "@opentelemetry/sdk-node": "0.219.0",
+    "@opentelemetry/sdk-trace-base": "2.8.0",
+    "@opentelemetry/semantic-conventions": "1.41.1",
+    "@sentry/node": "10.57.0",
+    "@sentry/opentelemetry": "10.58.0"
   }
 }

--- a/generated/monorepo-node-workspace/backend/src/bootstrap.ts
+++ b/generated/monorepo-node-workspace/backend/src/bootstrap.ts
@@ -1,3 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/strict-boolean-expressions --
+ * @fohte/service-kit ships .d.ts files that reference internal `@/...`
+ * path aliases unresolvable from consumer projects, so typescript-eslint
+ * sees these calls as untyped. tsc passes thanks to skipLibCheck.
+ */
 // Must run before any instrumented module is imported, otherwise
 // @opentelemetry/auto-instrumentations-node cannot patch them. Either
 // `import './bootstrap'` as the very first statement of the entrypoint,

--- a/generated/monorepo-node-workspace/backend/src/bootstrap.ts
+++ b/generated/monorepo-node-workspace/backend/src/bootstrap.ts
@@ -1,0 +1,8 @@
+import {
+  initObservability,
+  isObservabilityConfigured,
+} from '@fohte/service-kit/observability'
+
+if (isObservabilityConfigured(process.env)) {
+  initObservability(process.env)
+}

--- a/generated/monorepo-node-workspace/backend/src/bootstrap.ts
+++ b/generated/monorepo-node-workspace/backend/src/bootstrap.ts
@@ -1,8 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/strict-boolean-expressions --
- * @fohte/service-kit ships .d.ts files that reference internal `@/...`
- * path aliases unresolvable from consumer projects, so typescript-eslint
- * sees these calls as untyped. tsc passes thanks to skipLibCheck.
- */
 // Must run before any instrumented module is imported, otherwise
 // @opentelemetry/auto-instrumentations-node cannot patch them. Either
 // `import './bootstrap'` as the very first statement of the entrypoint,

--- a/generated/monorepo-node-workspace/backend/src/bootstrap.ts
+++ b/generated/monorepo-node-workspace/backend/src/bootstrap.ts
@@ -1,3 +1,7 @@
+// Must run before any instrumented module is imported, otherwise
+// @opentelemetry/auto-instrumentations-node cannot patch them. Either
+// `import './bootstrap'` as the very first statement of the entrypoint,
+// or pre-load with `node --import` (ESM) / `--require` (CJS).
 import {
   initObservability,
   isObservabilityConfigured,

--- a/generated/monorepo-node-workspace/pnpm-workspace.yaml
+++ b/generated/monorepo-node-workspace/pnpm-workspace.yaml
@@ -5,6 +5,8 @@ packages:
 allowBuilds:
   # required by vitest's transformer
   esbuild: true
+  # required by @opentelemetry/exporter-trace-otlp-proto
+  protobufjs: true
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
 

--- a/generated/node/package.json
+++ b/generated/node/package.json
@@ -15,7 +15,7 @@
     "storybook:build": "storybook build"
   },
   "dependencies": {
-    "@fohte/service-kit": "0.1.0",
+    "@fohte/service-kit": "0.1.1",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.77.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",

--- a/generated/node/package.json
+++ b/generated/node/package.json
@@ -14,6 +14,18 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build"
   },
+  "dependencies": {
+    "@fohte/service-kit": "0.1.0",
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/auto-instrumentations-node": "0.77.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",
+    "@opentelemetry/resources": "2.8.0",
+    "@opentelemetry/sdk-node": "0.219.0",
+    "@opentelemetry/sdk-trace-base": "2.8.0",
+    "@opentelemetry/semantic-conventions": "1.41.1",
+    "@sentry/node": "10.57.0",
+    "@sentry/opentelemetry": "10.58.0"
+  },
   "devDependencies": {
     "@commitlint/cli": "21.0.2",
     "@eslint/eslintrc": "3.3.5",

--- a/generated/node/pnpm-workspace.yaml
+++ b/generated/node/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 allowBuilds:
   # required by vitest's transformer
   esbuild: true
+  # required by @opentelemetry/exporter-trace-otlp-proto
+  protobufjs: true
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
 

--- a/generated/node/src/bootstrap.ts
+++ b/generated/node/src/bootstrap.ts
@@ -1,3 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/strict-boolean-expressions --
+ * @fohte/service-kit ships .d.ts files that reference internal `@/...`
+ * path aliases unresolvable from consumer projects, so typescript-eslint
+ * sees these calls as untyped. tsc passes thanks to skipLibCheck.
+ */
 // Must run before any instrumented module is imported, otherwise
 // @opentelemetry/auto-instrumentations-node cannot patch them. Either
 // `import './bootstrap'` as the very first statement of the entrypoint,

--- a/generated/node/src/bootstrap.ts
+++ b/generated/node/src/bootstrap.ts
@@ -1,0 +1,8 @@
+import {
+  initObservability,
+  isObservabilityConfigured,
+} from '@fohte/service-kit/observability'
+
+if (isObservabilityConfigured(process.env)) {
+  initObservability(process.env)
+}

--- a/generated/node/src/bootstrap.ts
+++ b/generated/node/src/bootstrap.ts
@@ -1,8 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/strict-boolean-expressions --
- * @fohte/service-kit ships .d.ts files that reference internal `@/...`
- * path aliases unresolvable from consumer projects, so typescript-eslint
- * sees these calls as untyped. tsc passes thanks to skipLibCheck.
- */
 // Must run before any instrumented module is imported, otherwise
 // @opentelemetry/auto-instrumentations-node cannot patch them. Either
 // `import './bootstrap'` as the very first statement of the entrypoint,

--- a/generated/node/src/bootstrap.ts
+++ b/generated/node/src/bootstrap.ts
@@ -1,3 +1,7 @@
+// Must run before any instrumented module is imported, otherwise
+// @opentelemetry/auto-instrumentations-node cannot patch them. Either
+// `import './bootstrap'` as the very first statement of the entrypoint,
+// or pre-load with `node --import` (ESM) / `--require` (CJS).
 import {
   initObservability,
   isObservabilityConfigured,

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -1,4 +1,5 @@
 {%- set has_storybook = use_storybook | default(false) -%}
+{%- set root_is_web_app = (type == 'node' and is_web_app | default(false)) -%}
 {#- Root package.json is only emitted for `type == 'node'` or pnpm workspace
     setups. Non-workspace monorepos host prettier/commitlint via mise instead,
     so they never gain a root package.json (see copier.yml _exclude). -#}
@@ -31,6 +32,20 @@
     "storybook:build": "storybook build"
 {%- endif %}
   },
+{%- if root_is_web_app %}
+  "dependencies": {
+    "@fohte/service-kit": "0.1.0",
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/auto-instrumentations-node": "0.77.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",
+    "@opentelemetry/resources": "2.8.0",
+    "@opentelemetry/sdk-node": "0.219.0",
+    "@opentelemetry/sdk-trace-base": "2.8.0",
+    "@opentelemetry/semantic-conventions": "1.41.1",
+    "@sentry/node": "10.57.0",
+    "@sentry/opentelemetry": "10.58.0"
+  },
+{%- endif %}
   "devDependencies": {
     "@commitlint/cli": "21.0.2",
     "@eslint/eslintrc": "3.3.5",

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -34,7 +34,7 @@
   },
 {%- if root_is_web_app %}
   "dependencies": {
-    "@fohte/service-kit": "0.1.0",
+    "@fohte/service-kit": "0.1.1",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.77.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",

--- a/template/pnpm-workspace.yaml.jinja
+++ b/template/pnpm-workspace.yaml.jinja
@@ -8,6 +8,10 @@ packages:
 allowBuilds:
   # required by vitest's transformer
   esbuild: true
+{%- if has_web_app %}
+  # required by @opentelemetry/exporter-trace-otlp-proto
+  protobufjs: true
+{%- endif %}
   # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
   unrs-resolver: true
 

--- a/template/src/bootstrap.ts
+++ b/template/src/bootstrap.ts
@@ -1,8 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/strict-boolean-expressions --
- * @fohte/service-kit ships .d.ts files that reference internal `@/...`
- * path aliases unresolvable from consumer projects, so typescript-eslint
- * sees these calls as untyped. tsc passes thanks to skipLibCheck.
- */
 // Must run before any instrumented module is imported, otherwise
 // @opentelemetry/auto-instrumentations-node cannot patch them. Either
 // `import './bootstrap'` as the very first statement of the entrypoint,

--- a/template/src/bootstrap.ts.jinja
+++ b/template/src/bootstrap.ts.jinja
@@ -1,3 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/strict-boolean-expressions --
+ * @fohte/service-kit ships .d.ts files that reference internal `@/...`
+ * path aliases unresolvable from consumer projects, so typescript-eslint
+ * sees these calls as untyped. tsc passes thanks to skipLibCheck.
+ */
 // Must run before any instrumented module is imported, otherwise
 // @opentelemetry/auto-instrumentations-node cannot patch them. Either
 // `import './bootstrap'` as the very first statement of the entrypoint,

--- a/template/src/bootstrap.ts.jinja
+++ b/template/src/bootstrap.ts.jinja
@@ -1,0 +1,8 @@
+import {
+  initObservability,
+  isObservabilityConfigured,
+} from '@fohte/service-kit/observability'
+
+if (isObservabilityConfigured(process.env)) {
+  initObservability(process.env)
+}

--- a/template/src/bootstrap.ts.jinja
+++ b/template/src/bootstrap.ts.jinja
@@ -1,3 +1,7 @@
+// Must run before any instrumented module is imported, otherwise
+// @opentelemetry/auto-instrumentations-node cannot patch them. Either
+// `import './bootstrap'` as the very first statement of the entrypoint,
+// or pre-load with `node --import` (ESM) / `--require` (CJS).
 import {
   initObservability,
   isObservabilityConfigured,

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
@@ -1,5 +1,6 @@
 {%- set has_storybook = pkg.storybook | default(false) -%}
 {%- set has_tests = pkg.tests | default(true) -%}
+{%- set pkg_is_web_app = pkg.web_app | default(false) -%}
 {%- set has_scripts = has_tests or has_storybook -%}
 {%- set has_dev_deps = (has_tests and not is_workspace) or has_storybook -%}
 {
@@ -8,7 +9,7 @@
 {%- if not is_workspace %}
   "packageManager": "pnpm@11.7.0",
 {%- endif %}
-  "type": "module"{{ "," if has_scripts else "" }}
+  "type": "module"{{ "," if has_scripts or pkg_is_web_app else "" }}
 {%- if has_scripts %}
   "scripts": {
 {%- if has_tests and not is_workspace %}
@@ -26,6 +27,20 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build"
 {%- endif %}
+  }{{ "," if has_dev_deps or pkg_is_web_app else "" }}
+{%- endif %}
+{%- if pkg_is_web_app %}
+  "dependencies": {
+    "@fohte/service-kit": "0.1.0",
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/auto-instrumentations-node": "0.77.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",
+    "@opentelemetry/resources": "2.8.0",
+    "@opentelemetry/sdk-node": "0.219.0",
+    "@opentelemetry/sdk-trace-base": "2.8.0",
+    "@opentelemetry/semantic-conventions": "1.41.1",
+    "@sentry/node": "10.57.0",
+    "@sentry/opentelemetry": "10.58.0"
   }{{ "," if has_dev_deps else "" }}
 {%- endif %}
 {%- if has_tests and not is_workspace %}

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
@@ -34,7 +34,7 @@
 {%- endif %}
 {%- if pkg_is_web_app %}
   "dependencies": {
-    "@fohte/service-kit": "0.1.0",
+    "@fohte/service-kit": "0.1.1",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.77.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
@@ -1,6 +1,9 @@
 {%- set has_storybook = pkg.storybook | default(false) -%}
 {%- set has_tests = pkg.tests | default(true) -%}
-{%- set pkg_is_web_app = pkg.web_app | default(false) -%}
+{#- bootstrap.ts only emits when both web_app and tests are true (tests=false
+    collapses the src/ segment). Keep the dependency block on the same gate
+    so we never ship deps without the file that uses them. -#}
+{%- set pkg_is_web_app = (pkg.web_app | default(false)) and (pkg.tests | default(true)) -%}
 {%- set has_scripts = has_tests or has_storybook -%}
 {%- set has_dev_deps = (has_tests and not is_workspace) or has_storybook -%}
 {

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'rust' or (pkg.type == 'node' and pkg.tests | default(true)) %}src{% endif %}/{% if pkg.type == 'node' and pkg.web_app | default(false) and pkg.tests | default(true) %}bootstrap.ts{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'rust' or (pkg.type == 'node' and pkg.tests | default(true)) %}src{% endif %}/{% if pkg.type == 'node' and pkg.web_app | default(false) and pkg.tests | default(true) %}bootstrap.ts{% endif %}.jinja
@@ -1,0 +1,1 @@
+{% include "template/src/bootstrap.ts.jinja" -%}

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'rust' or (pkg.type == 'node' and pkg.tests | default(true)) %}src{% endif %}/{% if pkg.type == 'node' and pkg.web_app | default(false) and pkg.tests | default(true) %}bootstrap.ts{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'rust' or (pkg.type == 'node' and pkg.tests | default(true)) %}src{% endif %}/{% if pkg.type == 'node' and pkg.web_app | default(false) and pkg.tests | default(true) %}bootstrap.ts{% endif %}.jinja
@@ -1,1 +1,1 @@
-{% include "template/src/bootstrap.ts.jinja" -%}
+{% include "template/src/bootstrap.ts" -%}

--- a/tests/fixtures/monorepo-node-workspace.yml
+++ b/tests/fixtures/monorepo-node-workspace.yml
@@ -11,4 +11,5 @@ subpackages:
     storybook: true
   - name: backend
     type: node
+    web_app: true
 repo_language: ja

--- a/tests/fixtures/node.yml
+++ b/tests/fixtures/node.yml
@@ -7,6 +7,6 @@ description: Test Node.js project description
 is_public: false
 use_release_please: false
 use_storybook: true
-is_web_app: false
+is_web_app: true
 repo_language: ja
 subpackages: []


### PR DESCRIPTION
## Purpose

- Make repositories generated with `is_web_app` or a `web_app: true` subpackage able to emit OTel spans / Sentry error events just by setting env vars

## Approach

- Emit a thin `src/bootstrap.ts` that calls `@fohte/service-kit/observability` along with the required OTel / Sentry dependencies
