### PR TITLE
fix(copier): correct _migrations command syntax to unblock copier update

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -6,7 +6,7 @@ _answers_file: .copier-answers.yml
 _migrations:
   - version: '0.8.10'
     before:
-      - command: rm -f .github/workflows/renovate-copier.yml
+      - rm -f .github/workflows/renovate-copier.yml
 
 type:
   type: str


### PR DESCRIPTION
## Purpose

- Renovate's copier update is broken

## Approach

- Drop the `command:` key from `_migrations[0].before[0]` and make `rm -f ...` the list element itself
