### PR TITLE
fix(template): skip no-op PR creation when the template version is unchanged

### DIFF
--- a/.github/workflows/boilerplate-update.yml
+++ b/.github/workflows/boilerplate-update.yml
@@ -59,14 +59,23 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
-      - name: Check whether the template version actually changed
-        id: version-changed
+      - name: Determine whether to proceed with a PR
+        id: should-update
         env:
+          CHANGED: ${{ steps.copier-update.outputs.changed }}
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          # Only set when workflow_dispatch explicitly pins a target version.
+          MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
         run: |
           set -euo pipefail
-          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${CHANGED}" != "true" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # copier-update-action's `changed` output reflects any diff (e.g. YAML
+            # quote-style drift), not whether the template version itself moved.
+            # Skip the no-op case for scheduled/latest-release runs; an explicit
+            # manual target-version means the caller wants to re-apply regardless.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -74,14 +83,14 @@ jobs:
           fi
 
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -95,7 +104,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -105,7 +114,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -124,7 +133,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/.github/workflows/boilerplate-update.yml
+++ b/.github/workflows/boilerplate-update.yml
@@ -59,15 +59,29 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
+      - name: Check whether the template version actually changed
+        id: version-changed
+        env:
+          FROM_VERSION: ${{ steps.current-version.outputs.version }}
+          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+        run: |
+          set -euo pipefail
+          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -81,7 +95,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -91,7 +105,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -110,7 +124,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -59,14 +59,23 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
-      - name: Check whether the template version actually changed
-        id: version-changed
+      - name: Determine whether to proceed with a PR
+        id: should-update
         env:
+          CHANGED: ${{ steps.copier-update.outputs.changed }}
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          # Only set when workflow_dispatch explicitly pins a target version.
+          MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
         run: |
           set -euo pipefail
-          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${CHANGED}" != "true" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # copier-update-action's `changed` output reflects any diff (e.g. YAML
+            # quote-style drift), not whether the template version itself moved.
+            # Skip the no-op case for scheduled/latest-release runs; an explicit
+            # manual target-version means the caller wants to re-apply regardless.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -74,14 +83,14 @@ jobs:
           fi
 
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -95,7 +104,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -105,7 +114,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -124,7 +133,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -59,15 +59,29 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
+      - name: Check whether the template version actually changed
+        id: version-changed
+        env:
+          FROM_VERSION: ${{ steps.current-version.outputs.version }}
+          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+        run: |
+          set -euo pipefail
+          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -81,7 +95,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -91,7 +105,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -110,7 +124,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -59,14 +59,23 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
-      - name: Check whether the template version actually changed
-        id: version-changed
+      - name: Determine whether to proceed with a PR
+        id: should-update
         env:
+          CHANGED: ${{ steps.copier-update.outputs.changed }}
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          # Only set when workflow_dispatch explicitly pins a target version.
+          MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
         run: |
           set -euo pipefail
-          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${CHANGED}" != "true" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # copier-update-action's `changed` output reflects any diff (e.g. YAML
+            # quote-style drift), not whether the template version itself moved.
+            # Skip the no-op case for scheduled/latest-release runs; an explicit
+            # manual target-version means the caller wants to re-apply regardless.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -74,14 +83,14 @@ jobs:
           fi
 
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -95,7 +104,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -105,7 +114,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -124,7 +133,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -59,15 +59,29 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
+      - name: Check whether the template version actually changed
+        id: version-changed
+        env:
+          FROM_VERSION: ${{ steps.current-version.outputs.version }}
+          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+        run: |
+          set -euo pipefail
+          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -81,7 +95,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -91,7 +105,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -110,7 +124,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -59,14 +59,23 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
-      - name: Check whether the template version actually changed
-        id: version-changed
+      - name: Determine whether to proceed with a PR
+        id: should-update
         env:
+          CHANGED: ${{ steps.copier-update.outputs.changed }}
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          # Only set when workflow_dispatch explicitly pins a target version.
+          MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
         run: |
           set -euo pipefail
-          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${CHANGED}" != "true" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # copier-update-action's `changed` output reflects any diff (e.g. YAML
+            # quote-style drift), not whether the template version itself moved.
+            # Skip the no-op case for scheduled/latest-release runs; an explicit
+            # manual target-version means the caller wants to re-apply regardless.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -74,14 +83,14 @@ jobs:
           fi
 
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -95,7 +104,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -105,7 +114,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -124,7 +133,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -59,15 +59,29 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
+      - name: Check whether the template version actually changed
+        id: version-changed
+        env:
+          FROM_VERSION: ${{ steps.current-version.outputs.version }}
+          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+        run: |
+          set -euo pipefail
+          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -81,7 +95,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -91,7 +105,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -110,7 +124,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -59,14 +59,23 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
-      - name: Check whether the template version actually changed
-        id: version-changed
+      - name: Determine whether to proceed with a PR
+        id: should-update
         env:
+          CHANGED: ${{ steps.copier-update.outputs.changed }}
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          # Only set when workflow_dispatch explicitly pins a target version.
+          MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
         run: |
           set -euo pipefail
-          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${CHANGED}" != "true" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # copier-update-action's `changed` output reflects any diff (e.g. YAML
+            # quote-style drift), not whether the template version itself moved.
+            # Skip the no-op case for scheduled/latest-release runs; an explicit
+            # manual target-version means the caller wants to re-apply regardless.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -74,14 +83,14 @@ jobs:
           fi
 
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -95,7 +104,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -105,7 +114,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -124,7 +133,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -59,15 +59,29 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
+      - name: Check whether the template version actually changed
+        id: version-changed
+        env:
+          FROM_VERSION: ${{ steps.current-version.outputs.version }}
+          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+        run: |
+          set -euo pipefail
+          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -81,7 +95,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -91,7 +105,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -110,7 +124,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -59,14 +59,23 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
-      - name: Check whether the template version actually changed
-        id: version-changed
+      - name: Determine whether to proceed with a PR
+        id: should-update
         env:
+          CHANGED: ${{ steps.copier-update.outputs.changed }}
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          # Only set when workflow_dispatch explicitly pins a target version.
+          MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
         run: |
           set -euo pipefail
-          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${CHANGED}" != "true" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # copier-update-action's `changed` output reflects any diff (e.g. YAML
+            # quote-style drift), not whether the template version itself moved.
+            # Skip the no-op case for scheduled/latest-release runs; an explicit
+            # manual target-version means the caller wants to re-apply regardless.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -74,14 +83,14 @@ jobs:
           fi
 
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -95,7 +104,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -105,7 +114,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -124,7 +133,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -59,15 +59,29 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
+      - name: Check whether the template version actually changed
+        id: version-changed
+        env:
+          FROM_VERSION: ${{ steps.current-version.outputs.version }}
+          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+        run: |
+          set -euo pipefail
+          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -81,7 +95,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -91,7 +105,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -110,7 +124,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -59,14 +59,23 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
-      - name: Check whether the template version actually changed
-        id: version-changed
+      - name: Determine whether to proceed with a PR
+        id: should-update
         env:
+          CHANGED: ${{ steps.copier-update.outputs.changed }}
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          # Only set when workflow_dispatch explicitly pins a target version.
+          MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
         run: |
           set -euo pipefail
-          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${CHANGED}" != "true" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # copier-update-action's `changed` output reflects any diff (e.g. YAML
+            # quote-style drift), not whether the template version itself moved.
+            # Skip the no-op case for scheduled/latest-release runs; an explicit
+            # manual target-version means the caller wants to re-apply regardless.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -74,14 +83,14 @@ jobs:
           fi
 
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -95,7 +104,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -105,7 +114,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -124,7 +133,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -59,15 +59,29 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
+      - name: Check whether the template version actually changed
+        id: version-changed
+        env:
+          FROM_VERSION: ${{ steps.current-version.outputs.version }}
+          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+        run: |
+          set -euo pipefail
+          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -81,7 +95,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -91,7 +105,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -110,7 +124,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -59,14 +59,23 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
-      - name: Check whether the template version actually changed
-        id: version-changed
+      - name: Determine whether to proceed with a PR
+        id: should-update
         env:
+          CHANGED: ${{ steps.copier-update.outputs.changed }}
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          # Only set when workflow_dispatch explicitly pins a target version.
+          MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
         run: |
           set -euo pipefail
-          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${CHANGED}" != "true" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # copier-update-action's `changed` output reflects any diff (e.g. YAML
+            # quote-style drift), not whether the template version itself moved.
+            # Skip the no-op case for scheduled/latest-release runs; an explicit
+            # manual target-version means the caller wants to re-apply regardless.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -74,14 +83,14 @@ jobs:
           fi
 
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -95,7 +104,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -105,7 +114,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -124,7 +133,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -59,15 +59,29 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
+      - name: Check whether the template version actually changed
+        id: version-changed
+        env:
+          FROM_VERSION: ${{ steps.current-version.outputs.version }}
+          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+        run: |
+          set -euo pipefail
+          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -81,7 +95,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -91,7 +105,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -110,7 +124,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -59,14 +59,23 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
-      - name: Check whether the template version actually changed
-        id: version-changed
+      - name: Determine whether to proceed with a PR
+        id: should-update
         env:
+          CHANGED: ${{ steps.copier-update.outputs.changed }}
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          # Only set when workflow_dispatch explicitly pins a target version.
+          MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
         run: |
           set -euo pipefail
-          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${CHANGED}" != "true" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # copier-update-action's `changed` output reflects any diff (e.g. YAML
+            # quote-style drift), not whether the template version itself moved.
+            # Skip the no-op case for scheduled/latest-release runs; an explicit
+            # manual target-version means the caller wants to re-apply regardless.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -74,14 +83,14 @@ jobs:
           fi
 
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -95,7 +104,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -105,7 +114,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -124,7 +133,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -59,15 +59,29 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
+      - name: Check whether the template version actually changed
+        id: version-changed
+        env:
+          FROM_VERSION: ${{ steps.current-version.outputs.version }}
+          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+        run: |
+          set -euo pipefail
+          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -81,7 +95,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -91,7 +105,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -110,7 +124,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -59,14 +59,23 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
-      - name: Check whether the template version actually changed
-        id: version-changed
+      - name: Determine whether to proceed with a PR
+        id: should-update
         env:
+          CHANGED: ${{ steps.copier-update.outputs.changed }}
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          # Only set when workflow_dispatch explicitly pins a target version.
+          MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
         run: |
           set -euo pipefail
-          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${CHANGED}" != "true" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # copier-update-action's `changed` output reflects any diff (e.g. YAML
+            # quote-style drift), not whether the template version itself moved.
+            # Skip the no-op case for scheduled/latest-release runs; an explicit
+            # manual target-version means the caller wants to re-apply regardless.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -74,14 +83,14 @@ jobs:
           fi
 
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -95,7 +104,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -105,7 +114,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -124,7 +133,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -59,15 +59,29 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
+      - name: Check whether the template version actually changed
+        id: version-changed
+        env:
+          FROM_VERSION: ${{ steps.current-version.outputs.version }}
+          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+        run: |
+          set -euo pipefail
+          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -81,7 +95,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -91,7 +105,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -110,7 +124,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -59,14 +59,23 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
-      - name: Check whether the template version actually changed
-        id: version-changed
+      - name: Determine whether to proceed with a PR
+        id: should-update
         env:
+          CHANGED: ${{ steps.copier-update.outputs.changed }}
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          # Only set when workflow_dispatch explicitly pins a target version.
+          MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
         run: |
           set -euo pipefail
-          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${CHANGED}" != "true" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # copier-update-action's `changed` output reflects any diff (e.g. YAML
+            # quote-style drift), not whether the template version itself moved.
+            # Skip the no-op case for scheduled/latest-release runs; an explicit
+            # manual target-version means the caller wants to re-apply regardless.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -74,14 +83,14 @@ jobs:
           fi
 
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -95,7 +104,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -105,7 +114,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -124,7 +133,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
+        if: steps.should-update.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -59,15 +59,29 @@ jobs:
           target-version: ${{ github.event.inputs.target-version }}
           github-token: ${{ steps.octo-sts.outputs.token }}
 
+      - name: Check whether the template version actually changed
+        id: version-changed
+        env:
+          FROM_VERSION: ${{ steps.current-version.outputs.version }}
+          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+        run: |
+          set -euo pipefail
+          if [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Restore executable bit on scripts/bootstrap
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         run: |
           if [ -f scripts/bootstrap ]; then
             chmod +x scripts/bootstrap
           fi
 
       - name: Create branch
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: branch
         env:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
@@ -81,7 +95,7 @@ jobs:
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         id: title
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
@@ -91,7 +105,7 @@ jobs:
           echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push changes
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
@@ -110,7 +124,7 @@ jobs:
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request
-        if: steps.copier-update.outputs.changed == 'true'
+        if: steps.copier-update.outputs.changed == 'true' && steps.version-changed.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TITLE: ${{ steps.title.outputs.value }}


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/fohte.net/pull/505
- The `boilerplate-update` workflow creates and auto-merges a meaningless PR even when the template version hasn't changed
    - It gets created with a title like `chore: update fohte/generic-boilerplate from v0.8.11 to v0.8.11` showing zero version change, and merges with zero diff

### Reproduction steps

1. Run the `boilerplate-update` workflow while `.copier-answers.yml` already points at the template's latest version
2. [`copier-update-action`](https://github.com/fohte/copier-update-action/blob/6bfc176a40a84743b18bcad41d36d3c4e8fff79d/action.yml) returns `changed=true` from YAML serialization drift alone (e.g. quote style) in `.copier-answers.yml`, with no actual template change
    - its `changed` output
      > `'true'` if there are tracked-file diffs after the update, `'false'` otherwise. Based on the exit code of `git diff --quiet HEAD --`.
      only looks at tracked-file diffs, not whether the version changed
3. A PR gets created even though the version string is identical before and after

## Approach

- Compare the version string before and after the update in addition to the `changed` output, and skip the PR-creation flow from branch creation onward when they match
- Exempt manual runs that pin an explicit `target-version` via `workflow_dispatch` from this comparison, so an intentional re-apply of the same version still creates a PR

<details>
<summary>Design decisions</summary>

#### Scope of the version-match check

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen | Apply the version-match check only to scheduled runs and manual runs without an explicit `target-version` | Doesn't block an intentional re-apply of the same version (e.g. re-syncing files that drifted locally from the template) | Adds a branching condition |
| Rejected | Gate solely on version equality, always | Simpler implementation | Blocks even a legitimate manual re-apply pinned to the same version |

</details>
