### PR TITLE
fix(template): use a fixed branch name for boilerplate-update

### DIFF
--- a/.claude/skills/update-boilerplate-prs/SKILL.md
+++ b/.claude/skills/update-boilerplate-prs/SKILL.md
@@ -155,7 +155,7 @@ gh pr view <number> -R fohte/<repo> --json headRefName -q .headRefName
 Use the fetched value directly as the branch name. The existing remote branch will be checked out automatically.
 
 ```bash
-a wm new copier-update/v0.8.9 -R ~/ghq/github.com/fohte/<repo> --agent --label "..." --prompt "..."
+a wm new copier-update/generic-boilerplate -R ~/ghq/github.com/fohte/<repo> --agent --label "..." --prompt "..."
 ```
 
 **Do NOT invent a new branch name** like `copier-update-foo-boilerplate`. **Do NOT add `--from`** -- the branch already exists on the remote.

--- a/.github/workflows/boilerplate-update.yml
+++ b/.github/workflows/boilerplate-update.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch
-        env:
-          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
         run: |
           set -euo pipefail
-          branch="copier-update/${TARGET_VERSION}"
+          # Fixed per template repo (not per version) so repeated runs reuse the
+          # same branch/PR instead of piling up one per target version.
+          branch="copier-update/${TEMPLATE_REPO#*/}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
@@ -124,12 +124,12 @@ jobs:
               -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
               commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
-          # Without this, commits on an existing copier-update/<version> branch accumulate and
-          # the PR drifts from the default branch.
+          # Without this, commits on the branch (fixed per template repo, reused across
+          # versions) accumulate and the PR drifts from the default branch.
           #
           # --force (not --force-with-lease): actions/checkout does not populate
           # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
-          # would reject with "stale info" on the second run for the same target version.
+          # would reject with "stale info" on a later run against the same branch.
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request

--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch
-        env:
-          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
         run: |
           set -euo pipefail
-          branch="copier-update/${TARGET_VERSION}"
+          # Fixed per template repo (not per version) so repeated runs reuse the
+          # same branch/PR instead of piling up one per target version.
+          branch="copier-update/${TEMPLATE_REPO#*/}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
@@ -124,12 +124,12 @@ jobs:
               -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
               commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
-          # Without this, commits on an existing copier-update/<version> branch accumulate and
-          # the PR drifts from the default branch.
+          # Without this, commits on the branch (fixed per template repo, reused across
+          # versions) accumulate and the PR drifts from the default branch.
           #
           # --force (not --force-with-lease): actions/checkout does not populate
           # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
-          # would reject with "stale info" on the second run for the same target version.
+          # would reject with "stale info" on a later run against the same branch.
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch
-        env:
-          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
         run: |
           set -euo pipefail
-          branch="copier-update/${TARGET_VERSION}"
+          # Fixed per template repo (not per version) so repeated runs reuse the
+          # same branch/PR instead of piling up one per target version.
+          branch="copier-update/${TEMPLATE_REPO#*/}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
@@ -124,12 +124,12 @@ jobs:
               -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
               commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
-          # Without this, commits on an existing copier-update/<version> branch accumulate and
-          # the PR drifts from the default branch.
+          # Without this, commits on the branch (fixed per template repo, reused across
+          # versions) accumulate and the PR drifts from the default branch.
           #
           # --force (not --force-with-lease): actions/checkout does not populate
           # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
-          # would reject with "stale info" on the second run for the same target version.
+          # would reject with "stale info" on a later run against the same branch.
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch
-        env:
-          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
         run: |
           set -euo pipefail
-          branch="copier-update/${TARGET_VERSION}"
+          # Fixed per template repo (not per version) so repeated runs reuse the
+          # same branch/PR instead of piling up one per target version.
+          branch="copier-update/${TEMPLATE_REPO#*/}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
@@ -124,12 +124,12 @@ jobs:
               -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
               commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
-          # Without this, commits on an existing copier-update/<version> branch accumulate and
-          # the PR drifts from the default branch.
+          # Without this, commits on the branch (fixed per template repo, reused across
+          # versions) accumulate and the PR drifts from the default branch.
           #
           # --force (not --force-with-lease): actions/checkout does not populate
           # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
-          # would reject with "stale info" on the second run for the same target version.
+          # would reject with "stale info" on a later run against the same branch.
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch
-        env:
-          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
         run: |
           set -euo pipefail
-          branch="copier-update/${TARGET_VERSION}"
+          # Fixed per template repo (not per version) so repeated runs reuse the
+          # same branch/PR instead of piling up one per target version.
+          branch="copier-update/${TEMPLATE_REPO#*/}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
@@ -124,12 +124,12 @@ jobs:
               -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
               commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
-          # Without this, commits on an existing copier-update/<version> branch accumulate and
-          # the PR drifts from the default branch.
+          # Without this, commits on the branch (fixed per template repo, reused across
+          # versions) accumulate and the PR drifts from the default branch.
           #
           # --force (not --force-with-lease): actions/checkout does not populate
           # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
-          # would reject with "stale info" on the second run for the same target version.
+          # would reject with "stale info" on a later run against the same branch.
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch
-        env:
-          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
         run: |
           set -euo pipefail
-          branch="copier-update/${TARGET_VERSION}"
+          # Fixed per template repo (not per version) so repeated runs reuse the
+          # same branch/PR instead of piling up one per target version.
+          branch="copier-update/${TEMPLATE_REPO#*/}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
@@ -124,12 +124,12 @@ jobs:
               -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
               commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
-          # Without this, commits on an existing copier-update/<version> branch accumulate and
-          # the PR drifts from the default branch.
+          # Without this, commits on the branch (fixed per template repo, reused across
+          # versions) accumulate and the PR drifts from the default branch.
           #
           # --force (not --force-with-lease): actions/checkout does not populate
           # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
-          # would reject with "stale info" on the second run for the same target version.
+          # would reject with "stale info" on a later run against the same branch.
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch
-        env:
-          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
         run: |
           set -euo pipefail
-          branch="copier-update/${TARGET_VERSION}"
+          # Fixed per template repo (not per version) so repeated runs reuse the
+          # same branch/PR instead of piling up one per target version.
+          branch="copier-update/${TEMPLATE_REPO#*/}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
@@ -124,12 +124,12 @@ jobs:
               -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
               commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
-          # Without this, commits on an existing copier-update/<version> branch accumulate and
-          # the PR drifts from the default branch.
+          # Without this, commits on the branch (fixed per template repo, reused across
+          # versions) accumulate and the PR drifts from the default branch.
           #
           # --force (not --force-with-lease): actions/checkout does not populate
           # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
-          # would reject with "stale info" on the second run for the same target version.
+          # would reject with "stale info" on a later run against the same branch.
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch
-        env:
-          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
         run: |
           set -euo pipefail
-          branch="copier-update/${TARGET_VERSION}"
+          # Fixed per template repo (not per version) so repeated runs reuse the
+          # same branch/PR instead of piling up one per target version.
+          branch="copier-update/${TEMPLATE_REPO#*/}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
@@ -124,12 +124,12 @@ jobs:
               -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
               commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
-          # Without this, commits on an existing copier-update/<version> branch accumulate and
-          # the PR drifts from the default branch.
+          # Without this, commits on the branch (fixed per template repo, reused across
+          # versions) accumulate and the PR drifts from the default branch.
           #
           # --force (not --force-with-lease): actions/checkout does not populate
           # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
-          # would reject with "stale info" on the second run for the same target version.
+          # would reject with "stale info" on a later run against the same branch.
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch
-        env:
-          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
         run: |
           set -euo pipefail
-          branch="copier-update/${TARGET_VERSION}"
+          # Fixed per template repo (not per version) so repeated runs reuse the
+          # same branch/PR instead of piling up one per target version.
+          branch="copier-update/${TEMPLATE_REPO#*/}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
@@ -124,12 +124,12 @@ jobs:
               -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
               commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
-          # Without this, commits on an existing copier-update/<version> branch accumulate and
-          # the PR drifts from the default branch.
+          # Without this, commits on the branch (fixed per template repo, reused across
+          # versions) accumulate and the PR drifts from the default branch.
           #
           # --force (not --force-with-lease): actions/checkout does not populate
           # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
-          # would reject with "stale info" on the second run for the same target version.
+          # would reject with "stale info" on a later run against the same branch.
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch
-        env:
-          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
         run: |
           set -euo pipefail
-          branch="copier-update/${TARGET_VERSION}"
+          # Fixed per template repo (not per version) so repeated runs reuse the
+          # same branch/PR instead of piling up one per target version.
+          branch="copier-update/${TEMPLATE_REPO#*/}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
@@ -124,12 +124,12 @@ jobs:
               -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
               commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
-          # Without this, commits on an existing copier-update/<version> branch accumulate and
-          # the PR drifts from the default branch.
+          # Without this, commits on the branch (fixed per template repo, reused across
+          # versions) accumulate and the PR drifts from the default branch.
           #
           # --force (not --force-with-lease): actions/checkout does not populate
           # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
-          # would reject with "stale info" on the second run for the same target version.
+          # would reject with "stale info" on a later run against the same branch.
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch
-        env:
-          TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
         run: |
           set -euo pipefail
-          branch="copier-update/${TARGET_VERSION}"
+          # Fixed per template repo (not per version) so repeated runs reuse the
+          # same branch/PR instead of piling up one per target version.
+          branch="copier-update/${TEMPLATE_REPO#*/}"
           echo "name=${branch}" >> "$GITHUB_OUTPUT"
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
@@ -124,12 +124,12 @@ jobs:
               -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
               commit -m "${COMMIT_MESSAGE}"
           # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
-          # Without this, commits on an existing copier-update/<version> branch accumulate and
-          # the PR drifts from the default branch.
+          # Without this, commits on the branch (fixed per template repo, reused across
+          # versions) accumulate and the PR drifts from the default branch.
           #
           # --force (not --force-with-lease): actions/checkout does not populate
           # refs/remotes/origin/<branch> for non-checked-out branches, so --force-with-lease
-          # would reject with "stale info" on the second run for the same target version.
+          # would reject with "stale info" on a later run against the same branch.
           git push --force origin "${BRANCH}"
 
       - name: Create or update pull request


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/copier-update-action/pull/27, https://github.com/fohte/copier-update-action/pull/28
- The `boilerplate-update` workflow creates a new branch and PR every time the template releases a new version, so update PRs pile up on the same repository instead of being reused

## Approach

- Make the branch name independent of the template version by fixing it to include the template repository name
    - The same branch keeps getting force-pushed, so the existing PR lookup/update logic keeps targeting the same PR

<details>
<summary>Design decisions</summary>

#### What to include in the branch name

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen   | Use only the repo name from `TEMPLATE_REPO` with the owner stripped (`copier-update/generic-boilerplate`) | Stays unique even if multiple template repos are handled in the future, without the confusion of an extra `/` | Could collide if repos with the same name but different owners are handled in the future |
| Rejected | Use `TEMPLATE_REPO` (owner/repo) as-is for the branch name (`copier-update/fohte/generic-boilerplate`) | Simpler to implement | The branch name ends up with a doubled `/`, easy to confuse with a path hierarchy |

</details>
