### PR TITLE
feat(template): add CLAUDE.md file-splitting rule

### DIFF
--- a/generated/monorepo-node-workspace/CLAUDE.md
+++ b/generated/monorepo-node-workspace/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Split files before they grow past ~500 lines of production code
 
-When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. `index.ts` re-exports). Tests move together with the code they verify.
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by keeping the entrypoint file in place and re-exporting the pieces you split out into new files (e.g. `index.ts` re-exports from the new files). Tests move together with the code they verify.
 
 Prefer creating a new focused file over appending to the largest existing one.
 

--- a/generated/monorepo-node-workspace/CLAUDE.md
+++ b/generated/monorepo-node-workspace/CLAUDE.md
@@ -1,5 +1,13 @@
 # CLAUDE.md
 
+## Code organization rules
+
+### Split files before they grow past ~500 lines of production code
+
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. `index.ts` re-exports). Tests move together with the code they verify.
+
+Prefer creating a new focused file over appending to the largest existing one.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/generated/monorepo/CLAUDE.md
+++ b/generated/monorepo/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Split files before they grow past ~500 lines of production code
 
-When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. `foo.rs` → `foo/mod.rs`, `index.ts` re-exports). Tests move together with the code they verify.
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by keeping the entrypoint file in place and re-exporting the pieces you split out into new files (e.g. `foo.rs` gains a `foo/` directory for its submodules, `index.ts` re-exports from the new files). Tests move together with the code they verify.
 
 Prefer creating a new focused file over appending to the largest existing one.
 

--- a/generated/monorepo/CLAUDE.md
+++ b/generated/monorepo/CLAUDE.md
@@ -1,5 +1,13 @@
 # CLAUDE.md
 
+## Code organization rules
+
+### Split files before they grow past ~500 lines of production code
+
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. `foo.rs` → `foo/mod.rs`, `index.ts` re-exports). Tests move together with the code they verify.
+
+Prefer creating a new focused file over appending to the largest existing one.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/generated/node/CLAUDE.md
+++ b/generated/node/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Split files before they grow past ~500 lines of production code
 
-When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. `index.ts` re-exports). Tests move together with the code they verify.
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by keeping the entrypoint file in place and re-exporting the pieces you split out into new files (e.g. `index.ts` re-exports from the new files). Tests move together with the code they verify.
 
 Prefer creating a new focused file over appending to the largest existing one.
 

--- a/generated/node/CLAUDE.md
+++ b/generated/node/CLAUDE.md
@@ -1,5 +1,13 @@
 # CLAUDE.md
 
+## Code organization rules
+
+### Split files before they grow past ~500 lines of production code
+
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. `index.ts` re-exports). Tests move together with the code they verify.
+
+Prefer creating a new focused file over appending to the largest existing one.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/generated/rust-release/CLAUDE.md
+++ b/generated/rust-release/CLAUDE.md
@@ -1,5 +1,13 @@
 # CLAUDE.md
 
+## Code organization rules
+
+### Split files before they grow past ~500 lines of production code
+
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. `foo.rs` → `foo/mod.rs`). Tests move together with the code they verify.
+
+Prefer creating a new focused file over appending to the largest existing one.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/generated/rust-release/CLAUDE.md
+++ b/generated/rust-release/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Split files before they grow past ~500 lines of production code
 
-When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. `foo.rs` → `foo/mod.rs`). Tests move together with the code they verify.
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by keeping the entrypoint file in place and re-exporting the pieces you split out into new files (e.g. `foo.rs` gains a `foo/` directory for its submodules). Tests move together with the code they verify.
 
 Prefer creating a new focused file over appending to the largest existing one.
 

--- a/generated/rust-with-node-subpackage/CLAUDE.md
+++ b/generated/rust-with-node-subpackage/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Split files before they grow past ~500 lines of production code
 
-When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. `foo.rs` → `foo/mod.rs`, `index.ts` re-exports). Tests move together with the code they verify.
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by keeping the entrypoint file in place and re-exporting the pieces you split out into new files (e.g. `foo.rs` gains a `foo/` directory for its submodules, `index.ts` re-exports from the new files). Tests move together with the code they verify.
 
 Prefer creating a new focused file over appending to the largest existing one.
 

--- a/generated/rust-with-node-subpackage/CLAUDE.md
+++ b/generated/rust-with-node-subpackage/CLAUDE.md
@@ -1,5 +1,13 @@
 # CLAUDE.md
 
+## Code organization rules
+
+### Split files before they grow past ~500 lines of production code
+
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. `foo.rs` → `foo/mod.rs`, `index.ts` re-exports). Tests move together with the code they verify.
+
+Prefer creating a new focused file over appending to the largest existing one.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/generated/rust/CLAUDE.md
+++ b/generated/rust/CLAUDE.md
@@ -1,5 +1,13 @@
 # CLAUDE.md
 
+## Code organization rules
+
+### Split files before they grow past ~500 lines of production code
+
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. `foo.rs` → `foo/mod.rs`). Tests move together with the code they verify.
+
+Prefer creating a new focused file over appending to the largest existing one.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/generated/rust/CLAUDE.md
+++ b/generated/rust/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Split files before they grow past ~500 lines of production code
 
-When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. `foo.rs` → `foo/mod.rs`). Tests move together with the code they verify.
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by keeping the entrypoint file in place and re-exporting the pieces you split out into new files (e.g. `foo.rs` gains a `foo/` directory for its submodules). Tests move together with the code they verify.
 
 Prefer creating a new focused file over appending to the largest existing one.
 

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -1,5 +1,13 @@
 # CLAUDE.md
 
+## Code organization rules
+
+### Split files before they grow past ~500 lines of production code
+
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. {% if has_rust %}`foo.rs` → `foo/mod.rs`{% endif %}{% if has_rust and has_node %}, {% endif %}{% if has_node %}`index.ts` re-exports{% endif %}). Tests move together with the code they verify.
+
+Prefer creating a new focused file over appending to the largest existing one.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -4,7 +4,7 @@
 
 ### Split files before they grow past ~500 lines of production code
 
-When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. {% if has_rust and has_node %}`foo.rs` → `foo/mod.rs`, `index.ts` re-exports{% elif has_rust %}`foo.rs` → `foo/mod.rs`{% else %}`index.ts` re-exports{% endif %}). Tests move together with the code they verify.
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by keeping the entrypoint file in place and re-exporting the pieces you split out into new files (e.g. {% if has_rust and has_node %}`foo.rs` gains a `foo/` directory for its submodules, `index.ts` re-exports from the new files{% elif has_rust %}`foo.rs` gains a `foo/` directory for its submodules{% else %}`index.ts` re-exports from the new files{% endif %}). Tests move together with the code they verify.
 
 Prefer creating a new focused file over appending to the largest existing one.
 

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -4,7 +4,7 @@
 
 ### Split files before they grow past ~500 lines of production code
 
-When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. {% if has_rust %}`foo.rs` → `foo/mod.rs`{% endif %}{% if has_rust and has_node %}, {% endif %}{% if has_node %}`index.ts` re-exports{% endif %}). Tests move together with the code they verify.
+When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by converting the file into a directory module that re-exports its contents (e.g. {% if has_rust and has_node %}`foo.rs` → `foo/mod.rs`, `index.ts` re-exports{% elif has_rust %}`foo.rs` → `foo/mod.rs`{% else %}`index.ts` re-exports{% endif %}). Tests move together with the code they verify.
 
 Prefer creating a new focused file over appending to the largest existing one.
 


### PR DESCRIPTION
## Purpose

- Prevent files in derived repositories from growing large while mixing multiple responsibilities, which hurts readability

## Approach

- Add a rule to `template/CLAUDE.md.jinja` for splitting large files by responsibility, and distribute it to every derived repository that generates a CLAUDE.md
