### PR TITLE
fix(template): don't enable auto-merge on PRs that can't merge cleanly

### DIFF
--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -183,8 +183,30 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
-          if [ -z "${UNRESOLVED_FILES}" ]; then
-            if OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+          if [ -n "${UNRESOLVED_FILES}" ]; then
+            # Unresolved copier conflicts already keep the PR in draft (see above).
+            # Disable auto-merge too, in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          else
+            # `unresolved-files` only reflects copier's own 3-way merge; it says
+            # nothing about whether this branch can still merge into the base
+            # branch. GitHub computes mergeability asynchronously and reports it
+            # as "UNKNOWN" for a few seconds after a push, so poll for a
+            # definite answer before trusting it.
+            mergeable=UNKNOWN
+            for _ in $(seq 1 10); do
+              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
+              if [ "${mergeable}" != "UNKNOWN" ]; then
+                break
+              fi
+              sleep 2
+            done
+
+            if [ "${mergeable}" != "MERGEABLE" ]; then
+              echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
+              gh pr merge --disable-auto "${pr_url}" || true
+            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
               echo "$OUTPUT"
             elif echo "$OUTPUT" | grep -q "clean status"; then
               echo "$OUTPUT"

--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -183,39 +183,47 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
+          # `unresolved-files` only reflects copier's own 3-way merge; it says
+          # nothing about whether this branch can still merge into the base
+          # branch. GitHub computes mergeability asynchronously and reports it
+          # as "UNKNOWN" for a few seconds after a push, so poll for a
+          # definite answer before trusting it. A transient `gh pr view`
+          # failure is treated the same as an "UNKNOWN" reading and retried,
+          # rather than aborting the step outright.
+          should_disable_auto=false
           if [ -n "${UNRESOLVED_FILES}" ]; then
-            # Unresolved copier conflicts already keep the PR in draft (see above).
-            # Disable auto-merge too, in case a conflict-free earlier run of this
-            # same reused branch had already armed it.
-            gh pr merge --disable-auto "${pr_url}" || true
+            should_disable_auto=true
           else
-            # `unresolved-files` only reflects copier's own 3-way merge; it says
-            # nothing about whether this branch can still merge into the base
-            # branch. GitHub computes mergeability asynchronously and reports it
-            # as "UNKNOWN" for a few seconds after a push, so poll for a
-            # definite answer before trusting it.
             mergeable=UNKNOWN
             for _ in $(seq 1 10); do
-              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
-              if [ "${mergeable}" != "UNKNOWN" ]; then
-                break
+              if output=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable); then
+                mergeable="${output}"
+                if [ "${mergeable}" != "UNKNOWN" ]; then
+                  break
+                fi
               fi
               sleep 2
             done
 
             if [ "${mergeable}" != "MERGEABLE" ]; then
               echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
-              gh pr merge --disable-auto "${pr_url}" || true
-            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
-              echo "$OUTPUT"
-            elif echo "$OUTPUT" | grep -q "clean status"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
-            elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
-            else
-              echo "$OUTPUT"
-              exit 1
+              should_disable_auto=true
             fi
+          fi
+
+          if [ "${should_disable_auto}" = "true" ]; then
+            # Disable auto-merge in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+            echo "$OUTPUT"
+          elif echo "$OUTPUT" | grep -q "clean status"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
+          elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
+          else
+            echo "$OUTPUT"
+            exit 1
           fi

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -183,8 +183,30 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
-          if [ -z "${UNRESOLVED_FILES}" ]; then
-            if OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+          if [ -n "${UNRESOLVED_FILES}" ]; then
+            # Unresolved copier conflicts already keep the PR in draft (see above).
+            # Disable auto-merge too, in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          else
+            # `unresolved-files` only reflects copier's own 3-way merge; it says
+            # nothing about whether this branch can still merge into the base
+            # branch. GitHub computes mergeability asynchronously and reports it
+            # as "UNKNOWN" for a few seconds after a push, so poll for a
+            # definite answer before trusting it.
+            mergeable=UNKNOWN
+            for _ in $(seq 1 10); do
+              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
+              if [ "${mergeable}" != "UNKNOWN" ]; then
+                break
+              fi
+              sleep 2
+            done
+
+            if [ "${mergeable}" != "MERGEABLE" ]; then
+              echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
+              gh pr merge --disable-auto "${pr_url}" || true
+            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
               echo "$OUTPUT"
             elif echo "$OUTPUT" | grep -q "clean status"; then
               echo "$OUTPUT"

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -183,39 +183,47 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
+          # `unresolved-files` only reflects copier's own 3-way merge; it says
+          # nothing about whether this branch can still merge into the base
+          # branch. GitHub computes mergeability asynchronously and reports it
+          # as "UNKNOWN" for a few seconds after a push, so poll for a
+          # definite answer before trusting it. A transient `gh pr view`
+          # failure is treated the same as an "UNKNOWN" reading and retried,
+          # rather than aborting the step outright.
+          should_disable_auto=false
           if [ -n "${UNRESOLVED_FILES}" ]; then
-            # Unresolved copier conflicts already keep the PR in draft (see above).
-            # Disable auto-merge too, in case a conflict-free earlier run of this
-            # same reused branch had already armed it.
-            gh pr merge --disable-auto "${pr_url}" || true
+            should_disable_auto=true
           else
-            # `unresolved-files` only reflects copier's own 3-way merge; it says
-            # nothing about whether this branch can still merge into the base
-            # branch. GitHub computes mergeability asynchronously and reports it
-            # as "UNKNOWN" for a few seconds after a push, so poll for a
-            # definite answer before trusting it.
             mergeable=UNKNOWN
             for _ in $(seq 1 10); do
-              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
-              if [ "${mergeable}" != "UNKNOWN" ]; then
-                break
+              if output=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable); then
+                mergeable="${output}"
+                if [ "${mergeable}" != "UNKNOWN" ]; then
+                  break
+                fi
               fi
               sleep 2
             done
 
             if [ "${mergeable}" != "MERGEABLE" ]; then
               echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
-              gh pr merge --disable-auto "${pr_url}" || true
-            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
-              echo "$OUTPUT"
-            elif echo "$OUTPUT" | grep -q "clean status"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
-            elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
-            else
-              echo "$OUTPUT"
-              exit 1
+              should_disable_auto=true
             fi
+          fi
+
+          if [ "${should_disable_auto}" = "true" ]; then
+            # Disable auto-merge in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+            echo "$OUTPUT"
+          elif echo "$OUTPUT" | grep -q "clean status"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
+          elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
+          else
+            echo "$OUTPUT"
+            exit 1
           fi

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -183,8 +183,30 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
-          if [ -z "${UNRESOLVED_FILES}" ]; then
-            if OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+          if [ -n "${UNRESOLVED_FILES}" ]; then
+            # Unresolved copier conflicts already keep the PR in draft (see above).
+            # Disable auto-merge too, in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          else
+            # `unresolved-files` only reflects copier's own 3-way merge; it says
+            # nothing about whether this branch can still merge into the base
+            # branch. GitHub computes mergeability asynchronously and reports it
+            # as "UNKNOWN" for a few seconds after a push, so poll for a
+            # definite answer before trusting it.
+            mergeable=UNKNOWN
+            for _ in $(seq 1 10); do
+              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
+              if [ "${mergeable}" != "UNKNOWN" ]; then
+                break
+              fi
+              sleep 2
+            done
+
+            if [ "${mergeable}" != "MERGEABLE" ]; then
+              echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
+              gh pr merge --disable-auto "${pr_url}" || true
+            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
               echo "$OUTPUT"
             elif echo "$OUTPUT" | grep -q "clean status"; then
               echo "$OUTPUT"

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -183,39 +183,47 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
+          # `unresolved-files` only reflects copier's own 3-way merge; it says
+          # nothing about whether this branch can still merge into the base
+          # branch. GitHub computes mergeability asynchronously and reports it
+          # as "UNKNOWN" for a few seconds after a push, so poll for a
+          # definite answer before trusting it. A transient `gh pr view`
+          # failure is treated the same as an "UNKNOWN" reading and retried,
+          # rather than aborting the step outright.
+          should_disable_auto=false
           if [ -n "${UNRESOLVED_FILES}" ]; then
-            # Unresolved copier conflicts already keep the PR in draft (see above).
-            # Disable auto-merge too, in case a conflict-free earlier run of this
-            # same reused branch had already armed it.
-            gh pr merge --disable-auto "${pr_url}" || true
+            should_disable_auto=true
           else
-            # `unresolved-files` only reflects copier's own 3-way merge; it says
-            # nothing about whether this branch can still merge into the base
-            # branch. GitHub computes mergeability asynchronously and reports it
-            # as "UNKNOWN" for a few seconds after a push, so poll for a
-            # definite answer before trusting it.
             mergeable=UNKNOWN
             for _ in $(seq 1 10); do
-              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
-              if [ "${mergeable}" != "UNKNOWN" ]; then
-                break
+              if output=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable); then
+                mergeable="${output}"
+                if [ "${mergeable}" != "UNKNOWN" ]; then
+                  break
+                fi
               fi
               sleep 2
             done
 
             if [ "${mergeable}" != "MERGEABLE" ]; then
               echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
-              gh pr merge --disable-auto "${pr_url}" || true
-            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
-              echo "$OUTPUT"
-            elif echo "$OUTPUT" | grep -q "clean status"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
-            elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
-            else
-              echo "$OUTPUT"
-              exit 1
+              should_disable_auto=true
             fi
+          fi
+
+          if [ "${should_disable_auto}" = "true" ]; then
+            # Disable auto-merge in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+            echo "$OUTPUT"
+          elif echo "$OUTPUT" | grep -q "clean status"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
+          elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
+          else
+            echo "$OUTPUT"
+            exit 1
           fi

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -183,8 +183,30 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
-          if [ -z "${UNRESOLVED_FILES}" ]; then
-            if OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+          if [ -n "${UNRESOLVED_FILES}" ]; then
+            # Unresolved copier conflicts already keep the PR in draft (see above).
+            # Disable auto-merge too, in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          else
+            # `unresolved-files` only reflects copier's own 3-way merge; it says
+            # nothing about whether this branch can still merge into the base
+            # branch. GitHub computes mergeability asynchronously and reports it
+            # as "UNKNOWN" for a few seconds after a push, so poll for a
+            # definite answer before trusting it.
+            mergeable=UNKNOWN
+            for _ in $(seq 1 10); do
+              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
+              if [ "${mergeable}" != "UNKNOWN" ]; then
+                break
+              fi
+              sleep 2
+            done
+
+            if [ "${mergeable}" != "MERGEABLE" ]; then
+              echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
+              gh pr merge --disable-auto "${pr_url}" || true
+            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
               echo "$OUTPUT"
             elif echo "$OUTPUT" | grep -q "clean status"; then
               echo "$OUTPUT"

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -183,39 +183,47 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
+          # `unresolved-files` only reflects copier's own 3-way merge; it says
+          # nothing about whether this branch can still merge into the base
+          # branch. GitHub computes mergeability asynchronously and reports it
+          # as "UNKNOWN" for a few seconds after a push, so poll for a
+          # definite answer before trusting it. A transient `gh pr view`
+          # failure is treated the same as an "UNKNOWN" reading and retried,
+          # rather than aborting the step outright.
+          should_disable_auto=false
           if [ -n "${UNRESOLVED_FILES}" ]; then
-            # Unresolved copier conflicts already keep the PR in draft (see above).
-            # Disable auto-merge too, in case a conflict-free earlier run of this
-            # same reused branch had already armed it.
-            gh pr merge --disable-auto "${pr_url}" || true
+            should_disable_auto=true
           else
-            # `unresolved-files` only reflects copier's own 3-way merge; it says
-            # nothing about whether this branch can still merge into the base
-            # branch. GitHub computes mergeability asynchronously and reports it
-            # as "UNKNOWN" for a few seconds after a push, so poll for a
-            # definite answer before trusting it.
             mergeable=UNKNOWN
             for _ in $(seq 1 10); do
-              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
-              if [ "${mergeable}" != "UNKNOWN" ]; then
-                break
+              if output=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable); then
+                mergeable="${output}"
+                if [ "${mergeable}" != "UNKNOWN" ]; then
+                  break
+                fi
               fi
               sleep 2
             done
 
             if [ "${mergeable}" != "MERGEABLE" ]; then
               echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
-              gh pr merge --disable-auto "${pr_url}" || true
-            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
-              echo "$OUTPUT"
-            elif echo "$OUTPUT" | grep -q "clean status"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
-            elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
-            else
-              echo "$OUTPUT"
-              exit 1
+              should_disable_auto=true
             fi
+          fi
+
+          if [ "${should_disable_auto}" = "true" ]; then
+            # Disable auto-merge in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+            echo "$OUTPUT"
+          elif echo "$OUTPUT" | grep -q "clean status"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
+          elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
+          else
+            echo "$OUTPUT"
+            exit 1
           fi

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -183,8 +183,30 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
-          if [ -z "${UNRESOLVED_FILES}" ]; then
-            if OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+          if [ -n "${UNRESOLVED_FILES}" ]; then
+            # Unresolved copier conflicts already keep the PR in draft (see above).
+            # Disable auto-merge too, in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          else
+            # `unresolved-files` only reflects copier's own 3-way merge; it says
+            # nothing about whether this branch can still merge into the base
+            # branch. GitHub computes mergeability asynchronously and reports it
+            # as "UNKNOWN" for a few seconds after a push, so poll for a
+            # definite answer before trusting it.
+            mergeable=UNKNOWN
+            for _ in $(seq 1 10); do
+              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
+              if [ "${mergeable}" != "UNKNOWN" ]; then
+                break
+              fi
+              sleep 2
+            done
+
+            if [ "${mergeable}" != "MERGEABLE" ]; then
+              echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
+              gh pr merge --disable-auto "${pr_url}" || true
+            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
               echo "$OUTPUT"
             elif echo "$OUTPUT" | grep -q "clean status"; then
               echo "$OUTPUT"

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -183,39 +183,47 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
+          # `unresolved-files` only reflects copier's own 3-way merge; it says
+          # nothing about whether this branch can still merge into the base
+          # branch. GitHub computes mergeability asynchronously and reports it
+          # as "UNKNOWN" for a few seconds after a push, so poll for a
+          # definite answer before trusting it. A transient `gh pr view`
+          # failure is treated the same as an "UNKNOWN" reading and retried,
+          # rather than aborting the step outright.
+          should_disable_auto=false
           if [ -n "${UNRESOLVED_FILES}" ]; then
-            # Unresolved copier conflicts already keep the PR in draft (see above).
-            # Disable auto-merge too, in case a conflict-free earlier run of this
-            # same reused branch had already armed it.
-            gh pr merge --disable-auto "${pr_url}" || true
+            should_disable_auto=true
           else
-            # `unresolved-files` only reflects copier's own 3-way merge; it says
-            # nothing about whether this branch can still merge into the base
-            # branch. GitHub computes mergeability asynchronously and reports it
-            # as "UNKNOWN" for a few seconds after a push, so poll for a
-            # definite answer before trusting it.
             mergeable=UNKNOWN
             for _ in $(seq 1 10); do
-              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
-              if [ "${mergeable}" != "UNKNOWN" ]; then
-                break
+              if output=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable); then
+                mergeable="${output}"
+                if [ "${mergeable}" != "UNKNOWN" ]; then
+                  break
+                fi
               fi
               sleep 2
             done
 
             if [ "${mergeable}" != "MERGEABLE" ]; then
               echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
-              gh pr merge --disable-auto "${pr_url}" || true
-            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
-              echo "$OUTPUT"
-            elif echo "$OUTPUT" | grep -q "clean status"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
-            elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
-            else
-              echo "$OUTPUT"
-              exit 1
+              should_disable_auto=true
             fi
+          fi
+
+          if [ "${should_disable_auto}" = "true" ]; then
+            # Disable auto-merge in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+            echo "$OUTPUT"
+          elif echo "$OUTPUT" | grep -q "clean status"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
+          elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
+          else
+            echo "$OUTPUT"
+            exit 1
           fi

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -183,8 +183,30 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
-          if [ -z "${UNRESOLVED_FILES}" ]; then
-            if OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+          if [ -n "${UNRESOLVED_FILES}" ]; then
+            # Unresolved copier conflicts already keep the PR in draft (see above).
+            # Disable auto-merge too, in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          else
+            # `unresolved-files` only reflects copier's own 3-way merge; it says
+            # nothing about whether this branch can still merge into the base
+            # branch. GitHub computes mergeability asynchronously and reports it
+            # as "UNKNOWN" for a few seconds after a push, so poll for a
+            # definite answer before trusting it.
+            mergeable=UNKNOWN
+            for _ in $(seq 1 10); do
+              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
+              if [ "${mergeable}" != "UNKNOWN" ]; then
+                break
+              fi
+              sleep 2
+            done
+
+            if [ "${mergeable}" != "MERGEABLE" ]; then
+              echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
+              gh pr merge --disable-auto "${pr_url}" || true
+            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
               echo "$OUTPUT"
             elif echo "$OUTPUT" | grep -q "clean status"; then
               echo "$OUTPUT"

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -183,39 +183,47 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
+          # `unresolved-files` only reflects copier's own 3-way merge; it says
+          # nothing about whether this branch can still merge into the base
+          # branch. GitHub computes mergeability asynchronously and reports it
+          # as "UNKNOWN" for a few seconds after a push, so poll for a
+          # definite answer before trusting it. A transient `gh pr view`
+          # failure is treated the same as an "UNKNOWN" reading and retried,
+          # rather than aborting the step outright.
+          should_disable_auto=false
           if [ -n "${UNRESOLVED_FILES}" ]; then
-            # Unresolved copier conflicts already keep the PR in draft (see above).
-            # Disable auto-merge too, in case a conflict-free earlier run of this
-            # same reused branch had already armed it.
-            gh pr merge --disable-auto "${pr_url}" || true
+            should_disable_auto=true
           else
-            # `unresolved-files` only reflects copier's own 3-way merge; it says
-            # nothing about whether this branch can still merge into the base
-            # branch. GitHub computes mergeability asynchronously and reports it
-            # as "UNKNOWN" for a few seconds after a push, so poll for a
-            # definite answer before trusting it.
             mergeable=UNKNOWN
             for _ in $(seq 1 10); do
-              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
-              if [ "${mergeable}" != "UNKNOWN" ]; then
-                break
+              if output=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable); then
+                mergeable="${output}"
+                if [ "${mergeable}" != "UNKNOWN" ]; then
+                  break
+                fi
               fi
               sleep 2
             done
 
             if [ "${mergeable}" != "MERGEABLE" ]; then
               echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
-              gh pr merge --disable-auto "${pr_url}" || true
-            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
-              echo "$OUTPUT"
-            elif echo "$OUTPUT" | grep -q "clean status"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
-            elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
-            else
-              echo "$OUTPUT"
-              exit 1
+              should_disable_auto=true
             fi
+          fi
+
+          if [ "${should_disable_auto}" = "true" ]; then
+            # Disable auto-merge in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+            echo "$OUTPUT"
+          elif echo "$OUTPUT" | grep -q "clean status"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
+          elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
+          else
+            echo "$OUTPUT"
+            exit 1
           fi

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -183,8 +183,30 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
-          if [ -z "${UNRESOLVED_FILES}" ]; then
-            if OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+          if [ -n "${UNRESOLVED_FILES}" ]; then
+            # Unresolved copier conflicts already keep the PR in draft (see above).
+            # Disable auto-merge too, in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          else
+            # `unresolved-files` only reflects copier's own 3-way merge; it says
+            # nothing about whether this branch can still merge into the base
+            # branch. GitHub computes mergeability asynchronously and reports it
+            # as "UNKNOWN" for a few seconds after a push, so poll for a
+            # definite answer before trusting it.
+            mergeable=UNKNOWN
+            for _ in $(seq 1 10); do
+              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
+              if [ "${mergeable}" != "UNKNOWN" ]; then
+                break
+              fi
+              sleep 2
+            done
+
+            if [ "${mergeable}" != "MERGEABLE" ]; then
+              echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
+              gh pr merge --disable-auto "${pr_url}" || true
+            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
               echo "$OUTPUT"
             elif echo "$OUTPUT" | grep -q "clean status"; then
               echo "$OUTPUT"

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -183,39 +183,47 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
+          # `unresolved-files` only reflects copier's own 3-way merge; it says
+          # nothing about whether this branch can still merge into the base
+          # branch. GitHub computes mergeability asynchronously and reports it
+          # as "UNKNOWN" for a few seconds after a push, so poll for a
+          # definite answer before trusting it. A transient `gh pr view`
+          # failure is treated the same as an "UNKNOWN" reading and retried,
+          # rather than aborting the step outright.
+          should_disable_auto=false
           if [ -n "${UNRESOLVED_FILES}" ]; then
-            # Unresolved copier conflicts already keep the PR in draft (see above).
-            # Disable auto-merge too, in case a conflict-free earlier run of this
-            # same reused branch had already armed it.
-            gh pr merge --disable-auto "${pr_url}" || true
+            should_disable_auto=true
           else
-            # `unresolved-files` only reflects copier's own 3-way merge; it says
-            # nothing about whether this branch can still merge into the base
-            # branch. GitHub computes mergeability asynchronously and reports it
-            # as "UNKNOWN" for a few seconds after a push, so poll for a
-            # definite answer before trusting it.
             mergeable=UNKNOWN
             for _ in $(seq 1 10); do
-              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
-              if [ "${mergeable}" != "UNKNOWN" ]; then
-                break
+              if output=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable); then
+                mergeable="${output}"
+                if [ "${mergeable}" != "UNKNOWN" ]; then
+                  break
+                fi
               fi
               sleep 2
             done
 
             if [ "${mergeable}" != "MERGEABLE" ]; then
               echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
-              gh pr merge --disable-auto "${pr_url}" || true
-            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
-              echo "$OUTPUT"
-            elif echo "$OUTPUT" | grep -q "clean status"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
-            elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
-            else
-              echo "$OUTPUT"
-              exit 1
+              should_disable_auto=true
             fi
+          fi
+
+          if [ "${should_disable_auto}" = "true" ]; then
+            # Disable auto-merge in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+            echo "$OUTPUT"
+          elif echo "$OUTPUT" | grep -q "clean status"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
+          elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
+          else
+            echo "$OUTPUT"
+            exit 1
           fi

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -183,8 +183,30 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
-          if [ -z "${UNRESOLVED_FILES}" ]; then
-            if OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+          if [ -n "${UNRESOLVED_FILES}" ]; then
+            # Unresolved copier conflicts already keep the PR in draft (see above).
+            # Disable auto-merge too, in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          else
+            # `unresolved-files` only reflects copier's own 3-way merge; it says
+            # nothing about whether this branch can still merge into the base
+            # branch. GitHub computes mergeability asynchronously and reports it
+            # as "UNKNOWN" for a few seconds after a push, so poll for a
+            # definite answer before trusting it.
+            mergeable=UNKNOWN
+            for _ in $(seq 1 10); do
+              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
+              if [ "${mergeable}" != "UNKNOWN" ]; then
+                break
+              fi
+              sleep 2
+            done
+
+            if [ "${mergeable}" != "MERGEABLE" ]; then
+              echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
+              gh pr merge --disable-auto "${pr_url}" || true
+            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
               echo "$OUTPUT"
             elif echo "$OUTPUT" | grep -q "clean status"; then
               echo "$OUTPUT"

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -183,39 +183,47 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
+          # `unresolved-files` only reflects copier's own 3-way merge; it says
+          # nothing about whether this branch can still merge into the base
+          # branch. GitHub computes mergeability asynchronously and reports it
+          # as "UNKNOWN" for a few seconds after a push, so poll for a
+          # definite answer before trusting it. A transient `gh pr view`
+          # failure is treated the same as an "UNKNOWN" reading and retried,
+          # rather than aborting the step outright.
+          should_disable_auto=false
           if [ -n "${UNRESOLVED_FILES}" ]; then
-            # Unresolved copier conflicts already keep the PR in draft (see above).
-            # Disable auto-merge too, in case a conflict-free earlier run of this
-            # same reused branch had already armed it.
-            gh pr merge --disable-auto "${pr_url}" || true
+            should_disable_auto=true
           else
-            # `unresolved-files` only reflects copier's own 3-way merge; it says
-            # nothing about whether this branch can still merge into the base
-            # branch. GitHub computes mergeability asynchronously and reports it
-            # as "UNKNOWN" for a few seconds after a push, so poll for a
-            # definite answer before trusting it.
             mergeable=UNKNOWN
             for _ in $(seq 1 10); do
-              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
-              if [ "${mergeable}" != "UNKNOWN" ]; then
-                break
+              if output=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable); then
+                mergeable="${output}"
+                if [ "${mergeable}" != "UNKNOWN" ]; then
+                  break
+                fi
               fi
               sleep 2
             done
 
             if [ "${mergeable}" != "MERGEABLE" ]; then
               echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
-              gh pr merge --disable-auto "${pr_url}" || true
-            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
-              echo "$OUTPUT"
-            elif echo "$OUTPUT" | grep -q "clean status"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
-            elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
-            else
-              echo "$OUTPUT"
-              exit 1
+              should_disable_auto=true
             fi
+          fi
+
+          if [ "${should_disable_auto}" = "true" ]; then
+            # Disable auto-merge in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+            echo "$OUTPUT"
+          elif echo "$OUTPUT" | grep -q "clean status"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
+          elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
+          else
+            echo "$OUTPUT"
+            exit 1
           fi

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -183,8 +183,30 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
-          if [ -z "${UNRESOLVED_FILES}" ]; then
-            if OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+          if [ -n "${UNRESOLVED_FILES}" ]; then
+            # Unresolved copier conflicts already keep the PR in draft (see above).
+            # Disable auto-merge too, in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          else
+            # `unresolved-files` only reflects copier's own 3-way merge; it says
+            # nothing about whether this branch can still merge into the base
+            # branch. GitHub computes mergeability asynchronously and reports it
+            # as "UNKNOWN" for a few seconds after a push, so poll for a
+            # definite answer before trusting it.
+            mergeable=UNKNOWN
+            for _ in $(seq 1 10); do
+              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
+              if [ "${mergeable}" != "UNKNOWN" ]; then
+                break
+              fi
+              sleep 2
+            done
+
+            if [ "${mergeable}" != "MERGEABLE" ]; then
+              echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
+              gh pr merge --disable-auto "${pr_url}" || true
+            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
               echo "$OUTPUT"
             elif echo "$OUTPUT" | grep -q "clean status"; then
               echo "$OUTPUT"

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -183,39 +183,47 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
+          # `unresolved-files` only reflects copier's own 3-way merge; it says
+          # nothing about whether this branch can still merge into the base
+          # branch. GitHub computes mergeability asynchronously and reports it
+          # as "UNKNOWN" for a few seconds after a push, so poll for a
+          # definite answer before trusting it. A transient `gh pr view`
+          # failure is treated the same as an "UNKNOWN" reading and retried,
+          # rather than aborting the step outright.
+          should_disable_auto=false
           if [ -n "${UNRESOLVED_FILES}" ]; then
-            # Unresolved copier conflicts already keep the PR in draft (see above).
-            # Disable auto-merge too, in case a conflict-free earlier run of this
-            # same reused branch had already armed it.
-            gh pr merge --disable-auto "${pr_url}" || true
+            should_disable_auto=true
           else
-            # `unresolved-files` only reflects copier's own 3-way merge; it says
-            # nothing about whether this branch can still merge into the base
-            # branch. GitHub computes mergeability asynchronously and reports it
-            # as "UNKNOWN" for a few seconds after a push, so poll for a
-            # definite answer before trusting it.
             mergeable=UNKNOWN
             for _ in $(seq 1 10); do
-              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
-              if [ "${mergeable}" != "UNKNOWN" ]; then
-                break
+              if output=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable); then
+                mergeable="${output}"
+                if [ "${mergeable}" != "UNKNOWN" ]; then
+                  break
+                fi
               fi
               sleep 2
             done
 
             if [ "${mergeable}" != "MERGEABLE" ]; then
               echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
-              gh pr merge --disable-auto "${pr_url}" || true
-            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
-              echo "$OUTPUT"
-            elif echo "$OUTPUT" | grep -q "clean status"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
-            elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
-            else
-              echo "$OUTPUT"
-              exit 1
+              should_disable_auto=true
             fi
+          fi
+
+          if [ "${should_disable_auto}" = "true" ]; then
+            # Disable auto-merge in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+            echo "$OUTPUT"
+          elif echo "$OUTPUT" | grep -q "clean status"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
+          elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
+          else
+            echo "$OUTPUT"
+            exit 1
           fi

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -183,8 +183,30 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
-          if [ -z "${UNRESOLVED_FILES}" ]; then
-            if OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+          if [ -n "${UNRESOLVED_FILES}" ]; then
+            # Unresolved copier conflicts already keep the PR in draft (see above).
+            # Disable auto-merge too, in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          else
+            # `unresolved-files` only reflects copier's own 3-way merge; it says
+            # nothing about whether this branch can still merge into the base
+            # branch. GitHub computes mergeability asynchronously and reports it
+            # as "UNKNOWN" for a few seconds after a push, so poll for a
+            # definite answer before trusting it.
+            mergeable=UNKNOWN
+            for _ in $(seq 1 10); do
+              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
+              if [ "${mergeable}" != "UNKNOWN" ]; then
+                break
+              fi
+              sleep 2
+            done
+
+            if [ "${mergeable}" != "MERGEABLE" ]; then
+              echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
+              gh pr merge --disable-auto "${pr_url}" || true
+            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
               echo "$OUTPUT"
             elif echo "$OUTPUT" | grep -q "clean status"; then
               echo "$OUTPUT"

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -183,39 +183,47 @@ jobs:
             pr_url=$(gh pr create "${create_args[@]}")
           fi
 
+          # `unresolved-files` only reflects copier's own 3-way merge; it says
+          # nothing about whether this branch can still merge into the base
+          # branch. GitHub computes mergeability asynchronously and reports it
+          # as "UNKNOWN" for a few seconds after a push, so poll for a
+          # definite answer before trusting it. A transient `gh pr view`
+          # failure is treated the same as an "UNKNOWN" reading and retried,
+          # rather than aborting the step outright.
+          should_disable_auto=false
           if [ -n "${UNRESOLVED_FILES}" ]; then
-            # Unresolved copier conflicts already keep the PR in draft (see above).
-            # Disable auto-merge too, in case a conflict-free earlier run of this
-            # same reused branch had already armed it.
-            gh pr merge --disable-auto "${pr_url}" || true
+            should_disable_auto=true
           else
-            # `unresolved-files` only reflects copier's own 3-way merge; it says
-            # nothing about whether this branch can still merge into the base
-            # branch. GitHub computes mergeability asynchronously and reports it
-            # as "UNKNOWN" for a few seconds after a push, so poll for a
-            # definite answer before trusting it.
             mergeable=UNKNOWN
             for _ in $(seq 1 10); do
-              mergeable=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable)
-              if [ "${mergeable}" != "UNKNOWN" ]; then
-                break
+              if output=$(gh pr view "${pr_url}" --json mergeable --jq .mergeable); then
+                mergeable="${output}"
+                if [ "${mergeable}" != "UNKNOWN" ]; then
+                  break
+                fi
               fi
               sleep 2
             done
 
             if [ "${mergeable}" != "MERGEABLE" ]; then
               echo "PR is not cleanly mergeable with the base branch (mergeable=${mergeable}); leaving it for manual review." >&2
-              gh pr merge --disable-auto "${pr_url}" || true
-            elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
-              echo "$OUTPUT"
-            elif echo "$OUTPUT" | grep -q "clean status"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
-            elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
-              echo "$OUTPUT"
-              gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
-            else
-              echo "$OUTPUT"
-              exit 1
+              should_disable_auto=true
             fi
+          fi
+
+          if [ "${should_disable_auto}" = "true" ]; then
+            # Disable auto-merge in case a conflict-free earlier run of this
+            # same reused branch had already armed it.
+            gh pr merge --disable-auto "${pr_url}" || true
+          elif OUTPUT=$(gh pr merge --auto --squash "${pr_url}" 2>&1); then
+            echo "$OUTPUT"
+          elif echo "$OUTPUT" | grep -q "clean status"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed. Leaving PR open."
+          elif echo "$OUTPUT" | grep -q "auto-merge is not enabled"; then
+            echo "$OUTPUT"
+            gh pr merge --squash "${pr_url}" || echo "Direct merge failed (likely due to pending checks). Leaving PR open."
+          else
+            echo "$OUTPUT"
+            exit 1
           fi


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/slack-bot/pull/82
- PRs from `boilerplate-update.yml` had auto-merge enabled as long as copier left no raw conflict markers, regardless of whether the branch could actually merge into the base branch. This let an unreviewed change get squash-merged in a real incident.

### Reproduction steps

1. Auto-merge gets enabled whenever copier leaves no conflicts, regardless of whether the branch can actually merge into the base branch.
2. The already-armed auto-merge later fires unreviewed and squash-merges the PR once someone resolves the base-branch conflict by pushing directly to the branch.

## Approach

- Check whether the branch can actually merge into the base branch in addition to `unresolved-files`, and skip enabling auto-merge if either check finds a problem.
    - Disable it if it was already enabled.

<details>
<summary>Design decisions</summary>

#### Detection scope

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen | Check mergeability against the base branch inside `boilerplate-update.yml` on every run | Self-contained in one file and preserves the existing auto-merge behavior for the clean, no-conflict case | Can't detect a direct push to the branch that bypasses a workflow re-run until this workflow runs again |
| Rejected | Enforce required reviews with stale-approval dismissal via branch protection rules | Always requires a fresh review regardless of who pushes | Requires a repository setting change and can't be achieved by editing this workflow file alone |

</details>
