### PR TITLE
ci(renovate): change jdx/mise update prefix to deps(ci)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -31,8 +31,7 @@
     },
     // jdx/mise is extracted from jdx/mise-action's `with: version:` by a
     // customManager (manager name `regex`), so the github-actions rule above
-    // does not match it. It represents a GitHub Actions workflow input, so
-    // apply the same deps(ci): prefix here.
+    // does not match it.
     //
     // This intentionally overrides base.json5's `ci:` prefix for jdx/mise,
     // which release-please-config.json hides from the CHANGELOG. Unlike

--- a/renovate.json5
+++ b/renovate.json5
@@ -29,6 +29,14 @@
       matchManagers: ['github-actions'],
       commitMessagePrefix: 'deps(ci):',
     },
+    // jdx/mise is extracted from jdx/mise-action's `with: version:` by a
+    // customManager (manager name `regex`), so the github-actions rule above
+    // does not match it. It represents a GitHub Actions workflow input, so
+    // apply the same deps(ci): prefix here.
+    {
+      matchPackageNames: ['jdx/mise'],
+      commitMessagePrefix: 'deps(ci):',
+    },
     {
       matchManagers: ['mise'],
       matchUpdateTypes: ['minor', 'patch'],

--- a/renovate.json5
+++ b/renovate.json5
@@ -33,6 +33,11 @@
     // customManager (manager name `regex`), so the github-actions rule above
     // does not match it. It represents a GitHub Actions workflow input, so
     // apply the same deps(ci): prefix here.
+    //
+    // This intentionally overrides base.json5's `ci:` prefix for jdx/mise,
+    // which release-please-config.json hides from the CHANGELOG. Unlike
+    // downstream repos, a jdx/mise bump here changes the generated CI
+    // workflow, so it must surface as a release-please patch bump.
     {
       matchPackageNames: ['jdx/mise'],
       commitMessagePrefix: 'deps(ci):',


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/generic-boilerplate/pull/506
- The commit prefix for jdx/mise (`jdx/mise-action`'s `version`) update PRs is `ci:`, which release-please treats as a no-bump type

## Approach

- Add a packageRule for `jdx/mise` in `renovate.json5` to use the same `deps(ci):` prefix as other GitHub Actions updates
