### PR TITLE
ci: detect peer dependency mismatches in generated fixtures

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -208,11 +208,14 @@ jobs:
       - name: Cache pnpm store
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
+          # node_modules must not be cached: pnpm treats a restored
+          # node_modules as up to date and keeps its auto-installed peers, so
+          # `pnpm peers check` would validate the stale cached resolution
+          # instead of a fresh one.
           path: |
             ${{ steps.pnpm-store.outputs.path }}
-            generated/node/node_modules
-          key: ${{ runner.os }}-pnpm-validate-node-${{ hashFiles('generated/node/package.json') }}
-          restore-keys: ${{ runner.os }}-pnpm-validate-node-
+          key: ${{ runner.os }}-pnpm-store-validate-node-${{ hashFiles('generated/node/package.json') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-validate-node-
 
       - run: pnpm install
         working-directory: generated/node
@@ -250,12 +253,10 @@ jobs:
       - name: Cache pnpm store
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          # node_modules is split across the workspace root and each package,
-          # so unlike validate-node only the shared pnpm store is cached.
           path: |
             ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-validate-monorepo-node-workspace-${{ hashFiles('generated/monorepo-node-workspace/**/package.json') }}
-          restore-keys: ${{ runner.os }}-pnpm-validate-monorepo-node-workspace-
+          key: ${{ runner.os }}-pnpm-store-validate-monorepo-node-workspace-${{ hashFiles('generated/monorepo-node-workspace/**/package.json') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-validate-monorepo-node-workspace-
 
       - run: pnpm install
         working-directory: generated/monorepo-node-workspace

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -40,6 +40,7 @@ jobs:
     needs: list-fixtures
     outputs:
       node_changed: ${{ steps.check-node-changes.outputs.any_changed }}
+      monorepo_node_workspace_changed: ${{ steps.check-monorepo-node-workspace-changes.outputs.any_changed }}
       rust_changed: ${{ steps.check-rust-changes.outputs.any_changed }}
 
     steps:
@@ -82,6 +83,13 @@ jobs:
         with:
           base_sha: master
           files: generated/node/**
+
+      - name: Check if monorepo-node-workspace template changed
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        id: check-monorepo-node-workspace-changes
+        with:
+          base_sha: master
+          files: generated/monorepo-node-workspace/**
 
       - name: Check if rust template changed
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
@@ -209,8 +217,55 @@ jobs:
       - run: pnpm install
         working-directory: generated/node
 
+      - name: Check peer dependencies
+        working-directory: generated/node
+        run: pnpm peers check
+
       - name: Run tests
         working-directory: generated/node
+        run: pnpm run test
+
+  validate-monorepo-node-workspace:
+    runs-on: ubuntu-latest
+    needs: regenerate-and-commit
+    if: needs.regenerate-and-commit.outputs.monorepo_node_workspace_changed == 'true'
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.ref_name }}
+
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          version: 2026.7.0
+          working_directory: generated/monorepo-node-workspace
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-validate-monorepo-node-workspace-${{ hashFiles('generated/monorepo-node-workspace/**/package.json') }}
+          restore-keys: ${{ runner.os }}-pnpm-validate-monorepo-node-workspace-
+
+      - run: pnpm install
+        working-directory: generated/monorepo-node-workspace
+
+      # Installing from the workspace root covers every workspace package, so a
+      # single root-level check also validates subpackage peer dependencies.
+      - name: Check peer dependencies
+        working-directory: generated/monorepo-node-workspace
+        run: pnpm peers check
+
+      - name: Run tests
+        working-directory: generated/monorepo-node-workspace
         run: pnpm run test
 
   validate-rust:
@@ -248,6 +303,7 @@ jobs:
       - regenerate-and-commit
       - validate
       - validate-node
+      - validate-monorepo-node-workspace
       - validate-rust
     if: always()
     steps:

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -250,6 +250,8 @@ jobs:
       - name: Cache pnpm store
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
+          # node_modules is split across the workspace root and each package,
+          # so unlike validate-node only the shared pnpm store is cached.
           path: |
             ${{ steps.pnpm-store.outputs.path }}
           key: ${{ runner.os }}-pnpm-validate-monorepo-node-workspace-${{ hashFiles('generated/monorepo-node-workspace/**/package.json') }}
@@ -258,8 +260,6 @@ jobs:
       - run: pnpm install
         working-directory: generated/monorepo-node-workspace
 
-      # Installing from the workspace root covers every workspace package, so a
-      # single root-level check also validates subpackage peer dependencies.
       - name: Check peer dependencies
         working-directory: generated/monorepo-node-workspace
         run: pnpm peers check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ The repository root itself is a consumer of this template, managed via `.copier-
 
 - `regenerate-and-commit`: runs `scripts/generate-snapshots` and auto-commits any diff in `generated/`. If you forget to regenerate locally, CI will commit the regeneration for you, but any push that also touches `generated/` inconsistently will still need to reconcile
 - `validate (<fixture>)`: for each fixture in `tests/fixtures/`, initializes a git repo inside `generated/<fixture>/`, runs `lefthook run pre-commit --all-files` (prettier, eslint, etc. as configured by that fixture's own lefthook), then fails if any file has a diff. **This means every file under `generated/` must already be in the exact form its own lefthook would produce.**
-- `validate-node` / `validate-monorepo-node-workspace` / `validate-rust`: run the generated project's test suite (plus `pnpm peers check` for node-based fixtures) when the corresponding `generated/` tree changed
+- `validate-node` / `validate-monorepo-node-workspace` / `validate-rust`: run the generated project's test suite (plus `pnpm peers check` for node-based fixtures) when the corresponding `generated/<fixture>` tree changed
 
 ### Implications for `template/` authors
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ The repository root itself is a consumer of this template, managed via `.copier-
 
 - `regenerate-and-commit`: runs `scripts/generate-snapshots` and auto-commits any diff in `generated/`. If you forget to regenerate locally, CI will commit the regeneration for you, but any push that also touches `generated/` inconsistently will still need to reconcile
 - `validate (<fixture>)`: for each fixture in `tests/fixtures/`, initializes a git repo inside `generated/<fixture>/`, runs `lefthook run pre-commit --all-files` (prettier, eslint, etc. as configured by that fixture's own lefthook), then fails if any file has a diff. **This means every file under `generated/` must already be in the exact form its own lefthook would produce.**
-- `validate-node` / `validate-rust`: run the generated project's test suite when the corresponding `generated/node` or `generated/rust` tree changed
+- `validate-node` / `validate-monorepo-node-workspace` / `validate-rust`: run the generated project's test suite (plus `pnpm peers check` for node-based fixtures) when the corresponding `generated/` tree changed
 
 ### Implications for `template/` authors
 


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/generic-boilerplate/pull/508, https://github.com/fohte/generic-boilerplate/pull/507
- Renovate PRs that break peer dependencies in the `generated/` fixtures still pass CI, forcing every triage to reproduce `pnpm peers check` locally

## Approach

- Run the same `pnpm peers check` in `validate-template.yml` that the [`test.yml` template](https://github.com/fohte/generic-boilerplate/blob/d21bbabe8822d875a27fa99c03c88662d248899a/template/.github/workflows/test.yml.jinja) already distributes to downstream repositories
- Run peer dependency checks and tests for `generated/monorepo-node-workspace`, which CI previously did not exercise

<details>
<summary>Design decisions</summary>

#### Job layout for monorepo-node-workspace

| Decision | Design                                                                    | Pros                                                | Cons                                                                             |
| -------- | ------------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------- |
| Chosen   | Add a dedicated job mirroring `validate-node`                             | Purely additive; leaves the existing jobs untouched | Duplicates the job definition; each new node fixture needs another copy          |
| Rejected | Merge into `validate-node` with a dynamic matrix of changed node fixtures | No duplication; adding a fixture touches one place  | Requires restructuring the existing `validate-node`, beyond the scope of this fix |

</details>
