### PR TITLE
fix(template): register the ESM loader hook so HTTP spans get created

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -87,6 +87,7 @@ _exclude:
   # on the subpackages entry; the per-pkg bootstrap path is gated separately
   # in the subpackage filename template.
   - "{% if type != 'node' or not is_web_app | default(false) %}/src/bootstrap.ts{% endif %}"
+  - "{% if type != 'node' or not is_web_app | default(false) %}/otel-register.mjs{% endif %}"
   # Exclude coverage files when coverage is disabled
   - '{% if not use_coverage %}/codecov.yml{% endif %}'
   # Exclude Storybook files when storybook is disabled or no storybook packages exist

--- a/generated/monorepo-node-workspace/backend/otel-register.mjs
+++ b/generated/monorepo-node-workspace/backend/otel-register.mjs
@@ -1,0 +1,13 @@
+// Node's ESM loader bypasses `require()`, so `@opentelemetry/instrumentation`'s
+// module-patching (used by instrumentation-http and friends to create spans
+// for built-in modules like `http`) never runs against `import`ed modules
+// unless this loader hook is registered before the app itself loads — without
+// it, `http.Server` is never patched and no server-side spans are created.
+// https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md
+import { register } from 'node:module'
+
+// `import.meta.url`, not a cwd-derived URL: `register()` resolves the bare
+// specifier against this parentURL synchronously and throws if it can't, so
+// the resolution must stay anchored to this file regardless of the process's
+// working directory at startup.
+register('@opentelemetry/instrumentation/hook.mjs', import.meta.url)

--- a/generated/monorepo-node-workspace/backend/package.json
+++ b/generated/monorepo-node-workspace/backend/package.json
@@ -12,6 +12,7 @@
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.77.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",
+    "@opentelemetry/instrumentation": "0.219.0",
     "@opentelemetry/resources": "2.8.0",
     "@opentelemetry/sdk-node": "0.219.0",
     "@opentelemetry/sdk-trace-base": "2.8.0",

--- a/generated/monorepo-node-workspace/backend/src/bootstrap.ts
+++ b/generated/monorepo-node-workspace/backend/src/bootstrap.ts
@@ -2,8 +2,8 @@
 // @opentelemetry/auto-instrumentations-node cannot patch them — hence
 // `import './bootstrap'` as the very first statement of `index.ts`.
 // This alone is not enough for built-in modules like `http`, though — see
-// otel-register.mjs, registered via `--import` in the `start`/`dev` scripts
-// and the Dockerfile's `CMD`, for why.
+// otel-register.mjs: it must be preloaded via `node --import` before this
+// file (or anything else) is imported, or `http.Server` is never patched.
 import {
   initObservability,
   isObservabilityConfigured,

--- a/generated/monorepo-node-workspace/backend/src/bootstrap.ts
+++ b/generated/monorepo-node-workspace/backend/src/bootstrap.ts
@@ -1,7 +1,9 @@
 // Must run before any instrumented module is imported, otherwise
-// @opentelemetry/auto-instrumentations-node cannot patch them. Either
-// `import './bootstrap'` as the very first statement of the entrypoint,
-// or pre-load with `node --import` (ESM) / `--require` (CJS).
+// @opentelemetry/auto-instrumentations-node cannot patch them — hence
+// `import './bootstrap'` as the very first statement of `index.ts`.
+// This alone is not enough for built-in modules like `http`, though — see
+// otel-register.mjs, registered via `--import` in the `start`/`dev` scripts
+// and the Dockerfile's `CMD`, for why.
 import {
   initObservability,
   isObservabilityConfigured,

--- a/generated/node/otel-register.mjs
+++ b/generated/node/otel-register.mjs
@@ -1,0 +1,13 @@
+// Node's ESM loader bypasses `require()`, so `@opentelemetry/instrumentation`'s
+// module-patching (used by instrumentation-http and friends to create spans
+// for built-in modules like `http`) never runs against `import`ed modules
+// unless this loader hook is registered before the app itself loads — without
+// it, `http.Server` is never patched and no server-side spans are created.
+// https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md
+import { register } from 'node:module'
+
+// `import.meta.url`, not a cwd-derived URL: `register()` resolves the bare
+// specifier against this parentURL synchronously and throws if it can't, so
+// the resolution must stay anchored to this file regardless of the process's
+// working directory at startup.
+register('@opentelemetry/instrumentation/hook.mjs', import.meta.url)

--- a/generated/node/package.json
+++ b/generated/node/package.json
@@ -19,6 +19,7 @@
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.77.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",
+    "@opentelemetry/instrumentation": "0.219.0",
     "@opentelemetry/resources": "2.8.0",
     "@opentelemetry/sdk-node": "0.219.0",
     "@opentelemetry/sdk-trace-base": "2.8.0",

--- a/generated/node/src/bootstrap.ts
+++ b/generated/node/src/bootstrap.ts
@@ -2,8 +2,8 @@
 // @opentelemetry/auto-instrumentations-node cannot patch them — hence
 // `import './bootstrap'` as the very first statement of `index.ts`.
 // This alone is not enough for built-in modules like `http`, though — see
-// otel-register.mjs, registered via `--import` in the `start`/`dev` scripts
-// and the Dockerfile's `CMD`, for why.
+// otel-register.mjs: it must be preloaded via `node --import` before this
+// file (or anything else) is imported, or `http.Server` is never patched.
 import {
   initObservability,
   isObservabilityConfigured,

--- a/generated/node/src/bootstrap.ts
+++ b/generated/node/src/bootstrap.ts
@@ -1,7 +1,9 @@
 // Must run before any instrumented module is imported, otherwise
-// @opentelemetry/auto-instrumentations-node cannot patch them. Either
-// `import './bootstrap'` as the very first statement of the entrypoint,
-// or pre-load with `node --import` (ESM) / `--require` (CJS).
+// @opentelemetry/auto-instrumentations-node cannot patch them — hence
+// `import './bootstrap'` as the very first statement of `index.ts`.
+// This alone is not enough for built-in modules like `http`, though — see
+// otel-register.mjs, registered via `--import` in the `start`/`dev` scripts
+// and the Dockerfile's `CMD`, for why.
 import {
   initObservability,
   isObservabilityConfigured,

--- a/template/otel-register.mjs
+++ b/template/otel-register.mjs
@@ -1,0 +1,13 @@
+// Node's ESM loader bypasses `require()`, so `@opentelemetry/instrumentation`'s
+// module-patching (used by instrumentation-http and friends to create spans
+// for built-in modules like `http`) never runs against `import`ed modules
+// unless this loader hook is registered before the app itself loads — without
+// it, `http.Server` is never patched and no server-side spans are created.
+// https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md
+import { register } from 'node:module'
+
+// `import.meta.url`, not a cwd-derived URL: `register()` resolves the bare
+// specifier against this parentURL synchronously and throws if it can't, so
+// the resolution must stay anchored to this file regardless of the process's
+// working directory at startup.
+register('@opentelemetry/instrumentation/hook.mjs', import.meta.url)

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -38,6 +38,7 @@
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.77.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",
+    "@opentelemetry/instrumentation": "0.219.0",
     "@opentelemetry/resources": "2.8.0",
     "@opentelemetry/sdk-node": "0.219.0",
     "@opentelemetry/sdk-trace-base": "2.8.0",

--- a/template/src/bootstrap.ts
+++ b/template/src/bootstrap.ts
@@ -2,8 +2,8 @@
 // @opentelemetry/auto-instrumentations-node cannot patch them — hence
 // `import './bootstrap'` as the very first statement of `index.ts`.
 // This alone is not enough for built-in modules like `http`, though — see
-// otel-register.mjs, registered via `--import` in the `start`/`dev` scripts
-// and the Dockerfile's `CMD`, for why.
+// otel-register.mjs: it must be preloaded via `node --import` before this
+// file (or anything else) is imported, or `http.Server` is never patched.
 import {
   initObservability,
   isObservabilityConfigured,

--- a/template/src/bootstrap.ts
+++ b/template/src/bootstrap.ts
@@ -1,7 +1,9 @@
 // Must run before any instrumented module is imported, otherwise
-// @opentelemetry/auto-instrumentations-node cannot patch them. Either
-// `import './bootstrap'` as the very first statement of the entrypoint,
-// or pre-load with `node --import` (ESM) / `--require` (CJS).
+// @opentelemetry/auto-instrumentations-node cannot patch them — hence
+// `import './bootstrap'` as the very first statement of `index.ts`.
+// This alone is not enough for built-in modules like `http`, though — see
+// otel-register.mjs, registered via `--import` in the `start`/`dev` scripts
+// and the Dockerfile's `CMD`, for why.
 import {
   initObservability,
   isObservabilityConfigured,

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
@@ -38,6 +38,7 @@
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.77.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.219.0",
+    "@opentelemetry/instrumentation": "0.219.0",
     "@opentelemetry/resources": "2.8.0",
     "@opentelemetry/sdk-node": "0.219.0",
     "@opentelemetry/sdk-trace-base": "2.8.0",

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.web_app | default(false) and pkg.tests | default(true) %}otel-register.mjs{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.web_app | default(false) and pkg.tests | default(true) %}otel-register.mjs{% endif %}.jinja
@@ -1,0 +1,1 @@
+{% include "template/otel-register.mjs" -%}


### PR DESCRIPTION
## Purpose

- In ESM (`"type": "module"`) node web apps, `@opentelemetry/auto-instrumentations-node` cannot patch built-in modules like `http`, so no server-side HTTP spans are created at all

## Approach

- Add `otel-register.mjs` under the same web app generation gate as `bootstrap.ts` (root's `is_web_app: true` and subpackages' `pkg.web_app: true`), so the ESM loader hook can be registered explicitly
- Update the `bootstrap.ts` comment to state that its `import` alone isn't enough to patch built-in modules

<details>
<summary>Design decisions</summary>

#### Scope of the `--import` wiring

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen | Limit this change to adding `otel-register.mjs` and fixing the comment, leaving the `--import` wiring into `start`/`dev` scripts and the Dockerfile to downstream repos | Avoids locking in a template scaffolding approach while build tooling still differs per repo | The preload the comment refers to isn't wired up yet right after generation, so each repo needs follow-up work |
| Rejected | Add `start`/`dev` scripts and a Dockerfile to `package.json.jinja` and wire up `--import` there | Works right after generation | Locks in a build/start/dev scaffolding approach before it's settled |

</details>
