### PR TITLE
feat(template)!: add neverthrow-based error handling scaffolding

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -82,6 +82,8 @@ _exclude:
   # Exclude Node.js specific src files when type is not 'node'
   - "{% if type != 'node' %}/src/index.ts{% endif %}"
   - "{% if type != 'node' %}/src/index.test.ts{% endif %}"
+  - "{% if type != 'node' %}/src/errors.ts{% endif %}"
+  - "{% if type != 'node' %}/src/errors.test.ts{% endif %}"
   # Exclude observability bootstrap when the root project is not a node web app.
   # Monorepo subpackages declare their own web app status via `web_app: true`
   # on the subpackages entry; the per-pkg bootstrap path is gated separately

--- a/generated/monorepo-node-workspace/CLAUDE.md
+++ b/generated/monorepo-node-workspace/CLAUDE.md
@@ -28,7 +28,7 @@ function parseConfig(raw: string): Result<Config, ConfigError> {
 }
 ```
 
-Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow with an `eslint-disable-next-line no-restricted-syntax` comment explaining why.
+Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow it — `no-restricted-syntax` bans `try`/`throw` as separate selectors, so both the `try` and the `throw` need their own `eslint-disable-next-line no-restricted-syntax` comment explaining why.
 
 ## Test code rules
 

--- a/generated/monorepo-node-workspace/CLAUDE.md
+++ b/generated/monorepo-node-workspace/CLAUDE.md
@@ -8,6 +8,28 @@ When a change would push a file's non-test code past ~500 lines, split it along 
 
 Prefer creating a new focused file over appending to the largest existing one.
 
+## Error handling rules
+
+### Return a `Result` instead of throwing
+
+`errorHandling` in `eslint.config.js` bans `throw`/`try-catch` in production code and requires every returned `Result` to be consumed (`no-restricted-syntax`, `neverthrow/must-use-result` in `@fohte/eslint-config`). Return a `Result`/`ResultAsync` from [neverthrow](https://github.com/supermacro/neverthrow) instead:
+
+```ts
+// bad: throws
+function parseConfig(raw: string): Config {
+  if (!isValid(raw)) throw new Error('invalid config')
+  return JSON.parse(raw)
+}
+
+// good: returns a Result
+function parseConfig(raw: string): Result<Config, ConfigError> {
+  if (!isValid(raw)) return err(new ConfigError('invalid config'))
+  return ok(JSON.parse(raw))
+}
+```
+
+Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow with an `eslint-disable-next-line no-restricted-syntax` comment explaining why.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/generated/monorepo-node-workspace/backend/package.json
+++ b/generated/monorepo-node-workspace/backend/package.json
@@ -18,6 +18,7 @@
     "@opentelemetry/sdk-trace-base": "2.8.0",
     "@opentelemetry/semantic-conventions": "1.41.1",
     "@sentry/node": "10.63.0",
-    "@sentry/opentelemetry": "10.63.0"
+    "@sentry/opentelemetry": "10.63.0",
+    "neverthrow": "8.2.0"
   }
 }

--- a/generated/monorepo-node-workspace/backend/src/bootstrap.ts
+++ b/generated/monorepo-node-workspace/backend/src/bootstrap.ts
@@ -12,3 +12,16 @@ import {
 if (isObservabilityConfigured(process.env)) {
   initObservability(process.env)
 }
+
+// `@fohte/service-kit/observability` also exports `captureWithFingerprint`,
+// for reporting an error at an interop boundary under a stable fingerprint
+// (for Sentry grouping) without changing control flow. Call it once, right
+// before re-throwing a wrapped BoundaryError (see src/errors.ts):
+//
+//   import { captureWithFingerprint } from '@fohte/service-kit/observability'
+//
+//   catch (caughtErr) {
+//     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     captureWithFingerprint(wrapped, 'task-store.persistence-error')
+//     throw wrapped
+//   }

--- a/generated/monorepo-node-workspace/backend/src/bootstrap.ts
+++ b/generated/monorepo-node-workspace/backend/src/bootstrap.ts
@@ -14,16 +14,5 @@ if (isObservabilityConfigured(process.env)) {
 }
 
 // `@fohte/service-kit/observability` also exports `captureWithFingerprint`,
-// for reporting an error under a stable fingerprint (for Sentry grouping)
-// without changing control flow. Call it once, right before re-throwing a
-// wrapped BoundaryError (see src/errors.ts), in a file listed under
-// eslint.config.js's errorHandling.interopBoundaryFiles — this file isn't
-// one, since it never catches an error itself:
-//
-//   import { captureWithFingerprint } from '@fohte/service-kit/observability'
-//
-//   catch (caughtErr) {
-//     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
-//     captureWithFingerprint(wrapped, 'task-store.persistence-error')
-//     throw wrapped
-//   }
+// for reporting a wrapped BoundaryError under a stable fingerprint (for
+// Sentry grouping) — see src/errors.ts for the throw/catch usage.

--- a/generated/monorepo-node-workspace/backend/src/bootstrap.ts
+++ b/generated/monorepo-node-workspace/backend/src/bootstrap.ts
@@ -12,7 +12,3 @@ import {
 if (isObservabilityConfigured(process.env)) {
   initObservability(process.env)
 }
-
-// `@fohte/service-kit/observability` also exports `captureWithFingerprint`,
-// for reporting a wrapped BoundaryError under a stable fingerprint (for
-// Sentry grouping) — see src/errors.ts for the throw/catch usage.

--- a/generated/monorepo-node-workspace/backend/src/bootstrap.ts
+++ b/generated/monorepo-node-workspace/backend/src/bootstrap.ts
@@ -14,9 +14,11 @@ if (isObservabilityConfigured(process.env)) {
 }
 
 // `@fohte/service-kit/observability` also exports `captureWithFingerprint`,
-// for reporting an error at an interop boundary under a stable fingerprint
-// (for Sentry grouping) without changing control flow. Call it once, right
-// before re-throwing a wrapped BoundaryError (see src/errors.ts):
+// for reporting an error under a stable fingerprint (for Sentry grouping)
+// without changing control flow. Call it once, right before re-throwing a
+// wrapped BoundaryError (see src/errors.ts), in a file listed under
+// eslint.config.js's errorHandling.interopBoundaryFiles — this file isn't
+// one, since it never catches an error itself:
 //
 //   import { captureWithFingerprint } from '@fohte/service-kit/observability'
 //

--- a/generated/monorepo-node-workspace/backend/src/errors.test.ts
+++ b/generated/monorepo-node-workspace/backend/src/errors.test.ts
@@ -10,8 +10,14 @@ describe('BoundaryError', () => {
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped.name).toBe('TaskStorePersistenceError')
-    expect(wrapped.message).toBe('failed to save')
-    expect(wrapped.cause).toBe(original)
+    expect({
+      name: wrapped.name,
+      message: wrapped.message,
+      causeIsOriginal: wrapped.cause === original,
+    }).toEqual({
+      name: 'TaskStorePersistenceError',
+      message: 'failed to save',
+      causeIsOriginal: true,
+    })
   })
 })

--- a/generated/monorepo-node-workspace/backend/src/errors.test.ts
+++ b/generated/monorepo-node-workspace/backend/src/errors.test.ts
@@ -10,14 +10,8 @@ describe('BoundaryError', () => {
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
 
-    expect({
-      name: wrapped.name,
-      message: wrapped.message,
-      causeIsOriginal: wrapped.cause === original,
-    }).toEqual({
-      name: 'TaskStorePersistenceError',
-      message: 'failed to save',
-      causeIsOriginal: true,
-    })
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
   })
 })

--- a/generated/monorepo-node-workspace/backend/src/errors.test.ts
+++ b/generated/monorepo-node-workspace/backend/src/errors.test.ts
@@ -9,8 +9,9 @@ describe('BoundaryError', () => {
     const original = new Error('connection refused')
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
-    const expected = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped).toEqual(expected)
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
   })
 })

--- a/generated/monorepo-node-workspace/backend/src/errors.test.ts
+++ b/generated/monorepo-node-workspace/backend/src/errors.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { BoundaryError } from '@/errors'
+
+class TaskStorePersistenceError extends BoundaryError {}
+
+describe('BoundaryError', () => {
+  it('derives name from the subclass and preserves the original error as cause', () => {
+    const original = new Error('connection refused')
+
+    const wrapped = new TaskStorePersistenceError('failed to save', original)
+
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
+  })
+})

--- a/generated/monorepo-node-workspace/backend/src/errors.test.ts
+++ b/generated/monorepo-node-workspace/backend/src/errors.test.ts
@@ -9,9 +9,8 @@ describe('BoundaryError', () => {
     const original = new Error('connection refused')
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
+    const expected = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped.name).toBe('TaskStorePersistenceError')
-    expect(wrapped.message).toBe('failed to save')
-    expect(wrapped.cause).toBe(original)
+    expect(wrapped).toEqual(expected)
   })
 })

--- a/generated/monorepo-node-workspace/backend/src/errors.ts
+++ b/generated/monorepo-node-workspace/backend/src/errors.ts
@@ -1,10 +1,24 @@
 // Wrap a caught external error before re-throwing, so it carries a
 // domain-meaningful message while preserving the original via `cause`.
-// Subclass per interop boundary (see eslint.config.js's
-// errorHandling.interopBoundaryFiles) — `name` is derived automatically, so
-// no constructor override is needed:
+// Subclass per interop boundary — `name` is derived automatically, so no
+// constructor override is needed. The throw/try-catch this requires needs
+// an eslint-disable-next-line comment, since @fohte/eslint-config's
+// errorHandling bans them elsewhere:
 //
 //   export class TaskStorePersistenceError extends BoundaryError {}
+//
+//   // eslint-disable-next-line no-restricted-syntax -- interop boundary
+//   try {
+//     ...
+//   } catch (caughtErr) {
+//     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     throw wrapped
+//   }
+//
+// To report a wrapped error under a stable fingerprint (for Sentry
+// grouping) without changing control flow, call `captureWithFingerprint`
+// (from `@fohte/service-kit/observability`, see src/bootstrap.ts) right
+// before re-throwing.
 export abstract class BoundaryError extends Error {
   constructor(message: string, cause: unknown) {
     super(message, { cause })

--- a/generated/monorepo-node-workspace/backend/src/errors.ts
+++ b/generated/monorepo-node-workspace/backend/src/errors.ts
@@ -1,0 +1,13 @@
+// Wrap a caught external error before re-throwing, so it carries a
+// domain-meaningful message while preserving the original via `cause`.
+// Subclass per interop boundary (see eslint.config.js's
+// errorHandling.interopBoundaryFiles) — `name` is derived automatically, so
+// no constructor override is needed:
+//
+//   export class TaskStorePersistenceError extends BoundaryError {}
+export abstract class BoundaryError extends Error {
+  constructor(message: string, cause: unknown) {
+    super(message, { cause })
+    this.name = new.target.name
+  }
+}

--- a/generated/monorepo-node-workspace/backend/src/errors.ts
+++ b/generated/monorepo-node-workspace/backend/src/errors.ts
@@ -1,9 +1,9 @@
 // Wrap a caught external error before re-throwing, so it carries a
 // domain-meaningful message while preserving the original via `cause`.
 // Subclass per interop boundary — `name` is derived automatically, so no
-// constructor override is needed. The throw/try-catch this requires needs
-// an eslint-disable-next-line comment, since @fohte/eslint-config's
-// errorHandling bans them elsewhere:
+// constructor override is needed. The try and the throw this requires each
+// need their own eslint-disable-next-line comment, since @fohte/eslint-config's
+// errorHandling bans ThrowStatement and TryStatement as separate selectors:
 //
 //   export class TaskStorePersistenceError extends BoundaryError {}
 //
@@ -12,6 +12,7 @@
 //     ...
 //   } catch (caughtErr) {
 //     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     // eslint-disable-next-line no-restricted-syntax -- interop boundary
 //     throw wrapped
 //   }
 //

--- a/generated/monorepo-node-workspace/eslint.config.js
+++ b/generated/monorepo-node-workspace/eslint.config.js
@@ -4,13 +4,7 @@ import storybook from 'eslint-plugin-storybook'
 export default config(
   {
     typescript: { typeChecked: true },
-    errorHandling: {
-      // Glob paths for files that interop with an external SDK/framework or
-      // run at process startup (e.g. env validation, DB migrations, main
-      // entrypoints) and therefore need throw/try-catch. Everywhere else,
-      // model failures as neverthrow Result/ResultAsync values instead.
-      interopBoundaryFiles: [],
-    },
+    errorHandling: {},
   },
   ...storybook.configs['flat/recommended'],
   {

--- a/generated/monorepo-node-workspace/eslint.config.js
+++ b/generated/monorepo-node-workspace/eslint.config.js
@@ -2,7 +2,16 @@ import { config } from '@fohte/eslint-config'
 import storybook from 'eslint-plugin-storybook'
 
 export default config(
-  { typescript: { typeChecked: true } },
+  {
+    typescript: { typeChecked: true },
+    errorHandling: {
+      // Glob paths for files that interop with an external SDK/framework or
+      // run at process startup (e.g. env validation, DB migrations, main
+      // entrypoints) and therefore need throw/try-catch. Everywhere else,
+      // model failures as neverthrow Result/ResultAsync values instead.
+      interopBoundaryFiles: [],
+    },
+  },
   ...storybook.configs['flat/recommended'],
   {
     rules: {

--- a/generated/monorepo-node-workspace/frontend/package.json
+++ b/generated/monorepo-node-workspace/frontend/package.json
@@ -9,6 +9,9 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build"
   },
+  "dependencies": {
+    "neverthrow": "8.2.0"
+  },
   "devDependencies": {
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",

--- a/generated/monorepo-node-workspace/frontend/src/errors.test.ts
+++ b/generated/monorepo-node-workspace/frontend/src/errors.test.ts
@@ -10,8 +10,14 @@ describe('BoundaryError', () => {
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped.name).toBe('TaskStorePersistenceError')
-    expect(wrapped.message).toBe('failed to save')
-    expect(wrapped.cause).toBe(original)
+    expect({
+      name: wrapped.name,
+      message: wrapped.message,
+      causeIsOriginal: wrapped.cause === original,
+    }).toEqual({
+      name: 'TaskStorePersistenceError',
+      message: 'failed to save',
+      causeIsOriginal: true,
+    })
   })
 })

--- a/generated/monorepo-node-workspace/frontend/src/errors.test.ts
+++ b/generated/monorepo-node-workspace/frontend/src/errors.test.ts
@@ -10,14 +10,8 @@ describe('BoundaryError', () => {
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
 
-    expect({
-      name: wrapped.name,
-      message: wrapped.message,
-      causeIsOriginal: wrapped.cause === original,
-    }).toEqual({
-      name: 'TaskStorePersistenceError',
-      message: 'failed to save',
-      causeIsOriginal: true,
-    })
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
   })
 })

--- a/generated/monorepo-node-workspace/frontend/src/errors.test.ts
+++ b/generated/monorepo-node-workspace/frontend/src/errors.test.ts
@@ -9,8 +9,9 @@ describe('BoundaryError', () => {
     const original = new Error('connection refused')
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
-    const expected = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped).toEqual(expected)
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
   })
 })

--- a/generated/monorepo-node-workspace/frontend/src/errors.test.ts
+++ b/generated/monorepo-node-workspace/frontend/src/errors.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { BoundaryError } from '@/errors'
+
+class TaskStorePersistenceError extends BoundaryError {}
+
+describe('BoundaryError', () => {
+  it('derives name from the subclass and preserves the original error as cause', () => {
+    const original = new Error('connection refused')
+
+    const wrapped = new TaskStorePersistenceError('failed to save', original)
+
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
+  })
+})

--- a/generated/monorepo-node-workspace/frontend/src/errors.test.ts
+++ b/generated/monorepo-node-workspace/frontend/src/errors.test.ts
@@ -9,9 +9,8 @@ describe('BoundaryError', () => {
     const original = new Error('connection refused')
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
+    const expected = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped.name).toBe('TaskStorePersistenceError')
-    expect(wrapped.message).toBe('failed to save')
-    expect(wrapped.cause).toBe(original)
+    expect(wrapped).toEqual(expected)
   })
 })

--- a/generated/monorepo-node-workspace/frontend/src/errors.ts
+++ b/generated/monorepo-node-workspace/frontend/src/errors.ts
@@ -1,10 +1,24 @@
 // Wrap a caught external error before re-throwing, so it carries a
 // domain-meaningful message while preserving the original via `cause`.
-// Subclass per interop boundary (see eslint.config.js's
-// errorHandling.interopBoundaryFiles) — `name` is derived automatically, so
-// no constructor override is needed:
+// Subclass per interop boundary — `name` is derived automatically, so no
+// constructor override is needed. The throw/try-catch this requires needs
+// an eslint-disable-next-line comment, since @fohte/eslint-config's
+// errorHandling bans them elsewhere:
 //
 //   export class TaskStorePersistenceError extends BoundaryError {}
+//
+//   // eslint-disable-next-line no-restricted-syntax -- interop boundary
+//   try {
+//     ...
+//   } catch (caughtErr) {
+//     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     throw wrapped
+//   }
+//
+// To report a wrapped error under a stable fingerprint (for Sentry
+// grouping) without changing control flow, call `captureWithFingerprint`
+// (from `@fohte/service-kit/observability`, see src/bootstrap.ts) right
+// before re-throwing.
 export abstract class BoundaryError extends Error {
   constructor(message: string, cause: unknown) {
     super(message, { cause })

--- a/generated/monorepo-node-workspace/frontend/src/errors.ts
+++ b/generated/monorepo-node-workspace/frontend/src/errors.ts
@@ -1,0 +1,13 @@
+// Wrap a caught external error before re-throwing, so it carries a
+// domain-meaningful message while preserving the original via `cause`.
+// Subclass per interop boundary (see eslint.config.js's
+// errorHandling.interopBoundaryFiles) — `name` is derived automatically, so
+// no constructor override is needed:
+//
+//   export class TaskStorePersistenceError extends BoundaryError {}
+export abstract class BoundaryError extends Error {
+  constructor(message: string, cause: unknown) {
+    super(message, { cause })
+    this.name = new.target.name
+  }
+}

--- a/generated/monorepo-node-workspace/frontend/src/errors.ts
+++ b/generated/monorepo-node-workspace/frontend/src/errors.ts
@@ -1,9 +1,9 @@
 // Wrap a caught external error before re-throwing, so it carries a
 // domain-meaningful message while preserving the original via `cause`.
 // Subclass per interop boundary — `name` is derived automatically, so no
-// constructor override is needed. The throw/try-catch this requires needs
-// an eslint-disable-next-line comment, since @fohte/eslint-config's
-// errorHandling bans them elsewhere:
+// constructor override is needed. The try and the throw this requires each
+// need their own eslint-disable-next-line comment, since @fohte/eslint-config's
+// errorHandling bans ThrowStatement and TryStatement as separate selectors:
 //
 //   export class TaskStorePersistenceError extends BoundaryError {}
 //
@@ -12,6 +12,7 @@
 //     ...
 //   } catch (caughtErr) {
 //     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     // eslint-disable-next-line no-restricted-syntax -- interop boundary
 //     throw wrapped
 //   }
 //

--- a/generated/monorepo-node-workspace/package.json
+++ b/generated/monorepo-node-workspace/package.json
@@ -17,7 +17,8 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.6",
+    "@fohte/eslint-config": "0.3.7",
+    "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/strictest": "2.0.8",
     "@types/node": "24.13.2",

--- a/generated/monorepo-node-workspace/package.json
+++ b/generated/monorepo-node-workspace/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.7",
+    "@fohte/eslint-config": "0.3.9",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/strictest": "2.0.8",

--- a/generated/monorepo/CLAUDE.md
+++ b/generated/monorepo/CLAUDE.md
@@ -28,7 +28,7 @@ function parseConfig(raw: string): Result<Config, ConfigError> {
 }
 ```
 
-Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow with an `eslint-disable-next-line no-restricted-syntax` comment explaining why.
+Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow it — `no-restricted-syntax` bans `try`/`throw` as separate selectors, so both the `try` and the `throw` need their own `eslint-disable-next-line no-restricted-syntax` comment explaining why.
 
 ## Test code rules
 

--- a/generated/monorepo/CLAUDE.md
+++ b/generated/monorepo/CLAUDE.md
@@ -8,6 +8,28 @@ When a change would push a file's non-test code past ~500 lines, split it along 
 
 Prefer creating a new focused file over appending to the largest existing one.
 
+## Error handling rules
+
+### Return a `Result` instead of throwing
+
+`errorHandling` in `eslint.config.js` bans `throw`/`try-catch` in production code and requires every returned `Result` to be consumed (`no-restricted-syntax`, `neverthrow/must-use-result` in `@fohte/eslint-config`). Return a `Result`/`ResultAsync` from [neverthrow](https://github.com/supermacro/neverthrow) instead:
+
+```ts
+// bad: throws
+function parseConfig(raw: string): Config {
+  if (!isValid(raw)) throw new Error('invalid config')
+  return JSON.parse(raw)
+}
+
+// good: returns a Result
+function parseConfig(raw: string): Result<Config, ConfigError> {
+  if (!isValid(raw)) return err(new ConfigError('invalid config'))
+  return ok(JSON.parse(raw))
+}
+```
+
+Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow with an `eslint-disable-next-line no-restricted-syntax` comment explaining why.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/generated/monorepo/frontend/eslint.config.js
+++ b/generated/monorepo/frontend/eslint.config.js
@@ -4,13 +4,7 @@ import storybook from 'eslint-plugin-storybook'
 export default config(
   {
     typescript: { typeChecked: true },
-    errorHandling: {
-      // Glob paths for files that interop with an external SDK/framework or
-      // run at process startup (e.g. env validation, DB migrations, main
-      // entrypoints) and therefore need throw/try-catch. Everywhere else,
-      // model failures as neverthrow Result/ResultAsync values instead.
-      interopBoundaryFiles: [],
-    },
+    errorHandling: {},
   },
   ...storybook.configs['flat/recommended'],
   {

--- a/generated/monorepo/frontend/eslint.config.js
+++ b/generated/monorepo/frontend/eslint.config.js
@@ -2,7 +2,16 @@ import { config } from '@fohte/eslint-config'
 import storybook from 'eslint-plugin-storybook'
 
 export default config(
-  { typescript: { typeChecked: true } },
+  {
+    typescript: { typeChecked: true },
+    errorHandling: {
+      // Glob paths for files that interop with an external SDK/framework or
+      // run at process startup (e.g. env validation, DB migrations, main
+      // entrypoints) and therefore need throw/try-catch. Everywhere else,
+      // model failures as neverthrow Result/ResultAsync values instead.
+      interopBoundaryFiles: [],
+    },
+  },
   ...storybook.configs['flat/recommended'],
   {
     rules: {

--- a/generated/monorepo/frontend/package.json
+++ b/generated/monorepo/frontend/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.7",
+    "@fohte/eslint-config": "0.3.9",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",

--- a/generated/monorepo/frontend/package.json
+++ b/generated/monorepo/frontend/package.json
@@ -14,6 +14,9 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build"
   },
+  "dependencies": {
+    "neverthrow": "8.2.0"
+  },
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",

--- a/generated/monorepo/frontend/package.json
+++ b/generated/monorepo/frontend/package.json
@@ -17,7 +17,8 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.6",
+    "@fohte/eslint-config": "0.3.7",
+    "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",
     "@storybook/react-vite": "10.4.6",

--- a/generated/monorepo/frontend/src/errors.test.ts
+++ b/generated/monorepo/frontend/src/errors.test.ts
@@ -10,8 +10,14 @@ describe('BoundaryError', () => {
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped.name).toBe('TaskStorePersistenceError')
-    expect(wrapped.message).toBe('failed to save')
-    expect(wrapped.cause).toBe(original)
+    expect({
+      name: wrapped.name,
+      message: wrapped.message,
+      causeIsOriginal: wrapped.cause === original,
+    }).toEqual({
+      name: 'TaskStorePersistenceError',
+      message: 'failed to save',
+      causeIsOriginal: true,
+    })
   })
 })

--- a/generated/monorepo/frontend/src/errors.test.ts
+++ b/generated/monorepo/frontend/src/errors.test.ts
@@ -10,14 +10,8 @@ describe('BoundaryError', () => {
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
 
-    expect({
-      name: wrapped.name,
-      message: wrapped.message,
-      causeIsOriginal: wrapped.cause === original,
-    }).toEqual({
-      name: 'TaskStorePersistenceError',
-      message: 'failed to save',
-      causeIsOriginal: true,
-    })
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
   })
 })

--- a/generated/monorepo/frontend/src/errors.test.ts
+++ b/generated/monorepo/frontend/src/errors.test.ts
@@ -9,8 +9,9 @@ describe('BoundaryError', () => {
     const original = new Error('connection refused')
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
-    const expected = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped).toEqual(expected)
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
   })
 })

--- a/generated/monorepo/frontend/src/errors.test.ts
+++ b/generated/monorepo/frontend/src/errors.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { BoundaryError } from '@/errors'
+
+class TaskStorePersistenceError extends BoundaryError {}
+
+describe('BoundaryError', () => {
+  it('derives name from the subclass and preserves the original error as cause', () => {
+    const original = new Error('connection refused')
+
+    const wrapped = new TaskStorePersistenceError('failed to save', original)
+
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
+  })
+})

--- a/generated/monorepo/frontend/src/errors.test.ts
+++ b/generated/monorepo/frontend/src/errors.test.ts
@@ -9,9 +9,8 @@ describe('BoundaryError', () => {
     const original = new Error('connection refused')
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
+    const expected = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped.name).toBe('TaskStorePersistenceError')
-    expect(wrapped.message).toBe('failed to save')
-    expect(wrapped.cause).toBe(original)
+    expect(wrapped).toEqual(expected)
   })
 })

--- a/generated/monorepo/frontend/src/errors.ts
+++ b/generated/monorepo/frontend/src/errors.ts
@@ -1,10 +1,24 @@
 // Wrap a caught external error before re-throwing, so it carries a
 // domain-meaningful message while preserving the original via `cause`.
-// Subclass per interop boundary (see eslint.config.js's
-// errorHandling.interopBoundaryFiles) — `name` is derived automatically, so
-// no constructor override is needed:
+// Subclass per interop boundary — `name` is derived automatically, so no
+// constructor override is needed. The throw/try-catch this requires needs
+// an eslint-disable-next-line comment, since @fohte/eslint-config's
+// errorHandling bans them elsewhere:
 //
 //   export class TaskStorePersistenceError extends BoundaryError {}
+//
+//   // eslint-disable-next-line no-restricted-syntax -- interop boundary
+//   try {
+//     ...
+//   } catch (caughtErr) {
+//     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     throw wrapped
+//   }
+//
+// To report a wrapped error under a stable fingerprint (for Sentry
+// grouping) without changing control flow, call `captureWithFingerprint`
+// (from `@fohte/service-kit/observability`, see src/bootstrap.ts) right
+// before re-throwing.
 export abstract class BoundaryError extends Error {
   constructor(message: string, cause: unknown) {
     super(message, { cause })

--- a/generated/monorepo/frontend/src/errors.ts
+++ b/generated/monorepo/frontend/src/errors.ts
@@ -1,0 +1,13 @@
+// Wrap a caught external error before re-throwing, so it carries a
+// domain-meaningful message while preserving the original via `cause`.
+// Subclass per interop boundary (see eslint.config.js's
+// errorHandling.interopBoundaryFiles) — `name` is derived automatically, so
+// no constructor override is needed:
+//
+//   export class TaskStorePersistenceError extends BoundaryError {}
+export abstract class BoundaryError extends Error {
+  constructor(message: string, cause: unknown) {
+    super(message, { cause })
+    this.name = new.target.name
+  }
+}

--- a/generated/monorepo/frontend/src/errors.ts
+++ b/generated/monorepo/frontend/src/errors.ts
@@ -1,9 +1,9 @@
 // Wrap a caught external error before re-throwing, so it carries a
 // domain-meaningful message while preserving the original via `cause`.
 // Subclass per interop boundary — `name` is derived automatically, so no
-// constructor override is needed. The throw/try-catch this requires needs
-// an eslint-disable-next-line comment, since @fohte/eslint-config's
-// errorHandling bans them elsewhere:
+// constructor override is needed. The try and the throw this requires each
+// need their own eslint-disable-next-line comment, since @fohte/eslint-config's
+// errorHandling bans ThrowStatement and TryStatement as separate selectors:
 //
 //   export class TaskStorePersistenceError extends BoundaryError {}
 //
@@ -12,6 +12,7 @@
 //     ...
 //   } catch (caughtErr) {
 //     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     // eslint-disable-next-line no-restricted-syntax -- interop boundary
 //     throw wrapped
 //   }
 //

--- a/generated/node/CLAUDE.md
+++ b/generated/node/CLAUDE.md
@@ -28,7 +28,7 @@ function parseConfig(raw: string): Result<Config, ConfigError> {
 }
 ```
 
-Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow with an `eslint-disable-next-line no-restricted-syntax` comment explaining why.
+Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow it — `no-restricted-syntax` bans `try`/`throw` as separate selectors, so both the `try` and the `throw` need their own `eslint-disable-next-line no-restricted-syntax` comment explaining why.
 
 ## Test code rules
 

--- a/generated/node/CLAUDE.md
+++ b/generated/node/CLAUDE.md
@@ -8,6 +8,28 @@ When a change would push a file's non-test code past ~500 lines, split it along 
 
 Prefer creating a new focused file over appending to the largest existing one.
 
+## Error handling rules
+
+### Return a `Result` instead of throwing
+
+`errorHandling` in `eslint.config.js` bans `throw`/`try-catch` in production code and requires every returned `Result` to be consumed (`no-restricted-syntax`, `neverthrow/must-use-result` in `@fohte/eslint-config`). Return a `Result`/`ResultAsync` from [neverthrow](https://github.com/supermacro/neverthrow) instead:
+
+```ts
+// bad: throws
+function parseConfig(raw: string): Config {
+  if (!isValid(raw)) throw new Error('invalid config')
+  return JSON.parse(raw)
+}
+
+// good: returns a Result
+function parseConfig(raw: string): Result<Config, ConfigError> {
+  if (!isValid(raw)) return err(new ConfigError('invalid config'))
+  return ok(JSON.parse(raw))
+}
+```
+
+Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow with an `eslint-disable-next-line no-restricted-syntax` comment explaining why.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/generated/node/eslint.config.js
+++ b/generated/node/eslint.config.js
@@ -4,13 +4,7 @@ import storybook from 'eslint-plugin-storybook'
 export default config(
   {
     typescript: { typeChecked: true },
-    errorHandling: {
-      // Glob paths for files that interop with an external SDK/framework or
-      // run at process startup (e.g. env validation, DB migrations, main
-      // entrypoints) and therefore need throw/try-catch. Everywhere else,
-      // model failures as neverthrow Result/ResultAsync values instead.
-      interopBoundaryFiles: [],
-    },
+    errorHandling: {},
   },
   ...storybook.configs['flat/recommended'],
   {

--- a/generated/node/eslint.config.js
+++ b/generated/node/eslint.config.js
@@ -2,7 +2,16 @@ import { config } from '@fohte/eslint-config'
 import storybook from 'eslint-plugin-storybook'
 
 export default config(
-  { typescript: { typeChecked: true } },
+  {
+    typescript: { typeChecked: true },
+    errorHandling: {
+      // Glob paths for files that interop with an external SDK/framework or
+      // run at process startup (e.g. env validation, DB migrations, main
+      // entrypoints) and therefore need throw/try-catch. Everywhere else,
+      // model failures as neverthrow Result/ResultAsync values instead.
+      interopBoundaryFiles: [],
+    },
+  },
   ...storybook.configs['flat/recommended'],
   {
     rules: {

--- a/generated/node/package.json
+++ b/generated/node/package.json
@@ -25,12 +25,14 @@
     "@opentelemetry/sdk-trace-base": "2.8.0",
     "@opentelemetry/semantic-conventions": "1.41.1",
     "@sentry/node": "10.63.0",
-    "@sentry/opentelemetry": "10.63.0"
+    "@sentry/opentelemetry": "10.63.0",
+    "neverthrow": "8.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.6",
+    "@fohte/eslint-config": "0.3.7",
+    "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",
     "@storybook/react-vite": "10.4.6",

--- a/generated/node/package.json
+++ b/generated/node/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.7",
+    "@fohte/eslint-config": "0.3.9",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",

--- a/generated/node/src/bootstrap.ts
+++ b/generated/node/src/bootstrap.ts
@@ -12,3 +12,16 @@ import {
 if (isObservabilityConfigured(process.env)) {
   initObservability(process.env)
 }
+
+// `@fohte/service-kit/observability` also exports `captureWithFingerprint`,
+// for reporting an error at an interop boundary under a stable fingerprint
+// (for Sentry grouping) without changing control flow. Call it once, right
+// before re-throwing a wrapped BoundaryError (see src/errors.ts):
+//
+//   import { captureWithFingerprint } from '@fohte/service-kit/observability'
+//
+//   catch (caughtErr) {
+//     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     captureWithFingerprint(wrapped, 'task-store.persistence-error')
+//     throw wrapped
+//   }

--- a/generated/node/src/bootstrap.ts
+++ b/generated/node/src/bootstrap.ts
@@ -14,16 +14,5 @@ if (isObservabilityConfigured(process.env)) {
 }
 
 // `@fohte/service-kit/observability` also exports `captureWithFingerprint`,
-// for reporting an error under a stable fingerprint (for Sentry grouping)
-// without changing control flow. Call it once, right before re-throwing a
-// wrapped BoundaryError (see src/errors.ts), in a file listed under
-// eslint.config.js's errorHandling.interopBoundaryFiles — this file isn't
-// one, since it never catches an error itself:
-//
-//   import { captureWithFingerprint } from '@fohte/service-kit/observability'
-//
-//   catch (caughtErr) {
-//     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
-//     captureWithFingerprint(wrapped, 'task-store.persistence-error')
-//     throw wrapped
-//   }
+// for reporting a wrapped BoundaryError under a stable fingerprint (for
+// Sentry grouping) — see src/errors.ts for the throw/catch usage.

--- a/generated/node/src/bootstrap.ts
+++ b/generated/node/src/bootstrap.ts
@@ -12,7 +12,3 @@ import {
 if (isObservabilityConfigured(process.env)) {
   initObservability(process.env)
 }
-
-// `@fohte/service-kit/observability` also exports `captureWithFingerprint`,
-// for reporting a wrapped BoundaryError under a stable fingerprint (for
-// Sentry grouping) — see src/errors.ts for the throw/catch usage.

--- a/generated/node/src/bootstrap.ts
+++ b/generated/node/src/bootstrap.ts
@@ -14,9 +14,11 @@ if (isObservabilityConfigured(process.env)) {
 }
 
 // `@fohte/service-kit/observability` also exports `captureWithFingerprint`,
-// for reporting an error at an interop boundary under a stable fingerprint
-// (for Sentry grouping) without changing control flow. Call it once, right
-// before re-throwing a wrapped BoundaryError (see src/errors.ts):
+// for reporting an error under a stable fingerprint (for Sentry grouping)
+// without changing control flow. Call it once, right before re-throwing a
+// wrapped BoundaryError (see src/errors.ts), in a file listed under
+// eslint.config.js's errorHandling.interopBoundaryFiles — this file isn't
+// one, since it never catches an error itself:
 //
 //   import { captureWithFingerprint } from '@fohte/service-kit/observability'
 //

--- a/generated/node/src/errors.test.ts
+++ b/generated/node/src/errors.test.ts
@@ -10,8 +10,14 @@ describe('BoundaryError', () => {
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped.name).toBe('TaskStorePersistenceError')
-    expect(wrapped.message).toBe('failed to save')
-    expect(wrapped.cause).toBe(original)
+    expect({
+      name: wrapped.name,
+      message: wrapped.message,
+      causeIsOriginal: wrapped.cause === original,
+    }).toEqual({
+      name: 'TaskStorePersistenceError',
+      message: 'failed to save',
+      causeIsOriginal: true,
+    })
   })
 })

--- a/generated/node/src/errors.test.ts
+++ b/generated/node/src/errors.test.ts
@@ -10,14 +10,8 @@ describe('BoundaryError', () => {
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
 
-    expect({
-      name: wrapped.name,
-      message: wrapped.message,
-      causeIsOriginal: wrapped.cause === original,
-    }).toEqual({
-      name: 'TaskStorePersistenceError',
-      message: 'failed to save',
-      causeIsOriginal: true,
-    })
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
   })
 })

--- a/generated/node/src/errors.test.ts
+++ b/generated/node/src/errors.test.ts
@@ -9,8 +9,9 @@ describe('BoundaryError', () => {
     const original = new Error('connection refused')
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
-    const expected = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped).toEqual(expected)
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
   })
 })

--- a/generated/node/src/errors.test.ts
+++ b/generated/node/src/errors.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { BoundaryError } from '@/errors'
+
+class TaskStorePersistenceError extends BoundaryError {}
+
+describe('BoundaryError', () => {
+  it('derives name from the subclass and preserves the original error as cause', () => {
+    const original = new Error('connection refused')
+
+    const wrapped = new TaskStorePersistenceError('failed to save', original)
+
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
+  })
+})

--- a/generated/node/src/errors.test.ts
+++ b/generated/node/src/errors.test.ts
@@ -9,9 +9,8 @@ describe('BoundaryError', () => {
     const original = new Error('connection refused')
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
+    const expected = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped.name).toBe('TaskStorePersistenceError')
-    expect(wrapped.message).toBe('failed to save')
-    expect(wrapped.cause).toBe(original)
+    expect(wrapped).toEqual(expected)
   })
 })

--- a/generated/node/src/errors.ts
+++ b/generated/node/src/errors.ts
@@ -1,10 +1,24 @@
 // Wrap a caught external error before re-throwing, so it carries a
 // domain-meaningful message while preserving the original via `cause`.
-// Subclass per interop boundary (see eslint.config.js's
-// errorHandling.interopBoundaryFiles) — `name` is derived automatically, so
-// no constructor override is needed:
+// Subclass per interop boundary — `name` is derived automatically, so no
+// constructor override is needed. The throw/try-catch this requires needs
+// an eslint-disable-next-line comment, since @fohte/eslint-config's
+// errorHandling bans them elsewhere:
 //
 //   export class TaskStorePersistenceError extends BoundaryError {}
+//
+//   // eslint-disable-next-line no-restricted-syntax -- interop boundary
+//   try {
+//     ...
+//   } catch (caughtErr) {
+//     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     throw wrapped
+//   }
+//
+// To report a wrapped error under a stable fingerprint (for Sentry
+// grouping) without changing control flow, call `captureWithFingerprint`
+// (from `@fohte/service-kit/observability`, see src/bootstrap.ts) right
+// before re-throwing.
 export abstract class BoundaryError extends Error {
   constructor(message: string, cause: unknown) {
     super(message, { cause })

--- a/generated/node/src/errors.ts
+++ b/generated/node/src/errors.ts
@@ -1,0 +1,13 @@
+// Wrap a caught external error before re-throwing, so it carries a
+// domain-meaningful message while preserving the original via `cause`.
+// Subclass per interop boundary (see eslint.config.js's
+// errorHandling.interopBoundaryFiles) — `name` is derived automatically, so
+// no constructor override is needed:
+//
+//   export class TaskStorePersistenceError extends BoundaryError {}
+export abstract class BoundaryError extends Error {
+  constructor(message: string, cause: unknown) {
+    super(message, { cause })
+    this.name = new.target.name
+  }
+}

--- a/generated/node/src/errors.ts
+++ b/generated/node/src/errors.ts
@@ -1,9 +1,9 @@
 // Wrap a caught external error before re-throwing, so it carries a
 // domain-meaningful message while preserving the original via `cause`.
 // Subclass per interop boundary — `name` is derived automatically, so no
-// constructor override is needed. The throw/try-catch this requires needs
-// an eslint-disable-next-line comment, since @fohte/eslint-config's
-// errorHandling bans them elsewhere:
+// constructor override is needed. The try and the throw this requires each
+// need their own eslint-disable-next-line comment, since @fohte/eslint-config's
+// errorHandling bans ThrowStatement and TryStatement as separate selectors:
 //
 //   export class TaskStorePersistenceError extends BoundaryError {}
 //
@@ -12,6 +12,7 @@
 //     ...
 //   } catch (caughtErr) {
 //     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     // eslint-disable-next-line no-restricted-syntax -- interop boundary
 //     throw wrapped
 //   }
 //

--- a/generated/rust-with-node-subpackage/CLAUDE.md
+++ b/generated/rust-with-node-subpackage/CLAUDE.md
@@ -28,7 +28,7 @@ function parseConfig(raw: string): Result<Config, ConfigError> {
 }
 ```
 
-Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow with an `eslint-disable-next-line no-restricted-syntax` comment explaining why.
+Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow it — `no-restricted-syntax` bans `try`/`throw` as separate selectors, so both the `try` and the `throw` need their own `eslint-disable-next-line no-restricted-syntax` comment explaining why.
 
 ## Test code rules
 

--- a/generated/rust-with-node-subpackage/CLAUDE.md
+++ b/generated/rust-with-node-subpackage/CLAUDE.md
@@ -8,6 +8,28 @@ When a change would push a file's non-test code past ~500 lines, split it along 
 
 Prefer creating a new focused file over appending to the largest existing one.
 
+## Error handling rules
+
+### Return a `Result` instead of throwing
+
+`errorHandling` in `eslint.config.js` bans `throw`/`try-catch` in production code and requires every returned `Result` to be consumed (`no-restricted-syntax`, `neverthrow/must-use-result` in `@fohte/eslint-config`). Return a `Result`/`ResultAsync` from [neverthrow](https://github.com/supermacro/neverthrow) instead:
+
+```ts
+// bad: throws
+function parseConfig(raw: string): Config {
+  if (!isValid(raw)) throw new Error('invalid config')
+  return JSON.parse(raw)
+}
+
+// good: returns a Result
+function parseConfig(raw: string): Result<Config, ConfigError> {
+  if (!isValid(raw)) return err(new ConfigError('invalid config'))
+  return ok(JSON.parse(raw))
+}
+```
+
+Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow with an `eslint-disable-next-line no-restricted-syntax` comment explaining why.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -7,6 +7,30 @@
 When a change would push a file's non-test code past ~500 lines, split it along responsibility seams before adding more. Splits must be move-only commits: no logic changes, renames, or reformatting mixed in. Keep external import paths unchanged by keeping the entrypoint file in place and re-exporting the pieces you split out into new files (e.g. {% if has_rust and has_node %}`foo.rs` gains a `foo/` directory for its submodules, `index.ts` re-exports from the new files{% elif has_rust %}`foo.rs` gains a `foo/` directory for its submodules{% else %}`index.ts` re-exports from the new files{% endif %}). Tests move together with the code they verify.
 
 Prefer creating a new focused file over appending to the largest existing one.
+{%- if has_node %}
+
+## Error handling rules
+
+### Return a `Result` instead of throwing
+
+`errorHandling` in `eslint.config.js` bans `throw`/`try-catch` in production code and requires every returned `Result` to be consumed (`no-restricted-syntax`, `neverthrow/must-use-result` in `@fohte/eslint-config`). Return a `Result`/`ResultAsync` from [neverthrow](https://github.com/supermacro/neverthrow) instead:
+
+```ts
+// bad: throws
+function parseConfig(raw: string): Config {
+  if (!isValid(raw)) throw new Error('invalid config')
+  return JSON.parse(raw)
+}
+
+// good: returns a Result
+function parseConfig(raw: string): Result<Config, ConfigError> {
+  if (!isValid(raw)) return err(new ConfigError('invalid config'))
+  return ok(JSON.parse(raw))
+}
+```
+
+Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow with an `eslint-disable-next-line no-restricted-syntax` comment explaining why.
+{%- endif %}
 
 ## Test code rules
 

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -29,7 +29,7 @@ function parseConfig(raw: string): Result<Config, ConfigError> {
 }
 ```
 
-Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow with an `eslint-disable-next-line no-restricted-syntax` comment explaining why.
+Use `ResultAsync.fromPromise()` or `Result.fromThrowable()` to interop with a throwing API without a local try/catch. If the throw-based contract genuinely can't be wrapped that way, catch the exception, wrap it in a `BoundaryError` subclass (see `src/errors.ts`), and rethrow it — `no-restricted-syntax` bans `try`/`throw` as separate selectors, so both the `try` and the `throw` need their own `eslint-disable-next-line no-restricted-syntax` comment explaining why.
 {%- endif %}
 
 ## Test code rules

--- a/template/eslint.config.js.jinja
+++ b/template/eslint.config.js.jinja
@@ -5,7 +5,16 @@ import storybook from 'eslint-plugin-storybook'
 {%- endif %}
 
 export default config(
-  { typescript: { typeChecked: true } },
+  {
+    typescript: { typeChecked: true },
+    errorHandling: {
+      // Glob paths for files that interop with an external SDK/framework or
+      // run at process startup (e.g. env validation, DB migrations, main
+      // entrypoints) and therefore need throw/try-catch. Everywhere else,
+      // model failures as neverthrow Result/ResultAsync values instead.
+      interopBoundaryFiles: [],
+    },
+  },
 {%- if has_storybook %}
   ...storybook.configs['flat/recommended'],
 {%- endif %}

--- a/template/eslint.config.js.jinja
+++ b/template/eslint.config.js.jinja
@@ -7,13 +7,7 @@ import storybook from 'eslint-plugin-storybook'
 export default config(
   {
     typescript: { typeChecked: true },
-    errorHandling: {
-      // Glob paths for files that interop with an external SDK/framework or
-      // run at process startup (e.g. env validation, DB migrations, main
-      // entrypoints) and therefore need throw/try-catch. Everywhere else,
-      // model failures as neverthrow Result/ResultAsync values instead.
-      interopBoundaryFiles: [],
-    },
+    errorHandling: {},
   },
 {%- if has_storybook %}
   ...storybook.configs['flat/recommended'],

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -44,13 +44,15 @@
     "@opentelemetry/sdk-trace-base": "2.8.0",
     "@opentelemetry/semantic-conventions": "1.41.1",
     "@sentry/node": "10.63.0",
-    "@sentry/opentelemetry": "10.63.0"
+    "@sentry/opentelemetry": "10.63.0",
+    "neverthrow": "8.2.0"
   },
 {%- endif %}
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.6",
+    "@fohte/eslint-config": "0.3.7",
+    "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
 {%- if has_storybook and not is_workspace %}
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.7",
+    "@fohte/eslint-config": "0.3.9",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
 {%- if has_storybook and not is_workspace %}
     "@storybook/addon-docs": "10.4.6",

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -32,8 +32,9 @@
     "storybook:build": "storybook build"
 {%- endif %}
   },
-{%- if root_is_web_app %}
+{%- if type == 'node' %}
   "dependencies": {
+{%- if root_is_web_app %}
     "@fohte/service-kit": "0.1.4",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.77.0",
@@ -45,6 +46,7 @@
     "@opentelemetry/semantic-conventions": "1.41.1",
     "@sentry/node": "10.63.0",
     "@sentry/opentelemetry": "10.63.0",
+{%- endif %}
     "neverthrow": "8.2.0"
   },
 {%- endif %}

--- a/template/src/bootstrap.ts
+++ b/template/src/bootstrap.ts
@@ -12,3 +12,16 @@ import {
 if (isObservabilityConfigured(process.env)) {
   initObservability(process.env)
 }
+
+// `@fohte/service-kit/observability` also exports `captureWithFingerprint`,
+// for reporting an error at an interop boundary under a stable fingerprint
+// (for Sentry grouping) without changing control flow. Call it once, right
+// before re-throwing a wrapped BoundaryError (see src/errors.ts):
+//
+//   import { captureWithFingerprint } from '@fohte/service-kit/observability'
+//
+//   catch (caughtErr) {
+//     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     captureWithFingerprint(wrapped, 'task-store.persistence-error')
+//     throw wrapped
+//   }

--- a/template/src/bootstrap.ts
+++ b/template/src/bootstrap.ts
@@ -14,16 +14,5 @@ if (isObservabilityConfigured(process.env)) {
 }
 
 // `@fohte/service-kit/observability` also exports `captureWithFingerprint`,
-// for reporting an error under a stable fingerprint (for Sentry grouping)
-// without changing control flow. Call it once, right before re-throwing a
-// wrapped BoundaryError (see src/errors.ts), in a file listed under
-// eslint.config.js's errorHandling.interopBoundaryFiles — this file isn't
-// one, since it never catches an error itself:
-//
-//   import { captureWithFingerprint } from '@fohte/service-kit/observability'
-//
-//   catch (caughtErr) {
-//     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
-//     captureWithFingerprint(wrapped, 'task-store.persistence-error')
-//     throw wrapped
-//   }
+// for reporting a wrapped BoundaryError under a stable fingerprint (for
+// Sentry grouping) — see src/errors.ts for the throw/catch usage.

--- a/template/src/bootstrap.ts
+++ b/template/src/bootstrap.ts
@@ -12,7 +12,3 @@ import {
 if (isObservabilityConfigured(process.env)) {
   initObservability(process.env)
 }
-
-// `@fohte/service-kit/observability` also exports `captureWithFingerprint`,
-// for reporting a wrapped BoundaryError under a stable fingerprint (for
-// Sentry grouping) — see src/errors.ts for the throw/catch usage.

--- a/template/src/bootstrap.ts
+++ b/template/src/bootstrap.ts
@@ -14,9 +14,11 @@ if (isObservabilityConfigured(process.env)) {
 }
 
 // `@fohte/service-kit/observability` also exports `captureWithFingerprint`,
-// for reporting an error at an interop boundary under a stable fingerprint
-// (for Sentry grouping) without changing control flow. Call it once, right
-// before re-throwing a wrapped BoundaryError (see src/errors.ts):
+// for reporting an error under a stable fingerprint (for Sentry grouping)
+// without changing control flow. Call it once, right before re-throwing a
+// wrapped BoundaryError (see src/errors.ts), in a file listed under
+// eslint.config.js's errorHandling.interopBoundaryFiles — this file isn't
+// one, since it never catches an error itself:
 //
 //   import { captureWithFingerprint } from '@fohte/service-kit/observability'
 //

--- a/template/src/errors.test.ts
+++ b/template/src/errors.test.ts
@@ -10,8 +10,14 @@ describe('BoundaryError', () => {
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped.name).toBe('TaskStorePersistenceError')
-    expect(wrapped.message).toBe('failed to save')
-    expect(wrapped.cause).toBe(original)
+    expect({
+      name: wrapped.name,
+      message: wrapped.message,
+      causeIsOriginal: wrapped.cause === original,
+    }).toEqual({
+      name: 'TaskStorePersistenceError',
+      message: 'failed to save',
+      causeIsOriginal: true,
+    })
   })
 })

--- a/template/src/errors.test.ts
+++ b/template/src/errors.test.ts
@@ -10,14 +10,8 @@ describe('BoundaryError', () => {
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
 
-    expect({
-      name: wrapped.name,
-      message: wrapped.message,
-      causeIsOriginal: wrapped.cause === original,
-    }).toEqual({
-      name: 'TaskStorePersistenceError',
-      message: 'failed to save',
-      causeIsOriginal: true,
-    })
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
   })
 })

--- a/template/src/errors.test.ts
+++ b/template/src/errors.test.ts
@@ -9,8 +9,9 @@ describe('BoundaryError', () => {
     const original = new Error('connection refused')
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
-    const expected = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped).toEqual(expected)
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
   })
 })

--- a/template/src/errors.test.ts
+++ b/template/src/errors.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { BoundaryError } from '@/errors'
+
+class TaskStorePersistenceError extends BoundaryError {}
+
+describe('BoundaryError', () => {
+  it('derives name from the subclass and preserves the original error as cause', () => {
+    const original = new Error('connection refused')
+
+    const wrapped = new TaskStorePersistenceError('failed to save', original)
+
+    expect(wrapped.name).toBe('TaskStorePersistenceError')
+    expect(wrapped.message).toBe('failed to save')
+    expect(wrapped.cause).toBe(original)
+  })
+})

--- a/template/src/errors.test.ts
+++ b/template/src/errors.test.ts
@@ -9,9 +9,8 @@ describe('BoundaryError', () => {
     const original = new Error('connection refused')
 
     const wrapped = new TaskStorePersistenceError('failed to save', original)
+    const expected = new TaskStorePersistenceError('failed to save', original)
 
-    expect(wrapped.name).toBe('TaskStorePersistenceError')
-    expect(wrapped.message).toBe('failed to save')
-    expect(wrapped.cause).toBe(original)
+    expect(wrapped).toEqual(expected)
   })
 })

--- a/template/src/errors.ts
+++ b/template/src/errors.ts
@@ -1,10 +1,24 @@
 // Wrap a caught external error before re-throwing, so it carries a
 // domain-meaningful message while preserving the original via `cause`.
-// Subclass per interop boundary (see eslint.config.js's
-// errorHandling.interopBoundaryFiles) — `name` is derived automatically, so
-// no constructor override is needed:
+// Subclass per interop boundary — `name` is derived automatically, so no
+// constructor override is needed. The throw/try-catch this requires needs
+// an eslint-disable-next-line comment, since @fohte/eslint-config's
+// errorHandling bans them elsewhere:
 //
 //   export class TaskStorePersistenceError extends BoundaryError {}
+//
+//   // eslint-disable-next-line no-restricted-syntax -- interop boundary
+//   try {
+//     ...
+//   } catch (caughtErr) {
+//     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     throw wrapped
+//   }
+//
+// To report a wrapped error under a stable fingerprint (for Sentry
+// grouping) without changing control flow, call `captureWithFingerprint`
+// (from `@fohte/service-kit/observability`, see src/bootstrap.ts) right
+// before re-throwing.
 export abstract class BoundaryError extends Error {
   constructor(message: string, cause: unknown) {
     super(message, { cause })

--- a/template/src/errors.ts
+++ b/template/src/errors.ts
@@ -1,0 +1,13 @@
+// Wrap a caught external error before re-throwing, so it carries a
+// domain-meaningful message while preserving the original via `cause`.
+// Subclass per interop boundary (see eslint.config.js's
+// errorHandling.interopBoundaryFiles) — `name` is derived automatically, so
+// no constructor override is needed:
+//
+//   export class TaskStorePersistenceError extends BoundaryError {}
+export abstract class BoundaryError extends Error {
+  constructor(message: string, cause: unknown) {
+    super(message, { cause })
+    this.name = new.target.name
+  }
+}

--- a/template/src/errors.ts
+++ b/template/src/errors.ts
@@ -1,9 +1,9 @@
 // Wrap a caught external error before re-throwing, so it carries a
 // domain-meaningful message while preserving the original via `cause`.
 // Subclass per interop boundary — `name` is derived automatically, so no
-// constructor override is needed. The throw/try-catch this requires needs
-// an eslint-disable-next-line comment, since @fohte/eslint-config's
-// errorHandling bans them elsewhere:
+// constructor override is needed. The try and the throw this requires each
+// need their own eslint-disable-next-line comment, since @fohte/eslint-config's
+// errorHandling bans ThrowStatement and TryStatement as separate selectors:
 //
 //   export class TaskStorePersistenceError extends BoundaryError {}
 //
@@ -12,6 +12,7 @@
 //     ...
 //   } catch (caughtErr) {
 //     const wrapped = new TaskStorePersistenceError('failed to save', caughtErr)
+//     // eslint-disable-next-line no-restricted-syntax -- interop boundary
 //     throw wrapped
 //   }
 //

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
@@ -1,8 +1,8 @@
 {%- set has_storybook = pkg.storybook | default(false) -%}
 {%- set has_tests = pkg.tests | default(true) -%}
 {#- bootstrap.ts only emits when both web_app and tests are true (tests=false
-    collapses the src/ segment). Keep the dependency block on the same gate
-    so we never ship deps without the file that uses them. -#}
+    collapses the src/ segment). Keep the OTel/Sentry dependency block on the
+    same gate so we never ship deps without the file that uses them. -#}
 {%- set pkg_is_web_app = (pkg.web_app | default(false)) and (pkg.tests | default(true)) -%}
 {%- set has_scripts = has_tests or has_storybook -%}
 {%- set has_dev_deps = (has_tests and not is_workspace) or has_storybook -%}
@@ -12,7 +12,7 @@
 {%- if not is_workspace %}
   "packageManager": "pnpm@11.9.0",
 {%- endif %}
-  "type": "module"{{ "," if has_scripts or pkg_is_web_app else "" }}
+  "type": "module"{{ "," if has_scripts else "" }}
 {%- if has_scripts %}
   "scripts": {
 {%- if has_tests and not is_workspace %}
@@ -30,10 +30,11 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build"
 {%- endif %}
-  }{{ "," if has_dev_deps or pkg_is_web_app else "" }}
+  }{{ "," if has_dev_deps or has_tests else "" }}
 {%- endif %}
-{%- if pkg_is_web_app %}
+{%- if has_tests %}
   "dependencies": {
+{%- if pkg_is_web_app %}
     "@fohte/service-kit": "0.1.4",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/auto-instrumentations-node": "0.77.0",
@@ -45,6 +46,7 @@
     "@opentelemetry/semantic-conventions": "1.41.1",
     "@sentry/node": "10.63.0",
     "@sentry/opentelemetry": "10.63.0",
+{%- endif %}
     "neverthrow": "8.2.0"
   }{{ "," if has_dev_deps else "" }}
 {%- endif %}

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.7",
+    "@fohte/eslint-config": "0.3.9",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
 {%- if has_storybook %}
     "@storybook/addon-docs": "10.4.6",

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
@@ -44,14 +44,16 @@
     "@opentelemetry/sdk-trace-base": "2.8.0",
     "@opentelemetry/semantic-conventions": "1.41.1",
     "@sentry/node": "10.63.0",
-    "@sentry/opentelemetry": "10.63.0"
+    "@sentry/opentelemetry": "10.63.0",
+    "neverthrow": "8.2.0"
   }{{ "," if has_dev_deps else "" }}
 {%- endif %}
 {%- if has_tests and not is_workspace %}
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.6",
+    "@fohte/eslint-config": "0.3.7",
+    "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
 {%- if has_storybook %}
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) and not (monorepo_node_workspace | default(false)) %}eslint.config.js{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) and not (monorepo_node_workspace | default(false)) %}eslint.config.js{% endif %}.jinja
@@ -5,7 +5,16 @@ import storybook from 'eslint-plugin-storybook'
 {%- endif %}
 
 export default config(
-  { typescript: { typeChecked: true } },
+  {
+    typescript: { typeChecked: true },
+    errorHandling: {
+      // Glob paths for files that interop with an external SDK/framework or
+      // run at process startup (e.g. env validation, DB migrations, main
+      // entrypoints) and therefore need throw/try-catch. Everywhere else,
+      // model failures as neverthrow Result/ResultAsync values instead.
+      interopBoundaryFiles: [],
+    },
+  },
 {%- if has_storybook %}
   ...storybook.configs['flat/recommended'],
 {%- endif %}

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) and not (monorepo_node_workspace | default(false)) %}eslint.config.js{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) and not (monorepo_node_workspace | default(false)) %}eslint.config.js{% endif %}.jinja
@@ -7,13 +7,7 @@ import storybook from 'eslint-plugin-storybook'
 export default config(
   {
     typescript: { typeChecked: true },
-    errorHandling: {
-      // Glob paths for files that interop with an external SDK/framework or
-      // run at process startup (e.g. env validation, DB migrations, main
-      // entrypoints) and therefore need throw/try-catch. Everywhere else,
-      // model failures as neverthrow Result/ResultAsync values instead.
-      interopBoundaryFiles: [],
-    },
+    errorHandling: {},
   },
 {%- if has_storybook %}
   ...storybook.configs['flat/recommended'],

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'rust' or (pkg.type == 'node' and pkg.tests | default(true)) %}src{% endif %}/{% if pkg.type == 'node' %}errors.test.ts{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'rust' or (pkg.type == 'node' and pkg.tests | default(true)) %}src{% endif %}/{% if pkg.type == 'node' %}errors.test.ts{% endif %}.jinja
@@ -1,0 +1,1 @@
+{% include "template/src/errors.test.ts" -%}

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'rust' or (pkg.type == 'node' and pkg.tests | default(true)) %}src{% endif %}/{% if pkg.type == 'node' %}errors.ts{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'rust' or (pkg.type == 'node' and pkg.tests | default(true)) %}src{% endif %}/{% if pkg.type == 'node' %}errors.ts{% endif %}.jinja
@@ -1,0 +1,1 @@
+{% include "template/src/errors.ts" -%}


### PR DESCRIPTION
## Purpose

- from: [fohte/meshi#68](https://github.com/fohte/meshi/pull/68), [fohte/eslint-config#433](https://github.com/fohte/eslint-config/pull/433)
- Let newly generated Node.js projects start with the same error-handling design meshi adopted
    - In meshi, catching an exception and only `console.error`/`logger.error`-ing it meant a production-equivalent TypeError never reached Sentry

## Approach

- Bump [`@fohte/eslint-config`](https://github.com/fohte/eslint-config) to v0.3.9 to enable its `errorHandling` option, banning `throw`/`try-catch` and discarded neverthrow `Result`s outside interop boundary files
- Add a domain error base class scaffold and the `neverthrow`/`@ninoseki/eslint-plugin-neverthrow` dependencies, assuming a migration to neverthrow
- Document the pattern of reporting to Sentry via `captureWithFingerprint` before re-throwing at an interop boundary, with a comment example
- Document the neverthrow convention in `CLAUDE.md` so it's followed from the start instead of being discovered via a lint failure

<details>
<summary>Design decisions</summary>

#### Scope of the neverthrow runtime dependency

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen | Add `neverthrow` to every node package that has tests | Matches the scope where `errorHandling` applies (every package with tests) with the packages that can actually import it | Adds a runtime dependency to non-web-app packages too |
| Rejected | Add `neverthrow` only to web-app packages (same condition as OTel/Sentry) | Limits the new runtime dependency to web apps | `errorHandling` applies beyond web apps too, so non-web-app packages couldn't resolve `neverthrow` even though the lint rule requires it |

</details>

### Breaking changes

- Existing `type: node` projects will start failing lint on any `throw`/`try-catch` in production code after running `copier update`
