### PR TITLE
feat(template)!: switch internal imports to # subpath imports

### DIFF
--- a/generated/monorepo-node-workspace/backend/package.json
+++ b/generated/monorepo-node-workspace/backend/package.json
@@ -2,6 +2,9 @@
   "name": "backend",
   "private": true,
   "type": "module",
+  "imports": {
+    "#*": "./src/*.ts"
+  },
   "scripts": {
     "test": "conc pnpm:test:type pnpm:test:unit",
     "test:type": "tsc --noEmit",

--- a/generated/monorepo-node-workspace/backend/src/errors.test.ts
+++ b/generated/monorepo-node-workspace/backend/src/errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BoundaryError } from '@/errors'
+import { BoundaryError } from '#errors'
 
 class TaskStorePersistenceError extends BoundaryError {}
 

--- a/generated/monorepo-node-workspace/backend/src/index.test.ts
+++ b/generated/monorepo-node-workspace/backend/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { greet } from '@/index'
+import { greet } from '#index'
 
 describe('greet', () => {
   it('should return greeting message', () => {

--- a/generated/monorepo-node-workspace/backend/tsconfig.json
+++ b/generated/monorepo-node-workspace/backend/tsconfig.json
@@ -7,9 +7,6 @@
   "compilerOptions": {
     "module": "preserve",
     "moduleResolution": "bundler",
-    "noEmit": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "noEmit": true
   }
 }

--- a/generated/monorepo-node-workspace/backend/vitest.config.ts
+++ b/generated/monorepo-node-workspace/backend/vitest.config.ts
@@ -1,9 +1,3 @@
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@': '/src',
-    },
-  },
-})
+export default defineConfig({})

--- a/generated/monorepo-node-workspace/eslint.config.js
+++ b/generated/monorepo-node-workspace/eslint.config.js
@@ -7,27 +7,4 @@ export default config(
     errorHandling: {},
   },
   ...storybook.configs['flat/recommended'],
-  {
-    rules: {
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: ['./*', '../*'],
-              message:
-                'Please use absolute imports instead of relative imports.',
-            },
-          ],
-        },
-      ],
-    },
-  },
-  // .storybook/ is outside src/ where @ alias is unavailable
-  {
-    files: ['**/.storybook/**/*.ts'],
-    rules: {
-      'no-restricted-imports': 'off',
-    },
-  },
 )

--- a/generated/monorepo-node-workspace/frontend/package.json
+++ b/generated/monorepo-node-workspace/frontend/package.json
@@ -2,6 +2,9 @@
   "name": "frontend",
   "private": true,
   "type": "module",
+  "imports": {
+    "#*": "./src/*.ts"
+  },
   "scripts": {
     "test": "conc pnpm:test:type pnpm:test:unit",
     "test:type": "tsc --noEmit",

--- a/generated/monorepo-node-workspace/frontend/src/errors.test.ts
+++ b/generated/monorepo-node-workspace/frontend/src/errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BoundaryError } from '@/errors'
+import { BoundaryError } from '#errors'
 
 class TaskStorePersistenceError extends BoundaryError {}
 

--- a/generated/monorepo-node-workspace/frontend/src/index.test.ts
+++ b/generated/monorepo-node-workspace/frontend/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { greet } from '@/index'
+import { greet } from '#index'
 
 describe('greet', () => {
   it('should return greeting message', () => {

--- a/generated/monorepo-node-workspace/frontend/tsconfig.json
+++ b/generated/monorepo-node-workspace/frontend/tsconfig.json
@@ -8,9 +8,6 @@
   "compilerOptions": {
     "module": "preserve",
     "moduleResolution": "bundler",
-    "noEmit": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "noEmit": true
   }
 }

--- a/generated/monorepo-node-workspace/frontend/vitest.config.ts
+++ b/generated/monorepo-node-workspace/frontend/vitest.config.ts
@@ -1,9 +1,3 @@
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@': '/src',
-    },
-  },
-})
+export default defineConfig({})

--- a/generated/monorepo-node-workspace/package.json
+++ b/generated/monorepo-node-workspace/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.9",
+    "@fohte/eslint-config": "0.4.0",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/strictest": "2.0.8",

--- a/generated/monorepo-node-workspace/pnpm-workspace.yaml
+++ b/generated/monorepo-node-workspace/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ allowBuilds:
   esbuild: true
   # required by @opentelemetry/exporter-trace-otlp-proto
   protobufjs: true
-  # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
+  # required by @fohte/eslint-config -> eslint-plugin-import-x for module resolution
   unrs-resolver: true
 
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by

--- a/generated/monorepo/frontend/eslint.config.js
+++ b/generated/monorepo/frontend/eslint.config.js
@@ -7,27 +7,4 @@ export default config(
     errorHandling: {},
   },
   ...storybook.configs['flat/recommended'],
-  {
-    rules: {
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: ['./*', '../*'],
-              message:
-                'Please use absolute imports instead of relative imports.',
-            },
-          ],
-        },
-      ],
-    },
-  },
-  // .storybook/ and vitest.config.ts are outside src/ where @ alias is unavailable
-  {
-    files: ['.storybook/**/*.ts', 'vitest.config.ts'],
-    rules: {
-      'no-restricted-imports': 'off',
-    },
-  },
 )

--- a/generated/monorepo/frontend/package.json
+++ b/generated/monorepo/frontend/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "packageManager": "pnpm@11.9.0",
   "type": "module",
+  "imports": {
+    "#*": "./src/*.ts"
+  },
   "scripts": {
     "lint": "eslint .",
     "format:eslint": "eslint --fix .",
@@ -20,7 +23,7 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.9",
+    "@fohte/eslint-config": "0.4.0",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",

--- a/generated/monorepo/frontend/pnpm-workspace.yaml
+++ b/generated/monorepo/frontend/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 allowBuilds:
   # required by vitest's transformer
   esbuild: true
-  # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
+  # required by @fohte/eslint-config -> eslint-plugin-import-x for module resolution
   unrs-resolver: true
 
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by

--- a/generated/monorepo/frontend/src/errors.test.ts
+++ b/generated/monorepo/frontend/src/errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BoundaryError } from '@/errors'
+import { BoundaryError } from '#errors'
 
 class TaskStorePersistenceError extends BoundaryError {}
 

--- a/generated/monorepo/frontend/src/index.test.ts
+++ b/generated/monorepo/frontend/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { greet } from '@/index'
+import { greet } from '#index'
 
 describe('greet', () => {
   it('should return greeting message', () => {

--- a/generated/monorepo/frontend/tsconfig.json
+++ b/generated/monorepo/frontend/tsconfig.json
@@ -8,9 +8,6 @@
   "compilerOptions": {
     "module": "preserve",
     "moduleResolution": "bundler",
-    "noEmit": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "noEmit": true
   }
 }

--- a/generated/monorepo/frontend/vitest.config.ts
+++ b/generated/monorepo/frontend/vitest.config.ts
@@ -1,9 +1,3 @@
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@': '/src',
-    },
-  },
-})
+export default defineConfig({})

--- a/generated/node/eslint.config.js
+++ b/generated/node/eslint.config.js
@@ -7,27 +7,4 @@ export default config(
     errorHandling: {},
   },
   ...storybook.configs['flat/recommended'],
-  {
-    rules: {
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: ['./*', '../*'],
-              message:
-                'Please use absolute imports instead of relative imports.',
-            },
-          ],
-        },
-      ],
-    },
-  },
-  // .storybook/ and vitest.config.ts are outside src/ where @ alias is unavailable
-  {
-    files: ['.storybook/**/*.ts', 'vitest.config.ts'],
-    rules: {
-      'no-restricted-imports': 'off',
-    },
-  },
 )

--- a/generated/node/package.json
+++ b/generated/node/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "packageManager": "pnpm@11.9.0",
   "type": "module",
+  "imports": {
+    "#*": "./src/*.ts"
+  },
   "scripts": {
     "lint": "eslint .",
     "format:eslint": "eslint --fix .",
@@ -31,7 +34,7 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.9",
+    "@fohte/eslint-config": "0.4.0",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",

--- a/generated/node/pnpm-workspace.yaml
+++ b/generated/node/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ allowBuilds:
   esbuild: true
   # required by @opentelemetry/exporter-trace-otlp-proto
   protobufjs: true
-  # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
+  # required by @fohte/eslint-config -> eslint-plugin-import-x for module resolution
   unrs-resolver: true
 
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by

--- a/generated/node/src/errors.test.ts
+++ b/generated/node/src/errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BoundaryError } from '@/errors'
+import { BoundaryError } from '#errors'
 
 class TaskStorePersistenceError extends BoundaryError {}
 

--- a/generated/node/src/index.test.ts
+++ b/generated/node/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { greet } from '@/index'
+import { greet } from '#index'
 
 describe('greet', () => {
   it('should return greeting message', () => {

--- a/generated/node/tsconfig.json
+++ b/generated/node/tsconfig.json
@@ -8,9 +8,6 @@
   "compilerOptions": {
     "module": "preserve",
     "moduleResolution": "bundler",
-    "noEmit": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "noEmit": true
   }
 }

--- a/generated/node/vitest.config.ts
+++ b/generated/node/vitest.config.ts
@@ -1,9 +1,3 @@
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@': '/src',
-    },
-  },
-})
+export default defineConfig({})

--- a/generated/rust-with-node-subpackage/docs/pnpm-workspace.yaml
+++ b/generated/rust-with-node-subpackage/docs/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 allowBuilds:
   # required by vitest's transformer
   esbuild: true
-  # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
+  # required by @fohte/eslint-config -> eslint-plugin-import-x for module resolution
   unrs-resolver: true
 
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by

--- a/template/eslint.config.js.jinja
+++ b/template/eslint.config.js.jinja
@@ -12,37 +12,4 @@ export default config(
 {%- if has_storybook %}
   ...storybook.configs['flat/recommended'],
 {%- endif %}
-  {
-    rules: {
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: ['./*', '../*'],
-              message:
-                'Please use absolute imports instead of relative imports.',
-            },
-          ],
-        },
-      ],
-    },
-  },
-{%- if has_storybook and not is_workspace %}
-  // .storybook/ and vitest.config.ts are outside src/ where @ alias is unavailable
-  {
-    files: ['.storybook/**/*.ts', 'vitest.config.ts'],
-    rules: {
-      'no-restricted-imports': 'off',
-    },
-  },
-{%- elif has_storybook and is_workspace %}
-  // .storybook/ is outside src/ where @ alias is unavailable
-  {
-    files: ['**/.storybook/**/*.ts'],
-    rules: {
-      'no-restricted-imports': 'off',
-    },
-  },
-{%- endif %}
 )

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -15,6 +15,11 @@
 {%- endif %}
   "packageManager": "pnpm@11.9.0",
   "type": "module",
+{%- if type == 'node' %}
+  "imports": {
+    "#*": "./src/*.ts"
+  },
+{%- endif %}
   "scripts": {
     "lint": "eslint .",
     "format:eslint": "eslint --fix .",
@@ -53,7 +58,7 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.9",
+    "@fohte/eslint-config": "0.4.0",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
 {%- if has_storybook and not is_workspace %}
     "@storybook/addon-docs": "10.4.6",

--- a/template/pnpm-workspace.yaml.jinja
+++ b/template/pnpm-workspace.yaml.jinja
@@ -12,7 +12,7 @@ allowBuilds:
   # required by @opentelemetry/exporter-trace-otlp-proto
   protobufjs: true
 {%- endif %}
-  # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
+  # required by @fohte/eslint-config -> eslint-plugin-import-x for module resolution
   unrs-resolver: true
 
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by

--- a/template/src/errors.test.ts
+++ b/template/src/errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BoundaryError } from '@/errors'
+import { BoundaryError } from '#errors'
 
 class TaskStorePersistenceError extends BoundaryError {}
 

--- a/template/src/index.test.ts
+++ b/template/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { greet } from '@/index'
+import { greet } from '#index'
 
 describe('greet', () => {
   it('should return greeting message', () => {

--- a/template/tsconfig.json.jinja
+++ b/template/tsconfig.json.jinja
@@ -11,9 +11,6 @@
   "compilerOptions": {
     "module": "preserve",
     "moduleResolution": "bundler",
-    "noEmit": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "noEmit": true
   }
 }

--- a/template/vitest.config.ts
+++ b/template/vitest.config.ts
@@ -1,9 +1,3 @@
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@': '/src',
-    },
-  },
-})
+export default defineConfig({})

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
@@ -13,6 +13,11 @@
   "packageManager": "pnpm@11.9.0",
 {%- endif %}
   "type": "module"{{ "," if has_scripts else "" }}
+{%- if has_tests %}
+  "imports": {
+    "#*": "./src/*.ts"
+  },
+{%- endif %}
 {%- if has_scripts %}
   "scripts": {
 {%- if has_tests and not is_workspace %}
@@ -54,7 +59,7 @@
   "devDependencies": {
     "@commitlint/cli": "21.2.0",
     "@eslint/eslintrc": "3.3.5",
-    "@fohte/eslint-config": "0.3.9",
+    "@fohte/eslint-config": "0.4.0",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
 {%- if has_storybook %}
     "@storybook/addon-docs": "10.4.6",

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and not (monorepo_node_workspace | default(false)) %}pnpm-workspace.yaml{% endif %}
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and not (monorepo_node_workspace | default(false)) %}pnpm-workspace.yaml{% endif %}
@@ -1,7 +1,7 @@
 allowBuilds:
   # required by vitest's transformer
   esbuild: true
-  # required by @fohte/eslint-config -> eslint-plugin-import-x for "@/*" resolution
+  # required by @fohte/eslint-config -> eslint-plugin-import-x for module resolution
   unrs-resolver: true
 
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) %}tsconfig.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) %}tsconfig.json{% endif %}.jinja
@@ -11,9 +11,6 @@
   "compilerOptions": {
     "module": "preserve",
     "moduleResolution": "bundler",
-    "noEmit": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "noEmit": true
   }
 }

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) and not (monorepo_node_workspace | default(false)) %}eslint.config.js{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) and not (monorepo_node_workspace | default(false)) %}eslint.config.js{% endif %}.jinja
@@ -12,29 +12,4 @@ export default config(
 {%- if has_storybook %}
   ...storybook.configs['flat/recommended'],
 {%- endif %}
-  {
-    rules: {
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: ['./*', '../*'],
-              message:
-                'Please use absolute imports instead of relative imports.',
-            },
-          ],
-        },
-      ],
-    },
-  },
-{%- if has_storybook %}
-  // .storybook/ and vitest.config.ts are outside src/ where @ alias is unavailable
-  {
-    files: ['.storybook/**/*.ts', 'vitest.config.ts'],
-    rules: {
-      'no-restricted-imports': 'off',
-    },
-  },
-{%- endif %}
 )


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/slack-bot/pull/13
- A generated repository fails to start when it runs on a runtime that can't resolve the `@/*` alias
    - A downstream repository hit this in production: `tsx` couldn't resolve a `@/*` import and failed to start

## Approach

- Standardize internal imports in generated Node projects on Node's native [`#` subpath imports](https://nodejs.org/api/packages.html#subpath-imports) (the `imports` field in `package.json`)
    ```diff
    -import { greet } from '@/index'
    +import { greet } from '#index'
    ```

<details>
<summary>Design decisions</summary>

#### `imports` field mapping format

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen | Extensionless `"#*": "./src/*.ts"` | Existing `@/index`-style imports can be replaced with `#index` as-is | - |
| Rejected | Extension-qualified `"#*.js": "./src/*.ts"` (the form `@fohte/eslint-config` itself uses) | Strictly follows the ESM relative-import convention (`.js` extension required) | Every existing import statement would additionally need a `.js` extension appended |

</details>

### Breaking changes

- After a `copier update`, existing generated repositories will get lint errors on any `@/*` alias or relative import
    - These need to be replaced with `#` subpath imports
