### PR TITLE
fix(template): pnpm missing after corepack enable

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -126,6 +126,12 @@ jobs:
         run: corepack enable
         if: hashFiles(format('generated/{0}/**/package.json', matrix.fixture)) != ''
 
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - name: Reshim mise shims
+        run: mise reshim
+        if: hashFiles(format('generated/{0}/**/package.json', matrix.fixture)) != ''
+
       - name: Generate lockfiles
         working-directory: generated/${{ matrix.fixture }}
         run: |
@@ -201,6 +207,11 @@ jobs:
       - name: Enable corepack
         run: corepack enable
 
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - name: Reshim mise shims
+        run: mise reshim
+
       - name: Get pnpm store directory
         id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
@@ -245,6 +256,11 @@ jobs:
 
       - name: Enable corepack
         run: corepack enable
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - name: Reshim mise shims
+        run: mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -122,14 +122,12 @@ jobs:
           version: 2026.7.7
           working_directory: generated/${{ matrix.fixture }}
 
-      - name: Enable corepack
-        run: corepack enable
-        if: hashFiles(format('generated/{0}/**/package.json', matrix.fixture)) != ''
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - name: Reshim mise shims
-        run: mise reshim
+      - name: Enable corepack
+        run: |
+          corepack enable
+          mise reshim
         if: hashFiles(format('generated/{0}/**/package.json', matrix.fixture)) != ''
 
       - name: Generate lockfiles
@@ -204,13 +202,12 @@ jobs:
           version: 2026.7.7
           working_directory: generated/node
 
-      - name: Enable corepack
-        run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - name: Reshim mise shims
-        run: mise reshim
+      - name: Enable corepack
+        run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -254,13 +251,12 @@ jobs:
           version: 2026.7.7
           working_directory: generated/monorepo-node-workspace
 
-      - name: Enable corepack
-        run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - name: Reshim mise shims
-        run: mise reshim
+      - name: Enable corepack
+        run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/generated/monorepo-node-workspace/.github/workflows/storybook.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/storybook.yml
@@ -49,6 +49,10 @@ jobs:
 
       - run: corepack enable
 
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
+
       - name: Get pnpm store directory
         id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"

--- a/generated/monorepo-node-workspace/.github/workflows/storybook.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/storybook.yml
@@ -47,11 +47,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/generated/monorepo-node-workspace/.github/workflows/test.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
 
       - run: corepack enable
 
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
+
       - name: Get pnpm store directory
         id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
@@ -166,6 +170,10 @@ jobs:
           version: 2026.7.7
 
       - run: corepack enable
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/generated/monorepo-node-workspace/.github/workflows/test.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/test.yml
@@ -44,11 +44,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -169,11 +169,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/generated/monorepo-node-workspace/scripts/bootstrap
+++ b/generated/monorepo-node-workspace/scripts/bootstrap
@@ -18,6 +18,12 @@ fi
 # Enable corepack so that pnpm version from package.json packageManager field is used
 corepack enable
 
+# corepack creates the pnpm executable inside mise's node install bin
+# directory; reshim so the mise shims dir (which is on PATH) picks it up.
+if command -v mise > /dev/null 2>&1; then
+  mise reshim
+fi
+
 # Use --frozen-lockfile when a lockfile exists so a Renovate-bumped dep still
 # inside the pnpm-workspace.yaml minimumReleaseAge window does not re-trigger
 # the supply-chain policy check and block bootstrap. Fall back to plain

--- a/generated/monorepo/.github/workflows/storybook.yml
+++ b/generated/monorepo/.github/workflows/storybook.yml
@@ -44,11 +44,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/generated/monorepo/.github/workflows/storybook.yml
+++ b/generated/monorepo/.github/workflows/storybook.yml
@@ -46,6 +46,10 @@ jobs:
 
       - run: corepack enable
 
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
+
       - name: Get pnpm store directory
         id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"

--- a/generated/monorepo/.github/workflows/test.yml
+++ b/generated/monorepo/.github/workflows/test.yml
@@ -57,11 +57,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -155,11 +155,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/generated/monorepo/.github/workflows/test.yml
+++ b/generated/monorepo/.github/workflows/test.yml
@@ -59,6 +59,10 @@ jobs:
 
       - run: corepack enable
 
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
+
       - name: Get pnpm store directory
         id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
@@ -152,6 +156,10 @@ jobs:
           version: 2026.7.7
 
       - run: corepack enable
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/generated/monorepo/scripts/bootstrap
+++ b/generated/monorepo/scripts/bootstrap
@@ -18,6 +18,12 @@ fi
 # Enable corepack so that pnpm version from package.json packageManager field is used
 corepack enable
 
+# corepack creates the pnpm executable inside mise's node install bin
+# directory; reshim so the mise shims dir (which is on PATH) picks it up.
+if command -v mise > /dev/null 2>&1; then
+  mise reshim
+fi
+
 # Use --frozen-lockfile when a lockfile exists so a Renovate-bumped dep still
 # inside the pnpm-workspace.yaml minimumReleaseAge window does not re-trigger
 # the supply-chain policy check and block bootstrap. Fall back to plain

--- a/generated/node/.github/workflows/storybook.yml
+++ b/generated/node/.github/workflows/storybook.yml
@@ -49,6 +49,10 @@ jobs:
 
       - run: corepack enable
 
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
+
       - name: Get pnpm store directory
         id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"

--- a/generated/node/.github/workflows/storybook.yml
+++ b/generated/node/.github/workflows/storybook.yml
@@ -47,11 +47,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/generated/node/.github/workflows/test.yml
+++ b/generated/node/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
 
       - run: corepack enable
 
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
+
       - name: Get pnpm store directory
         id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
@@ -103,6 +107,10 @@ jobs:
           version: 2026.7.7
 
       - run: corepack enable
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/generated/node/.github/workflows/test.yml
+++ b/generated/node/.github/workflows/test.yml
@@ -44,11 +44,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -106,11 +106,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/generated/node/scripts/bootstrap
+++ b/generated/node/scripts/bootstrap
@@ -18,6 +18,12 @@ fi
 # Enable corepack so that pnpm version from package.json packageManager field is used
 corepack enable
 
+# corepack creates the pnpm executable inside mise's node install bin
+# directory; reshim so the mise shims dir (which is on PATH) picks it up.
+if command -v mise > /dev/null 2>&1; then
+  mise reshim
+fi
+
 # Use --frozen-lockfile when a lockfile exists so a Renovate-bumped dep still
 # inside the pnpm-workspace.yaml minimumReleaseAge window does not re-trigger
 # the supply-chain policy check and block bootstrap. Fall back to plain

--- a/generated/rust-with-node-subpackage/scripts/bootstrap
+++ b/generated/rust-with-node-subpackage/scripts/bootstrap
@@ -18,6 +18,12 @@ fi
 # Enable corepack so that pnpm version from package.json packageManager field is used
 corepack enable
 
+# corepack creates the pnpm executable inside mise's node install bin
+# directory; reshim so the mise shims dir (which is on PATH) picks it up.
+if command -v mise > /dev/null 2>&1; then
+  mise reshim
+fi
+
 # Use --frozen-lockfile when a lockfile exists so a Renovate-bumped dep still
 # inside the pnpm-workspace.yaml minimumReleaseAge window does not re-trigger
 # the supply-chain policy check and block bootstrap. Fall back to plain

--- a/template/.github/workflows/storybook.yml.jinja
+++ b/template/.github/workflows/storybook.yml.jinja
@@ -55,11 +55,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 {%- if is_workspace %}
 
       - name: Get pnpm store directory
@@ -154,11 +154,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/template/.github/workflows/storybook.yml.jinja
+++ b/template/.github/workflows/storybook.yml.jinja
@@ -56,6 +56,10 @@ jobs:
           version: 2026.7.7
 
       - run: corepack enable
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
 {%- if is_workspace %}
 
       - name: Get pnpm store directory
@@ -151,6 +155,10 @@ jobs:
           version: 2026.7.7
 
       - run: corepack enable
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -84,11 +84,11 @@ jobs:
           version: 2026.7.7
 {%- if type == 'node' %}
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -115,11 +115,11 @@ jobs:
     snapshot coverage. Render it manually via `copier copy --overwrite
     --defaults --data-file <fixture>.yml . .` when editing. #}
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -148,11 +148,11 @@ jobs:
 {%- if is_workspace %}
 {#- Workspace mode: single root install (pnpm only) #}
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -177,11 +177,11 @@ jobs:
     lockfile is intentionally excluded from the cache key and install step. #}
 {%- if testable_node_pkgs %}
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -255,11 +255,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -334,11 +334,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -435,11 +435,11 @@ jobs:
         with:
           version: 2026.7.7
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -555,11 +555,11 @@ jobs:
 {%- if is_workspace %}
 {#- Workspace mode: install from root (pnpm only) #}
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -581,11 +581,11 @@ jobs:
 {%- else %}
 {#- Non-workspace mode: per-package install #}
 
-      - run: corepack enable
-
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
-      - run: mise reshim
+      - run: |
+          corepack enable
+          mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -86,6 +86,10 @@ jobs:
 
       - run: corepack enable
 
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
+
       - name: Get pnpm store directory
         id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
@@ -112,6 +116,10 @@ jobs:
     --defaults --data-file <fixture>.yml . .` when editing. #}
 
       - run: corepack enable
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -142,6 +150,10 @@ jobs:
 
       - run: corepack enable
 
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
+
       - name: Get pnpm store directory
         id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
@@ -166,6 +178,10 @@ jobs:
 {%- if testable_node_pkgs %}
 
       - run: corepack enable
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -241,6 +257,10 @@ jobs:
 
       - run: corepack enable
 
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
+
       - name: Get pnpm store directory
         id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
@@ -315,6 +335,10 @@ jobs:
           version: 2026.7.7
 
       - run: corepack enable
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -412,6 +436,10 @@ jobs:
           version: 2026.7.7
 
       - run: corepack enable
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store
@@ -529,6 +557,10 @@ jobs:
 
       - run: corepack enable
 
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
+
       - name: Get pnpm store directory
         id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
@@ -550,6 +582,10 @@ jobs:
 {#- Non-workspace mode: per-package install #}
 
       - run: corepack enable
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: mise reshim
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/template/scripts/bootstrap.jinja
+++ b/template/scripts/bootstrap.jinja
@@ -19,6 +19,12 @@ fi
 # Enable corepack so that pnpm version from package.json packageManager field is used
 corepack enable
 
+# corepack creates the pnpm executable inside mise's node install bin
+# directory; reshim so the mise shims dir (which is on PATH) picks it up.
+if command -v mise > /dev/null 2>&1; then
+  mise reshim
+fi
+
 # Use --frozen-lockfile when a lockfile exists so a Renovate-bumped dep still
 # inside the pnpm-workspace.yaml minimumReleaseAge window does not re-trigger
 # the supply-chain policy check and block bootstrap. Fall back to plain


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/generic-boilerplate/pull/539
- Adopting [jdx/mise-action](https://github.com/jdx/mise-action)'s [PATH leak fix (v4.2.1)](https://github.com/jdx/mise-action/releases/tag/v4.2.1) makes the pnpm executable that `corepack enable` creates unreachable in later steps, and CI fails

### Reproduction steps

1. Bump `jdx/mise-action` to v4.2.1 or later
2. Run a CI job for a node-based project that calls `pnpm install` after `corepack enable`
3. It fails with `pnpm: command not found` (exit code 127)

## Approach

- Run `mise reshim` right after `corepack enable` so pnpm is detected regardless of mise-action's PATH leak fix state

<details>
<summary>Design decisions</summary>

#### How to reliably detect pnpm in CI and locally

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen | Run `mise reshim` right after `corepack enable` | Keeps `package.json`'s `packageManager` field as the source of truth for the pnpm version | Requires appending to every affected step |
| Rejected | Add pnpm as a mise-managed tool in `.mise.toml` | mise handles PATH management, no extra command needed | Splits pnpm version management between the `packageManager` field and `.mise.toml` |
| Rejected | Explicitly add node's real install bin directory to `$GITHUB_PATH` after `corepack enable` | Doesn't depend on mise's internal shim generation | Requires hardcoding node's install path, tightly coupling to mise's version management |

</details>
