### PR TITLE
fix(template): sync lockfiles after copier update

### DIFF
--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -110,7 +110,10 @@ jobs:
           while IFS= read -r -d '' lockfile; do
             dir=$(dirname "$lockfile")
             echo "Updating ${lockfile}"
-            (cd "$dir" && pnpm install --no-frozen-lockfile)
+            # --ignore-scripts: this job holds an OIDC token (id-token: write)
+            # and a checked-out repo with credentials; don't let an installed
+            # package's lifecycle script run with access to either.
+            (cd "$dir" && pnpm install --no-frozen-lockfile --ignore-scripts)
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles

--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -89,6 +89,40 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier only rewrites version strings in package.json/Cargo.toml; the
+      # lockfiles are never touched, so they must be regenerated here or the
+      # PR ships a stale lockfile. This also fails the workflow outright (before
+      # a PR is opened) if a bumped version doesn't actually exist upstream.
+      - name: Set up mise
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: 2026.7.12
+
+      - name: Sync pnpm lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        run: |
+          set -euo pipefail
+          # corepack creates the pnpm executable inside mise's node install bin
+          # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+          corepack enable
+          mise reshim
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && pnpm install --no-frozen-lockfile)
+          done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
+
+      - name: Sync Cargo lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && rustup show && cargo generate-lockfile)
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -not -path '*/.git/*' -print0)
+
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -110,7 +110,10 @@ jobs:
           while IFS= read -r -d '' lockfile; do
             dir=$(dirname "$lockfile")
             echo "Updating ${lockfile}"
-            (cd "$dir" && pnpm install --no-frozen-lockfile)
+            # --ignore-scripts: this job holds an OIDC token (id-token: write)
+            # and a checked-out repo with credentials; don't let an installed
+            # package's lifecycle script run with access to either.
+            (cd "$dir" && pnpm install --no-frozen-lockfile --ignore-scripts)
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -89,6 +89,40 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier only rewrites version strings in package.json/Cargo.toml; the
+      # lockfiles are never touched, so they must be regenerated here or the
+      # PR ships a stale lockfile. This also fails the workflow outright (before
+      # a PR is opened) if a bumped version doesn't actually exist upstream.
+      - name: Set up mise
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: 2026.7.12
+
+      - name: Sync pnpm lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        run: |
+          set -euo pipefail
+          # corepack creates the pnpm executable inside mise's node install bin
+          # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+          corepack enable
+          mise reshim
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && pnpm install --no-frozen-lockfile)
+          done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
+
+      - name: Sync Cargo lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && rustup show && cargo generate-lockfile)
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -not -path '*/.git/*' -print0)
+
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -110,7 +110,10 @@ jobs:
           while IFS= read -r -d '' lockfile; do
             dir=$(dirname "$lockfile")
             echo "Updating ${lockfile}"
-            (cd "$dir" && pnpm install --no-frozen-lockfile)
+            # --ignore-scripts: this job holds an OIDC token (id-token: write)
+            # and a checked-out repo with credentials; don't let an installed
+            # package's lifecycle script run with access to either.
+            (cd "$dir" && pnpm install --no-frozen-lockfile --ignore-scripts)
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -89,6 +89,40 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier only rewrites version strings in package.json/Cargo.toml; the
+      # lockfiles are never touched, so they must be regenerated here or the
+      # PR ships a stale lockfile. This also fails the workflow outright (before
+      # a PR is opened) if a bumped version doesn't actually exist upstream.
+      - name: Set up mise
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: 2026.7.12
+
+      - name: Sync pnpm lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        run: |
+          set -euo pipefail
+          # corepack creates the pnpm executable inside mise's node install bin
+          # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+          corepack enable
+          mise reshim
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && pnpm install --no-frozen-lockfile)
+          done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
+
+      - name: Sync Cargo lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && rustup show && cargo generate-lockfile)
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -not -path '*/.git/*' -print0)
+
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -110,7 +110,10 @@ jobs:
           while IFS= read -r -d '' lockfile; do
             dir=$(dirname "$lockfile")
             echo "Updating ${lockfile}"
-            (cd "$dir" && pnpm install --no-frozen-lockfile)
+            # --ignore-scripts: this job holds an OIDC token (id-token: write)
+            # and a checked-out repo with credentials; don't let an installed
+            # package's lifecycle script run with access to either.
+            (cd "$dir" && pnpm install --no-frozen-lockfile --ignore-scripts)
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -89,6 +89,40 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier only rewrites version strings in package.json/Cargo.toml; the
+      # lockfiles are never touched, so they must be regenerated here or the
+      # PR ships a stale lockfile. This also fails the workflow outright (before
+      # a PR is opened) if a bumped version doesn't actually exist upstream.
+      - name: Set up mise
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: 2026.7.12
+
+      - name: Sync pnpm lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        run: |
+          set -euo pipefail
+          # corepack creates the pnpm executable inside mise's node install bin
+          # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+          corepack enable
+          mise reshim
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && pnpm install --no-frozen-lockfile)
+          done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
+
+      - name: Sync Cargo lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && rustup show && cargo generate-lockfile)
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -not -path '*/.git/*' -print0)
+
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -110,7 +110,10 @@ jobs:
           while IFS= read -r -d '' lockfile; do
             dir=$(dirname "$lockfile")
             echo "Updating ${lockfile}"
-            (cd "$dir" && pnpm install --no-frozen-lockfile)
+            # --ignore-scripts: this job holds an OIDC token (id-token: write)
+            # and a checked-out repo with credentials; don't let an installed
+            # package's lifecycle script run with access to either.
+            (cd "$dir" && pnpm install --no-frozen-lockfile --ignore-scripts)
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -89,6 +89,40 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier only rewrites version strings in package.json/Cargo.toml; the
+      # lockfiles are never touched, so they must be regenerated here or the
+      # PR ships a stale lockfile. This also fails the workflow outright (before
+      # a PR is opened) if a bumped version doesn't actually exist upstream.
+      - name: Set up mise
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: 2026.7.12
+
+      - name: Sync pnpm lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        run: |
+          set -euo pipefail
+          # corepack creates the pnpm executable inside mise's node install bin
+          # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+          corepack enable
+          mise reshim
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && pnpm install --no-frozen-lockfile)
+          done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
+
+      - name: Sync Cargo lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && rustup show && cargo generate-lockfile)
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -not -path '*/.git/*' -print0)
+
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -110,7 +110,10 @@ jobs:
           while IFS= read -r -d '' lockfile; do
             dir=$(dirname "$lockfile")
             echo "Updating ${lockfile}"
-            (cd "$dir" && pnpm install --no-frozen-lockfile)
+            # --ignore-scripts: this job holds an OIDC token (id-token: write)
+            # and a checked-out repo with credentials; don't let an installed
+            # package's lifecycle script run with access to either.
+            (cd "$dir" && pnpm install --no-frozen-lockfile --ignore-scripts)
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -89,6 +89,40 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier only rewrites version strings in package.json/Cargo.toml; the
+      # lockfiles are never touched, so they must be regenerated here or the
+      # PR ships a stale lockfile. This also fails the workflow outright (before
+      # a PR is opened) if a bumped version doesn't actually exist upstream.
+      - name: Set up mise
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: 2026.7.12
+
+      - name: Sync pnpm lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        run: |
+          set -euo pipefail
+          # corepack creates the pnpm executable inside mise's node install bin
+          # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+          corepack enable
+          mise reshim
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && pnpm install --no-frozen-lockfile)
+          done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
+
+      - name: Sync Cargo lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && rustup show && cargo generate-lockfile)
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -not -path '*/.git/*' -print0)
+
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -110,7 +110,10 @@ jobs:
           while IFS= read -r -d '' lockfile; do
             dir=$(dirname "$lockfile")
             echo "Updating ${lockfile}"
-            (cd "$dir" && pnpm install --no-frozen-lockfile)
+            # --ignore-scripts: this job holds an OIDC token (id-token: write)
+            # and a checked-out repo with credentials; don't let an installed
+            # package's lifecycle script run with access to either.
+            (cd "$dir" && pnpm install --no-frozen-lockfile --ignore-scripts)
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -89,6 +89,40 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier only rewrites version strings in package.json/Cargo.toml; the
+      # lockfiles are never touched, so they must be regenerated here or the
+      # PR ships a stale lockfile. This also fails the workflow outright (before
+      # a PR is opened) if a bumped version doesn't actually exist upstream.
+      - name: Set up mise
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: 2026.7.12
+
+      - name: Sync pnpm lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        run: |
+          set -euo pipefail
+          # corepack creates the pnpm executable inside mise's node install bin
+          # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+          corepack enable
+          mise reshim
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && pnpm install --no-frozen-lockfile)
+          done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
+
+      - name: Sync Cargo lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && rustup show && cargo generate-lockfile)
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -not -path '*/.git/*' -print0)
+
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -110,7 +110,10 @@ jobs:
           while IFS= read -r -d '' lockfile; do
             dir=$(dirname "$lockfile")
             echo "Updating ${lockfile}"
-            (cd "$dir" && pnpm install --no-frozen-lockfile)
+            # --ignore-scripts: this job holds an OIDC token (id-token: write)
+            # and a checked-out repo with credentials; don't let an installed
+            # package's lifecycle script run with access to either.
+            (cd "$dir" && pnpm install --no-frozen-lockfile --ignore-scripts)
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -89,6 +89,40 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier only rewrites version strings in package.json/Cargo.toml; the
+      # lockfiles are never touched, so they must be regenerated here or the
+      # PR ships a stale lockfile. This also fails the workflow outright (before
+      # a PR is opened) if a bumped version doesn't actually exist upstream.
+      - name: Set up mise
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: 2026.7.12
+
+      - name: Sync pnpm lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        run: |
+          set -euo pipefail
+          # corepack creates the pnpm executable inside mise's node install bin
+          # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+          corepack enable
+          mise reshim
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && pnpm install --no-frozen-lockfile)
+          done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
+
+      - name: Sync Cargo lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && rustup show && cargo generate-lockfile)
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -not -path '*/.git/*' -print0)
+
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -110,7 +110,10 @@ jobs:
           while IFS= read -r -d '' lockfile; do
             dir=$(dirname "$lockfile")
             echo "Updating ${lockfile}"
-            (cd "$dir" && pnpm install --no-frozen-lockfile)
+            # --ignore-scripts: this job holds an OIDC token (id-token: write)
+            # and a checked-out repo with credentials; don't let an installed
+            # package's lifecycle script run with access to either.
+            (cd "$dir" && pnpm install --no-frozen-lockfile --ignore-scripts)
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -89,6 +89,40 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier only rewrites version strings in package.json/Cargo.toml; the
+      # lockfiles are never touched, so they must be regenerated here or the
+      # PR ships a stale lockfile. This also fails the workflow outright (before
+      # a PR is opened) if a bumped version doesn't actually exist upstream.
+      - name: Set up mise
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: 2026.7.12
+
+      - name: Sync pnpm lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        run: |
+          set -euo pipefail
+          # corepack creates the pnpm executable inside mise's node install bin
+          # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+          corepack enable
+          mise reshim
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && pnpm install --no-frozen-lockfile)
+          done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
+
+      - name: Sync Cargo lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && rustup show && cargo generate-lockfile)
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -not -path '*/.git/*' -print0)
+
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -110,7 +110,10 @@ jobs:
           while IFS= read -r -d '' lockfile; do
             dir=$(dirname "$lockfile")
             echo "Updating ${lockfile}"
-            (cd "$dir" && pnpm install --no-frozen-lockfile)
+            # --ignore-scripts: this job holds an OIDC token (id-token: write)
+            # and a checked-out repo with credentials; don't let an installed
+            # package's lifecycle script run with access to either.
+            (cd "$dir" && pnpm install --no-frozen-lockfile --ignore-scripts)
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -89,6 +89,40 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier only rewrites version strings in package.json/Cargo.toml; the
+      # lockfiles are never touched, so they must be regenerated here or the
+      # PR ships a stale lockfile. This also fails the workflow outright (before
+      # a PR is opened) if a bumped version doesn't actually exist upstream.
+      - name: Set up mise
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: 2026.7.12
+
+      - name: Sync pnpm lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        run: |
+          set -euo pipefail
+          # corepack creates the pnpm executable inside mise's node install bin
+          # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+          corepack enable
+          mise reshim
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && pnpm install --no-frozen-lockfile)
+          done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
+
+      - name: Sync Cargo lockfiles
+        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' lockfile; do
+            dir=$(dirname "$lockfile")
+            echo "Updating ${lockfile}"
+            (cd "$dir" && rustup show && cargo generate-lockfile)
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -not -path '*/.git/*' -print0)
+
       - name: Create branch
         if: steps.should-update.outputs.value == 'true'
         id: branch


### PR DESCRIPTION
## Purpose

- Running `copier update` never updates lockfiles, so merging the generated PR breaks downstream CI with a pnpm/cargo lockfile mismatch
- Even when a mergiraf mismatch corrupts a template dependency version into one that doesn't exist, the PR still gets auto-merged undetected once the conflict markers are gone

## Approach

- After `copier update`, regenerate lockfiles to match the bumped dependency versions whenever a `pnpm-lock.yaml` or `Cargo.lock` is present
- Fail the workflow itself if regeneration fails, before a PR is ever created

<details>
<summary>Design decisions</summary>

#### When to verify

| Decision | Design                                                                  | Pros                                             | Cons                            |
| -------- | ------------------------------------------------------------------------ | --------------------------------------------------- | ---------------------------------- |
| Chosen   | Regenerate lockfiles in the workflow and fail the job on error         | Catches a nonexistent version before a PR is opened | Adds to the workflow's run time  |
| Rejected | Keep the status quo and let downstream's regular CI catch it            | Smaller change                                       | Stays undetected and auto-merges once conflict markers are gone |

</details>
