### PR TITLE
fix(template): bundle subpath imports into dist

### DIFF
--- a/generated/monorepo-node-workspace/backend/tsup.config.ts
+++ b/generated/monorepo-node-workspace/backend/tsup.config.ts
@@ -12,4 +12,8 @@ export default defineConfig({
   // @opentelemetry/auto-instrumentations-node's module-patching hook still
   // applies to the real package in node_modules instead of a bundled copy.
   skipNodeModulesBundle: true,
+  // skipNodeModulesBundle treats subpath imports (`#foo`) as external too,
+  // leaving `./src/*.ts` specifiers unresolved in a runtime image that only
+  // ships dist/. Force-bundle them so dist stays self-contained.
+  noExternal: [/^#/],
 })

--- a/generated/monorepo/frontend/tsup.config.ts
+++ b/generated/monorepo/frontend/tsup.config.ts
@@ -12,4 +12,8 @@ export default defineConfig({
   // @opentelemetry/auto-instrumentations-node's module-patching hook still
   // applies to the real package in node_modules instead of a bundled copy.
   skipNodeModulesBundle: true,
+  // skipNodeModulesBundle treats subpath imports (`#foo`) as external too,
+  // leaving `./src/*.ts` specifiers unresolved in a runtime image that only
+  // ships dist/. Force-bundle them so dist stays self-contained.
+  noExternal: [/^#/],
 })

--- a/generated/node/tsup.config.ts
+++ b/generated/node/tsup.config.ts
@@ -12,4 +12,8 @@ export default defineConfig({
   // @opentelemetry/auto-instrumentations-node's module-patching hook still
   // applies to the real package in node_modules instead of a bundled copy.
   skipNodeModulesBundle: true,
+  // skipNodeModulesBundle treats subpath imports (`#foo`) as external too,
+  // leaving `./src/*.ts` specifiers unresolved in a runtime image that only
+  // ships dist/. Force-bundle them so dist stays self-contained.
+  noExternal: [/^#/],
 })

--- a/template/tsup.config.ts
+++ b/template/tsup.config.ts
@@ -12,4 +12,8 @@ export default defineConfig({
   // @opentelemetry/auto-instrumentations-node's module-patching hook still
   // applies to the real package in node_modules instead of a bundled copy.
   skipNodeModulesBundle: true,
+  // skipNodeModulesBundle treats subpath imports (`#foo`) as external too,
+  // leaving `./src/*.ts` specifiers unresolved in a runtime image that only
+  // ships dist/. Force-bundle them so dist stays self-contained.
+  noExternal: [/^#/],
 })


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/t-rader/pull/261
- In a Node project's runtime image (which contains only `dist`, not `src`), using a `#foo`-style subpath import crashes on startup with `ERR_MODULE_NOT_FOUND: Cannot find module '.../src/xxx.ts'`

### Reproduction steps

1. Use a `#foo`-style subpath import (mapped to `./src/*.ts` via the `imports` field in `package.json`) in production code
2. Build with `tsup` and create a runtime image that copies only `dist`
3. Run `node dist/index.js`

## Approach

- Force-bundle `#foo`-style subpath imports so module resolution is self-contained within `dist`
