### PR TITLE
fix(template): pin wrangler working directory for storybook deploy

### DIFF
--- a/generated/monorepo-node-workspace/.github/workflows/storybook.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/storybook.yml
@@ -75,6 +75,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: frontend
+          packageManager: pnpm
           command: pages project create monorepo-node-workspace-pnpm-frontend-storybook --production-branch=main
         continue-on-error: true
 
@@ -84,7 +86,9 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy frontend/storybook-static --project-name=monorepo-node-workspace-pnpm-frontend-storybook --branch=${{ github.head_ref || 'main' }} --commit-dirty=true
+          workingDirectory: frontend
+          packageManager: pnpm
+          command: pages deploy storybook-static --project-name=monorepo-node-workspace-pnpm-frontend-storybook --branch=${{ github.head_ref || 'main' }} --commit-dirty=true
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'

--- a/generated/monorepo/.github/workflows/storybook.yml
+++ b/generated/monorepo/.github/workflows/storybook.yml
@@ -73,6 +73,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: frontend
+          packageManager: pnpm
           command: pages project create monorepo-frontend-storybook --production-branch=main
         continue-on-error: true
 
@@ -82,7 +84,9 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy frontend/storybook-static --project-name=monorepo-frontend-storybook --branch=${{ github.head_ref || 'main' }} --commit-dirty=true
+          workingDirectory: frontend
+          packageManager: pnpm
+          command: pages deploy storybook-static --project-name=monorepo-frontend-storybook --branch=${{ github.head_ref || 'main' }} --commit-dirty=true
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'

--- a/template/.github/workflows/storybook.yml.jinja
+++ b/template/.github/workflows/storybook.yml.jinja
@@ -98,6 +98,8 @@ jobs:
         with:
           apiToken: {% raw %}${{ secrets.CLOUDFLARE_API_TOKEN }}{% endraw %}
           accountId: {% raw %}${{ secrets.CLOUDFLARE_ACCOUNT_ID }}{% endraw %}
+          workingDirectory: {{ pkg.name }}
+          packageManager: pnpm
           command: pages project create {{ slug(project_name) }}-{{ slug(pkg.name) }}-storybook --production-branch=main
         continue-on-error: true
 
@@ -107,7 +109,9 @@ jobs:
         with:
           apiToken: {% raw %}${{ secrets.CLOUDFLARE_API_TOKEN }}{% endraw %}
           accountId: {% raw %}${{ secrets.CLOUDFLARE_ACCOUNT_ID }}{% endraw %}
-          command: pages deploy {{ pkg.name }}/storybook-static --project-name={{ slug(project_name) }}-{{ slug(pkg.name) }}-storybook --branch={% raw %}${{ github.head_ref || 'main' }}{% endraw %} --commit-dirty=true
+          workingDirectory: {{ pkg.name }}
+          packageManager: pnpm
+          command: pages deploy storybook-static --project-name={{ slug(project_name) }}-{{ slug(pkg.name) }}-storybook --branch={% raw %}${{ github.head_ref || 'main' }}{% endraw %} --commit-dirty=true
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/tq/pull/411
- In pnpm workspace repos, the Cloudflare Pages deploy in `storybook.yml` fails with `ERR_PNPM_ADDING_TO_ROOT`

## Approach

- Set `workingDirectory` and `packageManager: pnpm` on the `cloudflare/wrangler-action` calls to run them inside the subpackage directory
    - `cloudflare/wrangler-action` always runs its internal package-manager add command at the repository root, which was the cause
