### PR TITLE
fix(template): drop stale .storybook exception

### DIFF
--- a/generated/monorepo-node-workspace/eslint.config.js
+++ b/generated/monorepo-node-workspace/eslint.config.js
@@ -12,7 +12,9 @@ export default config(
     // vite.config.ts/vitest.config.ts are loaded through Vite's own
     // esbuild-based config loader, which doesn't resolve the package.json
     // "imports" field, unlike the Rollup pipeline that bundles the app
-    // itself.
+    // itself. .storybook/**/*.ts doesn't need this exception: Storybook's
+    // Node config loader only transpiles TS to ESM and otherwise defers to
+    // Node's own module resolution, which resolves "imports" natively.
     files: ['frontend/vite.config.ts', 'frontend/vitest.config.ts'],
     rules: { 'no-restricted-imports': 'off' },
   },

--- a/generated/monorepo-node-workspace/eslint.config.js
+++ b/generated/monorepo-node-workspace/eslint.config.js
@@ -12,13 +12,8 @@ export default config(
     // vite.config.ts/vitest.config.ts are loaded through Vite's own
     // esbuild-based config loader, which doesn't resolve the package.json
     // "imports" field, unlike the Rollup pipeline that bundles the app
-    // itself. .storybook/**/*.ts is loaded the same way, through
-    // Storybook's own Node-based config loader.
-    files: [
-      'frontend/.storybook/**/*.ts',
-      'frontend/vite.config.ts',
-      'frontend/vitest.config.ts',
-    ],
+    // itself.
+    files: ['frontend/vite.config.ts', 'frontend/vitest.config.ts'],
     rules: { 'no-restricted-imports': 'off' },
   },
 )

--- a/generated/monorepo/frontend/eslint.config.js
+++ b/generated/monorepo/frontend/eslint.config.js
@@ -12,7 +12,9 @@ export default config(
     // vite.config.ts/vitest.config.ts are loaded through Vite's own
     // esbuild-based config loader, which doesn't resolve the package.json
     // "imports" field, unlike the Rollup pipeline that bundles the app
-    // itself.
+    // itself. .storybook/**/*.ts doesn't need this exception: Storybook's
+    // Node config loader only transpiles TS to ESM and otherwise defers to
+    // Node's own module resolution, which resolves "imports" natively.
     files: ['vite.config.ts', 'vitest.config.ts'],
     rules: { 'no-restricted-imports': 'off' },
   },

--- a/generated/monorepo/frontend/eslint.config.js
+++ b/generated/monorepo/frontend/eslint.config.js
@@ -12,9 +12,8 @@ export default config(
     // vite.config.ts/vitest.config.ts are loaded through Vite's own
     // esbuild-based config loader, which doesn't resolve the package.json
     // "imports" field, unlike the Rollup pipeline that bundles the app
-    // itself. .storybook/**/*.ts is loaded the same way, through
-    // Storybook's own Node-based config loader.
-    files: ['.storybook/**/*.ts', 'vite.config.ts', 'vitest.config.ts'],
+    // itself.
+    files: ['vite.config.ts', 'vitest.config.ts'],
     rules: { 'no-restricted-imports': 'off' },
   },
 )

--- a/template/eslint.config.js.jinja
+++ b/template/eslint.config.js.jinja
@@ -17,8 +17,17 @@ export default config(
     // vite.config.ts/vitest.config.ts are loaded through Vite's own
     // esbuild-based config loader, which doesn't resolve the package.json
     // "imports" field, unlike the Rollup pipeline that bundles the app
-    // itself.
+    // itself. .storybook/**/*.ts doesn't need this exception: Storybook's
+    // Node config loader only transpiles TS to ESM and otherwise defers to
+    // Node's own module resolution, which resolves "imports" natively.
+{%- if (spa_pkgs[0].name | length) <= 14 %}
     files: ['{{ spa_pkgs[0].name }}/vite.config.ts', '{{ spa_pkgs[0].name }}/vitest.config.ts'],
+{%- else %}
+    files: [
+      '{{ spa_pkgs[0].name }}/vite.config.ts',
+      '{{ spa_pkgs[0].name }}/vitest.config.ts',
+    ],
+{%- endif %}
     rules: { 'no-restricted-imports': 'off' },
   },
 )

--- a/template/eslint.config.js.jinja
+++ b/template/eslint.config.js.jinja
@@ -20,8 +20,11 @@ export default config(
     // itself. .storybook/**/*.ts doesn't need this exception: Storybook's
     // Node config loader only transpiles TS to ESM and otherwise defers to
     // Node's own module resolution, which resolves "imports" natively.
-{%- if (spa_pkgs[0].name | length) <= 14 %}
-    files: ['{{ spa_pkgs[0].name }}/vite.config.ts', '{{ spa_pkgs[0].name }}/vitest.config.ts'],
+{#- Mirror prettier's printWidth (80, the .prettierrc.yaml default) so this
+    array renders single-line exactly when prettier would keep it single-line. -#}
+{%- set files_content = "files: ['" ~ spa_pkgs[0].name ~ "/vite.config.ts', '" ~ spa_pkgs[0].name ~ "/vitest.config.ts']," %}
+{%- if (4 + (files_content | length)) <= 80 %}
+    {{ files_content }}
 {%- else %}
     files: [
       '{{ spa_pkgs[0].name }}/vite.config.ts',

--- a/template/eslint.config.js.jinja
+++ b/template/eslint.config.js.jinja
@@ -17,13 +17,8 @@ export default config(
     // vite.config.ts/vitest.config.ts are loaded through Vite's own
     // esbuild-based config loader, which doesn't resolve the package.json
     // "imports" field, unlike the Rollup pipeline that bundles the app
-    // itself. .storybook/**/*.ts is loaded the same way, through
-    // Storybook's own Node-based config loader.
-    files: [
-      '{{ spa_pkgs[0].name }}/.storybook/**/*.ts',
-      '{{ spa_pkgs[0].name }}/vite.config.ts',
-      '{{ spa_pkgs[0].name }}/vitest.config.ts',
-    ],
+    // itself.
+    files: ['{{ spa_pkgs[0].name }}/vite.config.ts', '{{ spa_pkgs[0].name }}/vitest.config.ts'],
     rules: { 'no-restricted-imports': 'off' },
   },
 )

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) and not (monorepo_node_workspace | default(false)) %}eslint.config.js{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) and not (monorepo_node_workspace | default(false)) %}eslint.config.js{% endif %}.jinja
@@ -16,9 +16,8 @@ export default config(
     // vite.config.ts/vitest.config.ts are loaded through Vite's own
     // esbuild-based config loader, which doesn't resolve the package.json
     // "imports" field, unlike the Rollup pipeline that bundles the app
-    // itself. .storybook/**/*.ts is loaded the same way, through
-    // Storybook's own Node-based config loader.
-    files: ['.storybook/**/*.ts', 'vite.config.ts', 'vitest.config.ts'],
+    // itself.
+    files: ['vite.config.ts', 'vitest.config.ts'],
     rules: { 'no-restricted-imports': 'off' },
   },
 )

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) and not (monorepo_node_workspace | default(false)) %}eslint.config.js{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) and not (monorepo_node_workspace | default(false)) %}eslint.config.js{% endif %}.jinja
@@ -16,7 +16,9 @@ export default config(
     // vite.config.ts/vitest.config.ts are loaded through Vite's own
     // esbuild-based config loader, which doesn't resolve the package.json
     // "imports" field, unlike the Rollup pipeline that bundles the app
-    // itself.
+    // itself. .storybook/**/*.ts doesn't need this exception: Storybook's
+    // Node config loader only transpiles TS to ESM and otherwise defers to
+    // Node's own module resolution, which resolves "imports" natively.
     files: ['vite.config.ts', 'vitest.config.ts'],
     rules: { 'no-restricted-imports': 'off' },
   },


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/meshi/pull/172, https://github.com/fohte/tq/pull/411
- Two repositories that picked up the v0.10.0 spa scaffold independently patched the `.storybook/**/*.ts` `no-restricted-imports` exception for conflicting reasons; without folding this back into the template, every other spa-using repository keeps hitting the same problem on each `copier update`
    - The exception's own rationale was wrong (the template's generated setup doesn't need it)

## Approach

- Verified in Storybook's source that its config loader resolves the package.json `imports` field without issue

<details>
<summary>Design decisions</summary>

#### Reproducing prettier's line-wrap decision after dropping the exception

Removing an item from the array changed its element count, so whether prettier keeps `files:` on one line now depends on the length of the spa subpackage name. This needs to be reproduced on the jinja side.

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen   | Build the actual rendered `files:` line and compare its length against printWidth (80) | Threshold tracks automatically if the surrounding array literal changes shape | The computation is harder to read |
| Rejected | Hardcode the character threshold (14) | Simpler | Not self-explanatory, and drifts silently if the surrounding structure changes |

</details>

### Breaking changes

Downstream repositories using relative imports under `.storybook/**/*.ts` will start failing `no-restricted-imports` after applying `copier update`. Replace them with `#`-prefixed subpath imports.
