### PR TITLE
fix(template): allow workerd build script for spa

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -189,7 +189,9 @@ subpackages:
     Example: [{name: frontend, type: node}, {name: backend, type: rust}]
     Per-entry flags (optional):
       spa: true        -- mark a node subpackage as a SPA (Vite + React +
-                          Tailwind CSS + shadcn/ui + Storybook)
+                          Tailwind CSS + shadcn/ui + Storybook), and (unless
+                          tests: false) add the pnpm allowBuilds entry for
+                          workerd for that subpackage.
       web_app: true    -- mark a node subpackage as a web app (long-running
                           HTTP server). Implies error_tracking (see below)
                           and additionally gates build/container scaffolding

--- a/generated/monorepo-node-workspace/pnpm-workspace.yaml
+++ b/generated/monorepo-node-workspace/pnpm-workspace.yaml
@@ -9,6 +9,8 @@ allowBuilds:
   protobufjs: true
   # required by @fohte/eslint-config -> eslint-plugin-import-x for module resolution
   unrs-resolver: true
+  # required by cloudflare/wrangler-action's internal `pnpm add wrangler` step (Storybook deploy)
+  workerd: true
 
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.

--- a/generated/monorepo/frontend/pnpm-workspace.yaml
+++ b/generated/monorepo/frontend/pnpm-workspace.yaml
@@ -5,6 +5,8 @@ allowBuilds:
   protobufjs: true
   # required by @fohte/eslint-config -> eslint-plugin-import-x for module resolution
   unrs-resolver: true
+  # required by cloudflare/wrangler-action's internal `pnpm add wrangler` step (Storybook deploy)
+  workerd: true
 
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.

--- a/template/pnpm-workspace.yaml.jinja
+++ b/template/pnpm-workspace.yaml.jinja
@@ -14,6 +14,10 @@ allowBuilds:
 {%- endif %}
   # required by @fohte/eslint-config -> eslint-plugin-import-x for module resolution
   unrs-resolver: true
+{%- if has_spa_pkg %}
+  # required by cloudflare/wrangler-action's internal `pnpm add wrangler` step (Storybook deploy)
+  workerd: true
+{%- endif %}
 
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and not (monorepo_node_workspace | default(false)) %}pnpm-workspace.yaml{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and not (monorepo_node_workspace | default(false)) %}pnpm-workspace.yaml{% endif %}.jinja
@@ -7,6 +7,10 @@ allowBuilds:
 {%- endif %}
   # required by @fohte/eslint-config -> eslint-plugin-import-x for module resolution
   unrs-resolver: true
+{%- if (pkg.spa | default(false)) and (pkg.tests | default(true)) %}
+  # required by cloudflare/wrangler-action's internal `pnpm add wrangler` step (Storybook deploy)
+  workerd: true
+{%- endif %}
 
 # Dodge short-lived supply-chain attacks (e.g. shai-hulud, tinycolor) by
 # holding off freshly published versions. Unit is minutes; 10080 = 7 days.


### PR DESCRIPTION
## Purpose

- from:
  - https://github.com/fohte/meshi/pull/172
  - https://github.com/fohte/tq/pull/411
- The `pnpm-workspace.yaml` generated for spa subpackage configurations fails to install wrangler, which [`cloudflare/wrangler-action`](https://github.com/cloudflare/wrangler-action) runs internally to deploy Storybook to Cloudflare Pages

## Approach

- Add `workerd` to `allowBuilds` in both the root and subpackage templates whenever an spa package is present
