### PR TITLE
feat(template): add @fohte/storybook-addon to spa subpackages

### DIFF
--- a/generated/monorepo-node-workspace/frontend/.storybook/main.ts
+++ b/generated/monorepo-node-workspace/frontend/.storybook/main.ts
@@ -7,6 +7,7 @@ const config: StorybookConfig = {
     '@storybook/addon-docs',
     '@storybook/addon-themes',
     '@storybook/addon-vitest',
+    '@fohte/storybook-addon',
   ],
 }
 

--- a/generated/monorepo-node-workspace/frontend/package.json
+++ b/generated/monorepo-node-workspace/frontend/package.json
@@ -33,6 +33,7 @@
     "tailwind-merge": "3.6.0"
   },
   "devDependencies": {
+    "@fohte/storybook-addon": "0.1.2",
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",
     "@storybook/addon-vitest": "10.4.6",

--- a/generated/monorepo/frontend/.storybook/main.ts
+++ b/generated/monorepo/frontend/.storybook/main.ts
@@ -7,6 +7,7 @@ const config: StorybookConfig = {
     '@storybook/addon-docs',
     '@storybook/addon-themes',
     '@storybook/addon-vitest',
+    '@fohte/storybook-addon',
   ],
 }
 

--- a/generated/monorepo/frontend/package.json
+++ b/generated/monorepo/frontend/package.json
@@ -44,6 +44,7 @@
     "@commitlint/cli": "21.2.1",
     "@eslint/eslintrc": "3.3.6",
     "@fohte/eslint-config": "0.4.1",
+    "@fohte/storybook-addon": "0.1.2",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",

--- a/template/.storybook/main.ts
+++ b/template/.storybook/main.ts
@@ -7,6 +7,7 @@ const config: StorybookConfig = {
     '@storybook/addon-docs',
     '@storybook/addon-themes',
     '@storybook/addon-vitest',
+    '@fohte/storybook-addon',
   ],
 }
 

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
@@ -95,6 +95,9 @@
     "@commitlint/cli": "21.2.1",
     "@eslint/eslintrc": "3.3.6",
     "@fohte/eslint-config": "0.4.1",
+{%- if pkg_has_spa %}
+    "@fohte/storybook-addon": "0.1.2",
+{%- endif %}
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
 {%- if pkg_has_spa %}
     "@storybook/addon-docs": "10.4.6",
@@ -141,6 +144,7 @@
 {%- elif pkg_has_spa or pkg_is_web_app %}
   "devDependencies": {
 {%- if pkg_has_spa %}
+    "@fohte/storybook-addon": "0.1.2",
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",
     "@storybook/addon-vitest": "10.4.6",


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/generic-boilerplate/pull/587
- spa subpackage stories run headlessly but have no way to catch layout overflow or the VRT non-determinism caused by loading external resources, so they can't be trusted as a verification method

## Approach

- Add [`@fohte/storybook-addon`](https://github.com/fohte/storybook-addon) to the Storybook config for spa subpackages, running its overflow-check and external-resource-check on every story render
