### PR TITLE
fix(template): stop lockfile sync from failing when conflicts remain

### DIFF
--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -93,14 +93,17 @@ jobs:
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
+      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
+      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
+      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -117,7 +120,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -194,7 +197,9 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}"
+          ${unresolved_list}
+          >
+          > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
           fi
 
           body="${body}

--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -89,21 +89,35 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier-update-action leaves conflict markers in the working tree when
+      # it can't cleanly 3-way-merge a file; a marker landing in a file
+      # pnpm/cargo parse directly (e.g. pnpm-workspace.yaml) crashes the sync
+      # outright, so lockfile sync must wait until conflicts are resolved.
+      - name: Determine whether lockfile sync is safe
+        if: steps.should-update.outputs.value == 'true'
+        id: can-sync-lockfiles
+        env:
+          UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+        run: |
+          set -euo pipefail
+          if [ -z "${UNRESOLVED_FILES}" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # copier only rewrites version strings in package.json/Cargo.toml; the
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
-      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
-      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
-      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -120,7 +134,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -180,6 +194,7 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+          HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
@@ -197,9 +212,12 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}
+          ${unresolved_list}"
+            if [ "${HAS_LOCKFILES}" = "true" ]; then
+              body="${body}
           >
           > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
+            fi
           fi
 
           body="${body}

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -93,14 +93,17 @@ jobs:
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
+      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
+      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
+      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -117,7 +120,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -194,7 +197,9 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}"
+          ${unresolved_list}
+          >
+          > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
           fi
 
           body="${body}

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -89,21 +89,35 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier-update-action leaves conflict markers in the working tree when
+      # it can't cleanly 3-way-merge a file; a marker landing in a file
+      # pnpm/cargo parse directly (e.g. pnpm-workspace.yaml) crashes the sync
+      # outright, so lockfile sync must wait until conflicts are resolved.
+      - name: Determine whether lockfile sync is safe
+        if: steps.should-update.outputs.value == 'true'
+        id: can-sync-lockfiles
+        env:
+          UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+        run: |
+          set -euo pipefail
+          if [ -z "${UNRESOLVED_FILES}" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # copier only rewrites version strings in package.json/Cargo.toml; the
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
-      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
-      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
-      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -120,7 +134,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -180,6 +194,7 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+          HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
@@ -197,9 +212,12 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}
+          ${unresolved_list}"
+            if [ "${HAS_LOCKFILES}" = "true" ]; then
+              body="${body}
           >
           > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
+            fi
           fi
 
           body="${body}

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -93,14 +93,17 @@ jobs:
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
+      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
+      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
+      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -117,7 +120,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -194,7 +197,9 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}"
+          ${unresolved_list}
+          >
+          > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
           fi
 
           body="${body}

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -89,21 +89,35 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier-update-action leaves conflict markers in the working tree when
+      # it can't cleanly 3-way-merge a file; a marker landing in a file
+      # pnpm/cargo parse directly (e.g. pnpm-workspace.yaml) crashes the sync
+      # outright, so lockfile sync must wait until conflicts are resolved.
+      - name: Determine whether lockfile sync is safe
+        if: steps.should-update.outputs.value == 'true'
+        id: can-sync-lockfiles
+        env:
+          UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+        run: |
+          set -euo pipefail
+          if [ -z "${UNRESOLVED_FILES}" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # copier only rewrites version strings in package.json/Cargo.toml; the
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
-      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
-      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
-      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -120,7 +134,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -180,6 +194,7 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+          HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
@@ -197,9 +212,12 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}
+          ${unresolved_list}"
+            if [ "${HAS_LOCKFILES}" = "true" ]; then
+              body="${body}
           >
           > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
+            fi
           fi
 
           body="${body}

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -93,14 +93,17 @@ jobs:
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
+      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
+      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
+      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -117,7 +120,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -194,7 +197,9 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}"
+          ${unresolved_list}
+          >
+          > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
           fi
 
           body="${body}

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -89,21 +89,35 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier-update-action leaves conflict markers in the working tree when
+      # it can't cleanly 3-way-merge a file; a marker landing in a file
+      # pnpm/cargo parse directly (e.g. pnpm-workspace.yaml) crashes the sync
+      # outright, so lockfile sync must wait until conflicts are resolved.
+      - name: Determine whether lockfile sync is safe
+        if: steps.should-update.outputs.value == 'true'
+        id: can-sync-lockfiles
+        env:
+          UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+        run: |
+          set -euo pipefail
+          if [ -z "${UNRESOLVED_FILES}" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # copier only rewrites version strings in package.json/Cargo.toml; the
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
-      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
-      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
-      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -120,7 +134,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -180,6 +194,7 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+          HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
@@ -197,9 +212,12 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}
+          ${unresolved_list}"
+            if [ "${HAS_LOCKFILES}" = "true" ]; then
+              body="${body}
           >
           > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
+            fi
           fi
 
           body="${body}

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -93,14 +93,17 @@ jobs:
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
+      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
+      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
+      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -117,7 +120,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -194,7 +197,9 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}"
+          ${unresolved_list}
+          >
+          > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
           fi
 
           body="${body}

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -89,21 +89,35 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier-update-action leaves conflict markers in the working tree when
+      # it can't cleanly 3-way-merge a file; a marker landing in a file
+      # pnpm/cargo parse directly (e.g. pnpm-workspace.yaml) crashes the sync
+      # outright, so lockfile sync must wait until conflicts are resolved.
+      - name: Determine whether lockfile sync is safe
+        if: steps.should-update.outputs.value == 'true'
+        id: can-sync-lockfiles
+        env:
+          UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+        run: |
+          set -euo pipefail
+          if [ -z "${UNRESOLVED_FILES}" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # copier only rewrites version strings in package.json/Cargo.toml; the
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
-      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
-      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
-      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -120,7 +134,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -180,6 +194,7 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+          HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
@@ -197,9 +212,12 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}
+          ${unresolved_list}"
+            if [ "${HAS_LOCKFILES}" = "true" ]; then
+              body="${body}
           >
           > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
+            fi
           fi
 
           body="${body}

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -93,14 +93,17 @@ jobs:
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
+      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
+      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
+      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -117,7 +120,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -194,7 +197,9 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}"
+          ${unresolved_list}
+          >
+          > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
           fi
 
           body="${body}

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -89,21 +89,35 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier-update-action leaves conflict markers in the working tree when
+      # it can't cleanly 3-way-merge a file; a marker landing in a file
+      # pnpm/cargo parse directly (e.g. pnpm-workspace.yaml) crashes the sync
+      # outright, so lockfile sync must wait until conflicts are resolved.
+      - name: Determine whether lockfile sync is safe
+        if: steps.should-update.outputs.value == 'true'
+        id: can-sync-lockfiles
+        env:
+          UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+        run: |
+          set -euo pipefail
+          if [ -z "${UNRESOLVED_FILES}" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # copier only rewrites version strings in package.json/Cargo.toml; the
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
-      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
-      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
-      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -120,7 +134,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -180,6 +194,7 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+          HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
@@ -197,9 +212,12 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}
+          ${unresolved_list}"
+            if [ "${HAS_LOCKFILES}" = "true" ]; then
+              body="${body}
           >
           > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
+            fi
           fi
 
           body="${body}

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -93,14 +93,17 @@ jobs:
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
+      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
+      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
+      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -117,7 +120,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -194,7 +197,9 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}"
+          ${unresolved_list}
+          >
+          > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
           fi
 
           body="${body}

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -89,21 +89,35 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier-update-action leaves conflict markers in the working tree when
+      # it can't cleanly 3-way-merge a file; a marker landing in a file
+      # pnpm/cargo parse directly (e.g. pnpm-workspace.yaml) crashes the sync
+      # outright, so lockfile sync must wait until conflicts are resolved.
+      - name: Determine whether lockfile sync is safe
+        if: steps.should-update.outputs.value == 'true'
+        id: can-sync-lockfiles
+        env:
+          UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+        run: |
+          set -euo pipefail
+          if [ -z "${UNRESOLVED_FILES}" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # copier only rewrites version strings in package.json/Cargo.toml; the
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
-      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
-      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
-      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -120,7 +134,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -180,6 +194,7 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+          HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
@@ -197,9 +212,12 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}
+          ${unresolved_list}"
+            if [ "${HAS_LOCKFILES}" = "true" ]; then
+              body="${body}
           >
           > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
+            fi
           fi
 
           body="${body}

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -93,14 +93,17 @@ jobs:
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
+      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
+      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
+      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -117,7 +120,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -194,7 +197,9 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}"
+          ${unresolved_list}
+          >
+          > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
           fi
 
           body="${body}

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -89,21 +89,35 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier-update-action leaves conflict markers in the working tree when
+      # it can't cleanly 3-way-merge a file; a marker landing in a file
+      # pnpm/cargo parse directly (e.g. pnpm-workspace.yaml) crashes the sync
+      # outright, so lockfile sync must wait until conflicts are resolved.
+      - name: Determine whether lockfile sync is safe
+        if: steps.should-update.outputs.value == 'true'
+        id: can-sync-lockfiles
+        env:
+          UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+        run: |
+          set -euo pipefail
+          if [ -z "${UNRESOLVED_FILES}" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # copier only rewrites version strings in package.json/Cargo.toml; the
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
-      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
-      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
-      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -120,7 +134,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -180,6 +194,7 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+          HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
@@ -197,9 +212,12 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}
+          ${unresolved_list}"
+            if [ "${HAS_LOCKFILES}" = "true" ]; then
+              body="${body}
           >
           > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
+            fi
           fi
 
           body="${body}

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -93,14 +93,17 @@ jobs:
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
+      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
+      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
+      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -117,7 +120,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -194,7 +197,9 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}"
+          ${unresolved_list}
+          >
+          > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
           fi
 
           body="${body}

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -89,21 +89,35 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier-update-action leaves conflict markers in the working tree when
+      # it can't cleanly 3-way-merge a file; a marker landing in a file
+      # pnpm/cargo parse directly (e.g. pnpm-workspace.yaml) crashes the sync
+      # outright, so lockfile sync must wait until conflicts are resolved.
+      - name: Determine whether lockfile sync is safe
+        if: steps.should-update.outputs.value == 'true'
+        id: can-sync-lockfiles
+        env:
+          UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+        run: |
+          set -euo pipefail
+          if [ -z "${UNRESOLVED_FILES}" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # copier only rewrites version strings in package.json/Cargo.toml; the
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
-      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
-      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
-      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -120,7 +134,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -180,6 +194,7 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+          HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
@@ -197,9 +212,12 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}
+          ${unresolved_list}"
+            if [ "${HAS_LOCKFILES}" = "true" ]; then
+              body="${body}
           >
           > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
+            fi
           fi
 
           body="${body}

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -93,14 +93,17 @@ jobs:
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
+      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
+      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
+      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -117,7 +120,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
+        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -194,7 +197,9 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}"
+          ${unresolved_list}
+          >
+          > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
           fi
 
           body="${body}

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -89,21 +89,35 @@ jobs:
             chmod +x scripts/bootstrap
           fi
 
+      # copier-update-action leaves conflict markers in the working tree when
+      # it can't cleanly 3-way-merge a file; a marker landing in a file
+      # pnpm/cargo parse directly (e.g. pnpm-workspace.yaml) crashes the sync
+      # outright, so lockfile sync must wait until conflicts are resolved.
+      - name: Determine whether lockfile sync is safe
+        if: steps.should-update.outputs.value == 'true'
+        id: can-sync-lockfiles
+        env:
+          UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+        run: |
+          set -euo pipefail
+          if [ -z "${UNRESOLVED_FILES}" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # copier only rewrites version strings in package.json/Cargo.toml; the
       # lockfiles are never touched, so they must be regenerated here or the
       # PR ships a stale lockfile. This also fails the workflow outright (before
       # a PR is opened) if a bumped version doesn't actually exist upstream.
-      # Skipped when conflicts remain: copier's 3-way merge can leave conflict
-      # markers in files pnpm/cargo parse (e.g. pnpm-workspace.yaml), which
-      # crashes the sync outright instead of producing a usable lockfile.
       - name: Set up mise
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           version: 2026.7.12
 
       - name: Sync pnpm lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/pnpm-lock.yaml') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/pnpm-lock.yaml') != ''
         run: |
           set -euo pipefail
           # corepack creates the pnpm executable inside mise's node install bin
@@ -120,7 +134,7 @@ jobs:
           done < <(find . -name pnpm-lock.yaml -not -path '*/node_modules/*' -not -path '*/.git/*' -print0)
 
       - name: Sync Cargo lockfiles
-        if: steps.should-update.outputs.value == 'true' && steps.copier-update.outputs.unresolved-files == '' && hashFiles('**/Cargo.lock') != ''
+        if: steps.can-sync-lockfiles.outputs.value == 'true' && hashFiles('**/Cargo.lock') != ''
         run: |
           set -euo pipefail
           while IFS= read -r -d '' lockfile; do
@@ -180,6 +194,7 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           UNRESOLVED_FILES: ${{ steps.copier-update.outputs.unresolved-files }}
+          HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
         run: |
@@ -197,9 +212,12 @@ jobs:
           > [!WARNING]
           > Manual review required. Unresolved conflicts remain in:
           >
-          ${unresolved_list}
+          ${unresolved_list}"
+            if [ "${HAS_LOCKFILES}" = "true" ]; then
+              body="${body}
           >
           > Lockfiles were not synced because conflicts remain. Resolve the conflicts above, then sync lockfiles manually (e.g. \`pnpm install\`, \`cargo generate-lockfile\`)."
+            fi
           fi
 
           body="${body}


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/t-rader/actions/runs/32365879996
- The `boilerplate-update` workflow crashes the job whenever copier update leaves conflicts, because the lockfile sync step still runs regardless.
    - No draft PR gets created to prompt for conflict resolution, so the downstream repository stops tracking template updates.
- The PR body also tells users to sync lockfiles manually on projects that have none, whenever conflicts occur.

### Reproduction steps

1. Ship a template change that causes a copier update conflict.
2. Run the `boilerplate-update` workflow on a consumer repository.
3. The lockfile sync step fails, halting the job before a PR is created.

## Approach

- Run the lockfile sync steps (including the mise setup) only after conflicts are resolved.
    - Conflict markers left in files pnpm/cargo parse directly (e.g. `pnpm-workspace.yaml`) were crashing the sync outright.
- Show the "lockfiles were not synced" note in the PR body only for projects that actually have lockfiles.

<details>
<summary>Design decisions</summary>

#### How to skip lockfile sync during conflicts

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen   | Add a dedicated step (`can-sync-lockfiles`) that evaluates `unresolved-files`, and reference its output from the three downstream steps' `if:` conditions | Consolidates the check in one place, following the same pattern as the existing `should-update` step | Adds one more step |
| Rejected | Inline the same condition directly into each of the three steps' `if:` | Smallest diff | Duplicates the same condition three times, making it easy to miss one and reintroduce this failure |

</details>
