### PR TITLE
docs(template): add VRT review and approval instructions to CLAUDE.md

### DIFF
--- a/generated/monorepo-node-workspace/CLAUDE.md
+++ b/generated/monorepo-node-workspace/CLAUDE.md
@@ -40,6 +40,16 @@ Every presentational component under `src/components/` should have a co-located 
 
 When you need to check how a component looks or behaves in a given state, write or update its story and view it via the `storybook` script (`storybook dev`) before starting a dev server and driving a browser manually.
 
+## Visual Regression Testing (VRT)
+
+### Understand why the `vrt` check fails
+
+The `vrt` CI check renders Storybook stories to screenshots and compares them against the `main` baseline with reg-suit. A failure ("Visual differences detected") means the pixel diff exceeded reg-suit's `matchingThreshold`, not that something is broken — open the reg-suit report link posted on the PR and compare the actual/expected/diff images to judge whether the change is intentional.
+
+### Never add the `vrt-approved` label yourself
+
+The `vrt-approval` workflow treats the `vrt-approved` label as confirmation that a human reviewed the diff images and approved them. Only a human can make that visual judgment, so after inspecting the diff, ask the user to review it and add the label themselves — do not add it yourself even if the diff looks correct.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/generated/monorepo/CLAUDE.md
+++ b/generated/monorepo/CLAUDE.md
@@ -40,6 +40,16 @@ Every presentational component under `src/components/` should have a co-located 
 
 When you need to check how a component looks or behaves in a given state, write or update its story and view it via the `storybook` script (`storybook dev`) before starting a dev server and driving a browser manually.
 
+## Visual Regression Testing (VRT)
+
+### Understand why the `vrt` check fails
+
+The `vrt` CI check renders Storybook stories to screenshots and compares them against the `main` baseline with reg-suit. A failure ("Visual differences detected") means the pixel diff exceeded reg-suit's `matchingThreshold`, not that something is broken — open the reg-suit report link posted on the PR and compare the actual/expected/diff images to judge whether the change is intentional.
+
+### Never add the `vrt-approved` label yourself
+
+The `vrt-approval` workflow treats the `vrt-approved` label as confirmation that a human reviewed the diff images and approved them. Only a human can make that visual judgment, so after inspecting the diff, ask the user to review it and add the label themselves — do not add it yourself even if the diff looks correct.
+
 ## Test code rules
 
 ### Assert on the whole output with a single equality check

--- a/template/CLAUDE.md.jinja
+++ b/template/CLAUDE.md.jinja
@@ -43,6 +43,18 @@ Every presentational component under `src/components/` should have a co-located 
 
 When you need to check how a component looks or behaves in a given state, write or update its story and view it via the `storybook` script (`storybook dev`) before starting a dev server and driving a browser manually.
 {%- endif %}
+{%- if has_vrt_pkg %}
+
+## Visual Regression Testing (VRT)
+
+### Understand why the `vrt` check fails
+
+The `vrt` CI check renders Storybook stories to screenshots and compares them against the `main` baseline with reg-suit. A failure ("Visual differences detected") means the pixel diff exceeded reg-suit's `matchingThreshold`, not that something is broken — open the reg-suit report link posted on the PR and compare the actual/expected/diff images to judge whether the change is intentional.
+
+### Never add the `vrt-approved` label yourself
+
+The `vrt-approval` workflow treats the `vrt-approved` label as confirmation that a human reviewed the diff images and approved them. Only a human can make that visual judgment, so after inspecting the diff, ask the user to review it and add the label themselves — do not add it yourself even if the diff looks correct.
+{%- endif %}
 
 ## Test code rules
 


### PR DESCRIPTION
## Purpose

- Allow Claude Code to understand the cause and resolution workflow for failed `vrt` CI checks in VRT-enabled repositories without re-investigation

## Approach

- Add guidelines to the generated `CLAUDE.md` for reviewing diff images and asking users to apply the `vrt-approved` label on `vrt` CI check failures
