### PR TITLE
feat(template): add repo_id parameter for octo-sts trust policies

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -401,12 +401,13 @@ is_workspace:
   when: false
 
 # octo-sts trust policy inputs. Immutable subject claim `subject_pattern`
-# values take the form `repo:<owner>@<owner_id>/<name>@<repo_id>:...`. Not
-# consumed by any template file yet.
+# values take the form `repo:<owner>@<owner_id>/<name>@<repo_id>:...`.
 repo_id:
   type: str
   default: ''
-  help: GitHub repository ID (`github.repository_id` in the Actions context)
+  help: |
+    GitHub repository ID (`github.repository_id` in the Actions context).
+    No template consumes this yet, so leave it empty.
 
 # fohte org's GitHub owner ID. Constant: it only changes if the org itself
 # is deleted and recreated.

--- a/copier.yml
+++ b/copier.yml
@@ -399,3 +399,18 @@ is_workspace:
   type: bool
   default: '{{ monorepo_node_workspace | default(false) }}'
   when: false
+
+# octo-sts trust policy inputs. Immutable subject claim `subject_pattern`
+# values take the form `repo:<owner>@<owner_id>/<name>@<repo_id>:...`. Not
+# consumed by any template file yet.
+repo_id:
+  type: str
+  default: ''
+  help: GitHub repository ID (`github.repository_id` in the Actions context)
+
+# fohte org's GitHub owner ID. Constant: it only changes if the org itself
+# is deleted and recreated.
+owner_id:
+  type: str
+  default: '11088009'
+  when: false

--- a/tests/fixtures/base-public.yml
+++ b/tests/fixtures/base-public.yml
@@ -6,3 +6,4 @@ is_public: true
 use_release_please: false
 subpackages: []
 repo_language: en
+repo_id: ''

--- a/tests/fixtures/base-release.yml
+++ b/tests/fixtures/base-release.yml
@@ -8,3 +8,4 @@ release_type: simple
 auto_merge_release_pr: false
 subpackages: []
 repo_language: ja
+repo_id: ''

--- a/tests/fixtures/base.yml
+++ b/tests/fixtures/base.yml
@@ -8,3 +8,4 @@ is_public: false
 use_release_please: false
 subpackages: []
 repo_language: ja
+repo_id: ''

--- a/tests/fixtures/monorepo-node-workspace.yml
+++ b/tests/fixtures/monorepo-node-workspace.yml
@@ -14,3 +14,4 @@ subpackages:
     type: node
     web_app: true
 repo_language: ja
+repo_id: ''

--- a/tests/fixtures/monorepo.yml
+++ b/tests/fixtures/monorepo.yml
@@ -16,3 +16,4 @@ subpackages:
   - name: backend
     type: rust
 repo_language: ja
+repo_id: ''

--- a/tests/fixtures/node.yml
+++ b/tests/fixtures/node.yml
@@ -11,3 +11,4 @@ web_app_port: 8080
 error_tracking: false
 repo_language: ja
 subpackages: []
+repo_id: ''

--- a/tests/fixtures/rust-release.yml
+++ b/tests/fixtures/rust-release.yml
@@ -11,3 +11,4 @@ release_binary: true
 binary_name: rust-release
 repo_language: ja
 subpackages: []
+repo_id: ''

--- a/tests/fixtures/rust-with-node-subpackage.yml
+++ b/tests/fixtures/rust-with-node-subpackage.yml
@@ -17,3 +17,4 @@ subpackages:
     tests: false
     web_app: true
 repo_language: ja
+repo_id: ''

--- a/tests/fixtures/rust.yml
+++ b/tests/fixtures/rust.yml
@@ -9,3 +9,4 @@ use_release_please: false
 use_coverage: false
 repo_language: ja
 subpackages: []
+repo_id: ''


### PR DESCRIPTION
## Purpose

- Migrate octo-sts trust policy management to individual repositories and allow generating policies with immutable subject claims in the template

## Approach

- Add `repo_id` and `owner_id` parameters to `copier` to generate immutable subject claims
