### PR TITLE
ci(chainguard): add octo-sts trust policy

### DIFF
--- a/.github/chainguard/generic-boilerplate-sync-generated-to-template.sts.yaml
+++ b/.github/chainguard/generic-boilerplate-sync-generated-to-template.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte(@11088009)?/generic-boilerplate(@996201414)?:pull_request$
+claim_pattern:
+  job_workflow_ref: ^fohte/generic-boilerplate/\.github/workflows/sync-generated-to-template\.yml@[^@]+$
+permissions:
+  contents: write

--- a/.github/chainguard/generic-boilerplate-validate-template.sts.yaml
+++ b/.github/chainguard/generic-boilerplate-validate-template.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte(@11088009)?/generic-boilerplate(@996201414)?:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/generic-boilerplate/\.github/workflows/validate-template\.yml@[^@]+$
+permissions:
+  contents: write


### PR DESCRIPTION
## Purpose

- Prevent private repository names and dependencies from being exposed via the octo-sts trust policy aggregated in public `fohte/.github`

## Approach

- Add the octo-sts trust policy to this repository in advance
  - Apply the policy before switching the workflow scope, as octo-sts only references policies on the default branch
