### PR TITLE
feat(template): auto-populate repo_id in boilerplate-update

### DIFF
--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -62,7 +62,12 @@ jobs:
           # still-empty default is patched; an already-backfilled value is
           # left as-is, and a missing key (pre-repo_id template versions) is
           # a no-op here and picked up on a later run once copier adds it.
-          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+          if grep -q "^repo_id: ''$" .copier-answers.yml; then
+            sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            echo "Backfilled repo_id=${REPO_ID}"
+          else
+            echo "repo_id already set or key not present; skipping backfill" >&2
+          fi
 
       - name: Run copier-update-action
         id: copier-update

--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -51,6 +51,19 @@ jobs:
           fi
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
+      - name: Backfill repo_id in copier answers
+        env:
+          REPO_ID: ${{ github.repository_id }}
+        run: |
+          set -euo pipefail
+          # `repo_id` is a normal copier.yml question (no `when: false`), so
+          # `copier update --defaults` reuses whatever value already sits in
+          # `.copier-answers.yml` instead of resetting it. Only the
+          # still-empty default is patched; an already-backfilled value is
+          # left as-is, and a missing key (pre-repo_id template versions) is
+          # a no-op here and picked up on a later run once copier adds it.
+          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+
       - name: Run copier-update-action
         id: copier-update
         uses: fohte/copier-update-action@a1c6dfff1b9bb8d5c7ec7af88436611fe7d3f209 # v0.1.5

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -62,7 +62,12 @@ jobs:
           # still-empty default is patched; an already-backfilled value is
           # left as-is, and a missing key (pre-repo_id template versions) is
           # a no-op here and picked up on a later run once copier adds it.
-          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+          if grep -q "^repo_id: ''$" .copier-answers.yml; then
+            sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            echo "Backfilled repo_id=${REPO_ID}"
+          else
+            echo "repo_id already set or key not present; skipping backfill" >&2
+          fi
 
       - name: Run copier-update-action
         id: copier-update

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -51,6 +51,19 @@ jobs:
           fi
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
+      - name: Backfill repo_id in copier answers
+        env:
+          REPO_ID: ${{ github.repository_id }}
+        run: |
+          set -euo pipefail
+          # `repo_id` is a normal copier.yml question (no `when: false`), so
+          # `copier update --defaults` reuses whatever value already sits in
+          # `.copier-answers.yml` instead of resetting it. Only the
+          # still-empty default is patched; an already-backfilled value is
+          # left as-is, and a missing key (pre-repo_id template versions) is
+          # a no-op here and picked up on a later run once copier adds it.
+          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+
       - name: Run copier-update-action
         id: copier-update
         uses: fohte/copier-update-action@a1c6dfff1b9bb8d5c7ec7af88436611fe7d3f209 # v0.1.5

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -62,7 +62,12 @@ jobs:
           # still-empty default is patched; an already-backfilled value is
           # left as-is, and a missing key (pre-repo_id template versions) is
           # a no-op here and picked up on a later run once copier adds it.
-          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+          if grep -q "^repo_id: ''$" .copier-answers.yml; then
+            sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            echo "Backfilled repo_id=${REPO_ID}"
+          else
+            echo "repo_id already set or key not present; skipping backfill" >&2
+          fi
 
       - name: Run copier-update-action
         id: copier-update

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -51,6 +51,19 @@ jobs:
           fi
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
+      - name: Backfill repo_id in copier answers
+        env:
+          REPO_ID: ${{ github.repository_id }}
+        run: |
+          set -euo pipefail
+          # `repo_id` is a normal copier.yml question (no `when: false`), so
+          # `copier update --defaults` reuses whatever value already sits in
+          # `.copier-answers.yml` instead of resetting it. Only the
+          # still-empty default is patched; an already-backfilled value is
+          # left as-is, and a missing key (pre-repo_id template versions) is
+          # a no-op here and picked up on a later run once copier adds it.
+          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+
       - name: Run copier-update-action
         id: copier-update
         uses: fohte/copier-update-action@a1c6dfff1b9bb8d5c7ec7af88436611fe7d3f209 # v0.1.5

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -62,7 +62,12 @@ jobs:
           # still-empty default is patched; an already-backfilled value is
           # left as-is, and a missing key (pre-repo_id template versions) is
           # a no-op here and picked up on a later run once copier adds it.
-          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+          if grep -q "^repo_id: ''$" .copier-answers.yml; then
+            sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            echo "Backfilled repo_id=${REPO_ID}"
+          else
+            echo "repo_id already set or key not present; skipping backfill" >&2
+          fi
 
       - name: Run copier-update-action
         id: copier-update

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -51,6 +51,19 @@ jobs:
           fi
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
+      - name: Backfill repo_id in copier answers
+        env:
+          REPO_ID: ${{ github.repository_id }}
+        run: |
+          set -euo pipefail
+          # `repo_id` is a normal copier.yml question (no `when: false`), so
+          # `copier update --defaults` reuses whatever value already sits in
+          # `.copier-answers.yml` instead of resetting it. Only the
+          # still-empty default is patched; an already-backfilled value is
+          # left as-is, and a missing key (pre-repo_id template versions) is
+          # a no-op here and picked up on a later run once copier adds it.
+          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+
       - name: Run copier-update-action
         id: copier-update
         uses: fohte/copier-update-action@a1c6dfff1b9bb8d5c7ec7af88436611fe7d3f209 # v0.1.5

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -62,7 +62,12 @@ jobs:
           # still-empty default is patched; an already-backfilled value is
           # left as-is, and a missing key (pre-repo_id template versions) is
           # a no-op here and picked up on a later run once copier adds it.
-          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+          if grep -q "^repo_id: ''$" .copier-answers.yml; then
+            sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            echo "Backfilled repo_id=${REPO_ID}"
+          else
+            echo "repo_id already set or key not present; skipping backfill" >&2
+          fi
 
       - name: Run copier-update-action
         id: copier-update

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -51,6 +51,19 @@ jobs:
           fi
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
+      - name: Backfill repo_id in copier answers
+        env:
+          REPO_ID: ${{ github.repository_id }}
+        run: |
+          set -euo pipefail
+          # `repo_id` is a normal copier.yml question (no `when: false`), so
+          # `copier update --defaults` reuses whatever value already sits in
+          # `.copier-answers.yml` instead of resetting it. Only the
+          # still-empty default is patched; an already-backfilled value is
+          # left as-is, and a missing key (pre-repo_id template versions) is
+          # a no-op here and picked up on a later run once copier adds it.
+          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+
       - name: Run copier-update-action
         id: copier-update
         uses: fohte/copier-update-action@a1c6dfff1b9bb8d5c7ec7af88436611fe7d3f209 # v0.1.5

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -62,7 +62,12 @@ jobs:
           # still-empty default is patched; an already-backfilled value is
           # left as-is, and a missing key (pre-repo_id template versions) is
           # a no-op here and picked up on a later run once copier adds it.
-          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+          if grep -q "^repo_id: ''$" .copier-answers.yml; then
+            sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            echo "Backfilled repo_id=${REPO_ID}"
+          else
+            echo "repo_id already set or key not present; skipping backfill" >&2
+          fi
 
       - name: Run copier-update-action
         id: copier-update

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -51,6 +51,19 @@ jobs:
           fi
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
+      - name: Backfill repo_id in copier answers
+        env:
+          REPO_ID: ${{ github.repository_id }}
+        run: |
+          set -euo pipefail
+          # `repo_id` is a normal copier.yml question (no `when: false`), so
+          # `copier update --defaults` reuses whatever value already sits in
+          # `.copier-answers.yml` instead of resetting it. Only the
+          # still-empty default is patched; an already-backfilled value is
+          # left as-is, and a missing key (pre-repo_id template versions) is
+          # a no-op here and picked up on a later run once copier adds it.
+          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+
       - name: Run copier-update-action
         id: copier-update
         uses: fohte/copier-update-action@a1c6dfff1b9bb8d5c7ec7af88436611fe7d3f209 # v0.1.5

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -62,7 +62,12 @@ jobs:
           # still-empty default is patched; an already-backfilled value is
           # left as-is, and a missing key (pre-repo_id template versions) is
           # a no-op here and picked up on a later run once copier adds it.
-          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+          if grep -q "^repo_id: ''$" .copier-answers.yml; then
+            sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            echo "Backfilled repo_id=${REPO_ID}"
+          else
+            echo "repo_id already set or key not present; skipping backfill" >&2
+          fi
 
       - name: Run copier-update-action
         id: copier-update

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -51,6 +51,19 @@ jobs:
           fi
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
+      - name: Backfill repo_id in copier answers
+        env:
+          REPO_ID: ${{ github.repository_id }}
+        run: |
+          set -euo pipefail
+          # `repo_id` is a normal copier.yml question (no `when: false`), so
+          # `copier update --defaults` reuses whatever value already sits in
+          # `.copier-answers.yml` instead of resetting it. Only the
+          # still-empty default is patched; an already-backfilled value is
+          # left as-is, and a missing key (pre-repo_id template versions) is
+          # a no-op here and picked up on a later run once copier adds it.
+          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+
       - name: Run copier-update-action
         id: copier-update
         uses: fohte/copier-update-action@a1c6dfff1b9bb8d5c7ec7af88436611fe7d3f209 # v0.1.5

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -62,7 +62,12 @@ jobs:
           # still-empty default is patched; an already-backfilled value is
           # left as-is, and a missing key (pre-repo_id template versions) is
           # a no-op here and picked up on a later run once copier adds it.
-          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+          if grep -q "^repo_id: ''$" .copier-answers.yml; then
+            sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            echo "Backfilled repo_id=${REPO_ID}"
+          else
+            echo "repo_id already set or key not present; skipping backfill" >&2
+          fi
 
       - name: Run copier-update-action
         id: copier-update

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -51,6 +51,19 @@ jobs:
           fi
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
+      - name: Backfill repo_id in copier answers
+        env:
+          REPO_ID: ${{ github.repository_id }}
+        run: |
+          set -euo pipefail
+          # `repo_id` is a normal copier.yml question (no `when: false`), so
+          # `copier update --defaults` reuses whatever value already sits in
+          # `.copier-answers.yml` instead of resetting it. Only the
+          # still-empty default is patched; an already-backfilled value is
+          # left as-is, and a missing key (pre-repo_id template versions) is
+          # a no-op here and picked up on a later run once copier adds it.
+          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+
       - name: Run copier-update-action
         id: copier-update
         uses: fohte/copier-update-action@a1c6dfff1b9bb8d5c7ec7af88436611fe7d3f209 # v0.1.5

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -62,7 +62,12 @@ jobs:
           # still-empty default is patched; an already-backfilled value is
           # left as-is, and a missing key (pre-repo_id template versions) is
           # a no-op here and picked up on a later run once copier adds it.
-          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+          if grep -q "^repo_id: ''$" .copier-answers.yml; then
+            sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            echo "Backfilled repo_id=${REPO_ID}"
+          else
+            echo "repo_id already set or key not present; skipping backfill" >&2
+          fi
 
       - name: Run copier-update-action
         id: copier-update

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -51,6 +51,19 @@ jobs:
           fi
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
+      - name: Backfill repo_id in copier answers
+        env:
+          REPO_ID: ${{ github.repository_id }}
+        run: |
+          set -euo pipefail
+          # `repo_id` is a normal copier.yml question (no `when: false`), so
+          # `copier update --defaults` reuses whatever value already sits in
+          # `.copier-answers.yml` instead of resetting it. Only the
+          # still-empty default is patched; an already-backfilled value is
+          # left as-is, and a missing key (pre-repo_id template versions) is
+          # a no-op here and picked up on a later run once copier adds it.
+          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+
       - name: Run copier-update-action
         id: copier-update
         uses: fohte/copier-update-action@a1c6dfff1b9bb8d5c7ec7af88436611fe7d3f209 # v0.1.5

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -62,7 +62,12 @@ jobs:
           # still-empty default is patched; an already-backfilled value is
           # left as-is, and a missing key (pre-repo_id template versions) is
           # a no-op here and picked up on a later run once copier adds it.
-          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+          if grep -q "^repo_id: ''$" .copier-answers.yml; then
+            sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            echo "Backfilled repo_id=${REPO_ID}"
+          else
+            echo "repo_id already set or key not present; skipping backfill" >&2
+          fi
 
       - name: Run copier-update-action
         id: copier-update

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -51,6 +51,19 @@ jobs:
           fi
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
+      - name: Backfill repo_id in copier answers
+        env:
+          REPO_ID: ${{ github.repository_id }}
+        run: |
+          set -euo pipefail
+          # `repo_id` is a normal copier.yml question (no `when: false`), so
+          # `copier update --defaults` reuses whatever value already sits in
+          # `.copier-answers.yml` instead of resetting it. Only the
+          # still-empty default is patched; an already-backfilled value is
+          # left as-is, and a missing key (pre-repo_id template versions) is
+          # a no-op here and picked up on a later run once copier adds it.
+          sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+
       - name: Run copier-update-action
         id: copier-update
         uses: fohte/copier-update-action@a1c6dfff1b9bb8d5c7ec7af88436611fe7d3f209 # v0.1.5


### PR DESCRIPTION
## Purpose

- from: #597
- Propagate `repo_id` into `.copier-answers.yml` across downstream repositories without manual intervention to prepare for the per-repository migration of octo-sts trust policies.

## Approach

- Automatically populate each repository's ID into `repo_id` in `.copier-answers.yml` during `boilerplate-update`.
