### PR TITLE
ci(chainguard): switch octo-sts policy references in workflows to own repository

### DIFF
--- a/.github/workflows/sync-generated-to-template.yml
+++ b/.github/workflows/sync-generated-to-template.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: fohte/generic-boilerplate
           identity: generic-boilerplate-sync-generated-to-template
           domain: octo-sts.fohte.net
 

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: fohte/generic-boilerplate
           identity: generic-boilerplate-validate-template
           domain: octo-sts.fohte.net
 


### PR DESCRIPTION
## Purpose

- from: #598
- Prevent exposure of private repository names and dependencies through public repositories

## Approach

- Update each workflow to reference octo-sts policies in its own repository
