### PR TITLE
feat(template): add repo-scoped octo-sts trust policy

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -55,7 +55,15 @@ _exclude:
   - '{% if not use_release_please %}.github/workflows/release-please.yml{% endif %}'
   - '{% if not use_release_please %}.github/workflows/test-release-please.yml{% endif %}'
   - '{% if not use_release_please %}.github/workflows/pr-title-check.yml{% endif %}'
-  - '{% if not use_release_please %}.github/chainguard/{{ project_name }}-release-please.sts.yaml{% endif %}'
+  # octo-sts trust policies embed repo_id in an immutable subject_pattern
+  # (see the repo_id parameter below); skip them entirely while it's empty
+  # instead of rendering a policy that can never match, so a fresh `copier
+  # copy`/`update` with no repo_id yet doesn't ship a dead file, and so a
+  # missing repo_id never hard-fails the rest of generation.
+  - "{% if repo_id == '' %}.github/chainguard/{{ project_name }}.sts.yaml{% endif %}"
+  - "{% if repo_id == '' %}.github/chainguard/{{ project_name }}-boilerplate-update.sts.yaml{% endif %}"
+  - "{% if repo_id == '' %}.github/chainguard/{{ project_name }}-bootstrap.sts.yaml{% endif %}"
+  - "{% if repo_id == '' or not use_release_please %}.github/chainguard/{{ project_name }}-release-please.sts.yaml{% endif %}"
   # Exclude Node.js specific files when type is not 'node'
   # Use leading / to match root only (not yield subpackage directories)
   # Non-workspace monorepos (even with node subpackages) keep prettier/commitlint
@@ -407,18 +415,22 @@ is_workspace:
 
 # octo-sts trust policy inputs. Immutable subject claim `subject_pattern`
 # values take the form `repo:<owner>@<owner_id>/<name>@<repo_id>:...`.
+#
+# The .github/chainguard/*.sts.yaml.jinja templates mirror
+# fohte/infra's octo-sts-trust-policy*.tftpl content exactly, including two
+# properties that look like oversights but aren't: project_name/repo_id are
+# interpolated unescaped into subject_pattern/job_workflow_ref (fohte org
+# repo names are operator-controlled, not attacker input), and the
+# bootstrap policy matches any branch (`.+`) rather than main/master even
+# though bootstrap.yml only ever triggers on those — harmless since
+# obtaining a token still requires actually triggering that workflow.
 repo_id:
   type: str
   default: ''
   help: |
     GitHub repository ID (`github.repository_id` in the Actions context).
-    Embedded in the octo-sts trust policies under .github/chainguard/.
-  validator: |-
-    {%- if repo_id == '' -%}
-    repo_id must not be empty: octo-sts trust policies under
-    .github/chainguard/ embed it in an immutable subject_pattern, and an
-    empty value renders a broken pattern.
-    {%- endif -%}
+    Embedded in the octo-sts trust policies under .github/chainguard/; those
+    files are skipped (see _exclude above) while this is empty.
 
 # fohte org's GitHub owner ID. Constant: it only changes if the org itself
 # is deleted and recreated.

--- a/copier.yml
+++ b/copier.yml
@@ -55,6 +55,7 @@ _exclude:
   - '{% if not use_release_please %}.github/workflows/release-please.yml{% endif %}'
   - '{% if not use_release_please %}.github/workflows/test-release-please.yml{% endif %}'
   - '{% if not use_release_please %}.github/workflows/pr-title-check.yml{% endif %}'
+  - '{% if not use_release_please %}.github/chainguard/{{ project_name }}-release-please.sts.yaml{% endif %}'
   # Exclude Node.js specific files when type is not 'node'
   # Use leading / to match root only (not yield subpackage directories)
   # Non-workspace monorepos (even with node subpackages) keep prettier/commitlint
@@ -75,6 +76,10 @@ _exclude:
   # lockfiles, so the workflow would self-delete on the next push and leave a
   # stray commit.
   - '{% if _copier_operation == "update" %}.github/workflows/bootstrap.yml{% endif %}'
+  # The bootstrap octo-sts trust policy is intentionally NOT excluded on
+  # `copier update` or gated on has_node/has_rust, unlike bootstrap.yml
+  # above: it mirrors fohte/infra's octo_sts_trust_policy.tf, which commits
+  # it once and never removes it, regardless of language.
   # Exclude Rust specific files when type is not 'rust'
   - "{% if type != 'rust' %}/Cargo.toml{% endif %}"
   - "{% if type != 'rust' %}/rust-toolchain.toml{% endif %}"
@@ -407,7 +412,13 @@ repo_id:
   default: ''
   help: |
     GitHub repository ID (`github.repository_id` in the Actions context).
-    No template consumes this yet, so leave it empty.
+    Embedded in the octo-sts trust policies under .github/chainguard/.
+  validator: |-
+    {%- if repo_id == '' -%}
+    repo_id must not be empty: octo-sts trust policies under
+    .github/chainguard/ embed it in an immutable subject_pattern, and an
+    empty value renders a broken pattern.
+    {%- endif -%}
 
 # fohte org's GitHub owner ID. Constant: it only changes if the org itself
 # is deleted and recreated.

--- a/generated/base-public/.github/chainguard/base-public-boilerplate-update.sts.yaml
+++ b/generated/base-public/.github/chainguard/base-public-boilerplate-update.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/base-public@123456789:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/base-public/\.github/workflows/boilerplate-update\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write

--- a/generated/base-public/.github/chainguard/base-public-bootstrap.sts.yaml
+++ b/generated/base-public/.github/chainguard/base-public-bootstrap.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/base-public@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/base-public/\.github/workflows/bootstrap\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/base-public/.github/chainguard/base-public.sts.yaml
+++ b/generated/base-public/.github/chainguard/base-public.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/base-public@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/base-public/\.github/workflows/test\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/base-release/.github/chainguard/base-release-boilerplate-update.sts.yaml
+++ b/generated/base-release/.github/chainguard/base-release-boilerplate-update.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/base-release@123456789:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/base-release/\.github/workflows/boilerplate-update\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write

--- a/generated/base-release/.github/chainguard/base-release-bootstrap.sts.yaml
+++ b/generated/base-release/.github/chainguard/base-release-bootstrap.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/base-release@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/base-release/\.github/workflows/bootstrap\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/base-release/.github/chainguard/base-release-release-please.sts.yaml
+++ b/generated/base-release/.github/chainguard/base-release-release-please.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/base-release@123456789:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/base-release/\.github/workflows/release-please\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write

--- a/generated/base-release/.github/chainguard/base-release.sts.yaml
+++ b/generated/base-release/.github/chainguard/base-release.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/base-release@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/base-release/\.github/workflows/test\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/base/.github/chainguard/base-boilerplate-update.sts.yaml
+++ b/generated/base/.github/chainguard/base-boilerplate-update.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/base@123456789:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/base/\.github/workflows/boilerplate-update\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write

--- a/generated/base/.github/chainguard/base-bootstrap.sts.yaml
+++ b/generated/base/.github/chainguard/base-bootstrap.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/base@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/base/\.github/workflows/bootstrap\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/base/.github/chainguard/base.sts.yaml
+++ b/generated/base/.github/chainguard/base.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/base@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/base/\.github/workflows/test\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/monorepo-node-workspace/.github/chainguard/monorepo-node-workspace-pnpm-boilerplate-update.sts.yaml
+++ b/generated/monorepo-node-workspace/.github/chainguard/monorepo-node-workspace-pnpm-boilerplate-update.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/monorepo-node-workspace-pnpm@123456789:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/monorepo-node-workspace-pnpm/\.github/workflows/boilerplate-update\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write

--- a/generated/monorepo-node-workspace/.github/chainguard/monorepo-node-workspace-pnpm-bootstrap.sts.yaml
+++ b/generated/monorepo-node-workspace/.github/chainguard/monorepo-node-workspace-pnpm-bootstrap.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/monorepo-node-workspace-pnpm@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/monorepo-node-workspace-pnpm/\.github/workflows/bootstrap\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/monorepo-node-workspace/.github/chainguard/monorepo-node-workspace-pnpm.sts.yaml
+++ b/generated/monorepo-node-workspace/.github/chainguard/monorepo-node-workspace-pnpm.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/monorepo-node-workspace-pnpm@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/monorepo-node-workspace-pnpm/\.github/workflows/test\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/monorepo/.github/chainguard/monorepo-boilerplate-update.sts.yaml
+++ b/generated/monorepo/.github/chainguard/monorepo-boilerplate-update.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/monorepo@123456789:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/monorepo/\.github/workflows/boilerplate-update\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write

--- a/generated/monorepo/.github/chainguard/monorepo-bootstrap.sts.yaml
+++ b/generated/monorepo/.github/chainguard/monorepo-bootstrap.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/monorepo@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/monorepo/\.github/workflows/bootstrap\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/monorepo/.github/chainguard/monorepo.sts.yaml
+++ b/generated/monorepo/.github/chainguard/monorepo.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/monorepo@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/monorepo/\.github/workflows/test\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/node/.github/chainguard/node-boilerplate-update.sts.yaml
+++ b/generated/node/.github/chainguard/node-boilerplate-update.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/node@123456789:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/node/\.github/workflows/boilerplate-update\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write

--- a/generated/node/.github/chainguard/node-bootstrap.sts.yaml
+++ b/generated/node/.github/chainguard/node-bootstrap.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/node@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/node/\.github/workflows/bootstrap\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/node/.github/chainguard/node.sts.yaml
+++ b/generated/node/.github/chainguard/node.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/node@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/node/\.github/workflows/test\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/rust-release/.github/chainguard/rust-release-boilerplate-update.sts.yaml
+++ b/generated/rust-release/.github/chainguard/rust-release-boilerplate-update.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/rust-release@123456789:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/rust-release/\.github/workflows/boilerplate-update\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write

--- a/generated/rust-release/.github/chainguard/rust-release-bootstrap.sts.yaml
+++ b/generated/rust-release/.github/chainguard/rust-release-bootstrap.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/rust-release@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/rust-release/\.github/workflows/bootstrap\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/rust-release/.github/chainguard/rust-release-release-please.sts.yaml
+++ b/generated/rust-release/.github/chainguard/rust-release-release-please.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/rust-release@123456789:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/rust-release/\.github/workflows/release-please\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write

--- a/generated/rust-release/.github/chainguard/rust-release.sts.yaml
+++ b/generated/rust-release/.github/chainguard/rust-release.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/rust-release@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/rust-release/\.github/workflows/test\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/rust-with-node-subpackage/.github/chainguard/rust-with-node-subpackage-boilerplate-update.sts.yaml
+++ b/generated/rust-with-node-subpackage/.github/chainguard/rust-with-node-subpackage-boilerplate-update.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/rust-with-node-subpackage@123456789:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/rust-with-node-subpackage/\.github/workflows/boilerplate-update\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write

--- a/generated/rust-with-node-subpackage/.github/chainguard/rust-with-node-subpackage-bootstrap.sts.yaml
+++ b/generated/rust-with-node-subpackage/.github/chainguard/rust-with-node-subpackage-bootstrap.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/rust-with-node-subpackage@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/rust-with-node-subpackage/\.github/workflows/bootstrap\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/rust-with-node-subpackage/.github/chainguard/rust-with-node-subpackage.sts.yaml
+++ b/generated/rust-with-node-subpackage/.github/chainguard/rust-with-node-subpackage.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/rust-with-node-subpackage@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/rust-with-node-subpackage/\.github/workflows/test\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/rust/.github/chainguard/rust-boilerplate-update.sts.yaml
+++ b/generated/rust/.github/chainguard/rust-boilerplate-update.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/rust@123456789:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/rust/\.github/workflows/boilerplate-update\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write

--- a/generated/rust/.github/chainguard/rust-bootstrap.sts.yaml
+++ b/generated/rust/.github/chainguard/rust-bootstrap.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/rust@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/rust/\.github/workflows/bootstrap\.yml@[^@]+$
+permissions:
+  contents: write

--- a/generated/rust/.github/chainguard/rust.sts.yaml
+++ b/generated/rust/.github/chainguard/rust.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/rust@123456789:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/rust/\.github/workflows/test\.yml@[^@]+$
+permissions:
+  contents: write

--- a/template/.github/chainguard/{{ project_name }}-boilerplate-update.sts.yaml.jinja
+++ b/template/.github/chainguard/{{ project_name }}-boilerplate-update.sts.yaml.jinja
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@{{ owner_id }}/{{ project_name }}@{{ repo_id }}:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/{{ project_name }}/\.github/workflows/boilerplate-update\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write

--- a/template/.github/chainguard/{{ project_name }}-bootstrap.sts.yaml.jinja
+++ b/template/.github/chainguard/{{ project_name }}-bootstrap.sts.yaml.jinja
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@{{ owner_id }}/{{ project_name }}@{{ repo_id }}:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/{{ project_name }}/\.github/workflows/bootstrap\.yml@[^@]+$
+permissions:
+  contents: write

--- a/template/.github/chainguard/{{ project_name }}-release-please.sts.yaml.jinja
+++ b/template/.github/chainguard/{{ project_name }}-release-please.sts.yaml.jinja
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@{{ owner_id }}/{{ project_name }}@{{ repo_id }}:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/{{ project_name }}/\.github/workflows/release-please\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write

--- a/template/.github/chainguard/{{ project_name }}.sts.yaml.jinja
+++ b/template/.github/chainguard/{{ project_name }}.sts.yaml.jinja
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@{{ owner_id }}/{{ project_name }}@{{ repo_id }}:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/{{ project_name }}/\.github/workflows/test\.yml@[^@]+$
+permissions:
+  contents: write

--- a/tests/fixtures/base-public.yml
+++ b/tests/fixtures/base-public.yml
@@ -6,4 +6,4 @@ is_public: true
 use_release_please: false
 subpackages: []
 repo_language: en
-repo_id: ''
+repo_id: '123456789'

--- a/tests/fixtures/base-release.yml
+++ b/tests/fixtures/base-release.yml
@@ -8,4 +8,4 @@ release_type: simple
 auto_merge_release_pr: false
 subpackages: []
 repo_language: ja
-repo_id: ''
+repo_id: '123456789'

--- a/tests/fixtures/base.yml
+++ b/tests/fixtures/base.yml
@@ -8,4 +8,4 @@ is_public: false
 use_release_please: false
 subpackages: []
 repo_language: ja
-repo_id: ''
+repo_id: '123456789'

--- a/tests/fixtures/monorepo-node-workspace.yml
+++ b/tests/fixtures/monorepo-node-workspace.yml
@@ -14,4 +14,4 @@ subpackages:
     type: node
     web_app: true
 repo_language: ja
-repo_id: ''
+repo_id: '123456789'

--- a/tests/fixtures/monorepo.yml
+++ b/tests/fixtures/monorepo.yml
@@ -16,4 +16,4 @@ subpackages:
   - name: backend
     type: rust
 repo_language: ja
-repo_id: ''
+repo_id: '123456789'

--- a/tests/fixtures/node.yml
+++ b/tests/fixtures/node.yml
@@ -11,4 +11,4 @@ web_app_port: 8080
 error_tracking: false
 repo_language: ja
 subpackages: []
-repo_id: ''
+repo_id: '123456789'

--- a/tests/fixtures/rust-release.yml
+++ b/tests/fixtures/rust-release.yml
@@ -11,4 +11,4 @@ release_binary: true
 binary_name: rust-release
 repo_language: ja
 subpackages: []
-repo_id: ''
+repo_id: '123456789'

--- a/tests/fixtures/rust-with-node-subpackage.yml
+++ b/tests/fixtures/rust-with-node-subpackage.yml
@@ -17,4 +17,4 @@ subpackages:
     tests: false
     web_app: true
 repo_language: ja
-repo_id: ''
+repo_id: '123456789'

--- a/tests/fixtures/rust.yml
+++ b/tests/fixtures/rust.yml
@@ -9,4 +9,4 @@ use_release_please: false
 use_coverage: false
 repo_language: ja
 subpackages: []
-repo_id: ''
+repo_id: '123456789'


### PR DESCRIPTION
## Purpose

- Eliminate the risk of leaking private repository information from octo-sts trust policies centralized in public `fohte/.github`

## Approach

- Generate octo-sts trust policies in each repository's `.github/chainguard/`
