### PR TITLE
chore: set repo_id in copier answers

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -8,7 +8,7 @@ description:
 is_public: true
 project_name: generic-boilerplate
 release_type: simple
-repo_id: ''
+repo_id: '996201414'
 repo_language: en
 subpackages: []
 type: base


### PR DESCRIPTION
## Purpose

- Template updates no longer reach this repository
    - The `boilerplate-update` workflow patches `repo_id` in `.copier-answers.yml` in place and never commits it
    - The `copier update` that runs next aborts with `Destination repository is dirty`

## Approach

- Write the real repository ID into `repo_id`, which leaves the patching step with nothing to do
    - The same ID is what the octo-sts trust policy templates interpolate into `subject_pattern`