### PR TITLE
fix(template): commit repo_id backfill in advance

### DIFF
--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -192,6 +192,15 @@ jobs:
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
           git add -A
+          # Whether copier update produced anything beyond the repo_id backfill
+          # commit (already committed in the `backfill` step, if any). Computed
+          # once here and reused below so the title/commit/PR-body steps agree
+          # on whether this run is backfill-only.
+          if git diff --cached --quiet; then
+            echo "has-extra-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-extra-changes=true" >> "$GITHUB_OUTPUT"
+          fi
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
@@ -201,13 +210,13 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
-            # Template version didn't move, so the only reason should-update
-            # is true is the repo_id backfill; don't claim a version bump
-            # that didn't happen (a manual re-apply of the same version, with
-            # nothing backfilled, still falls through to the branch below).
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
+            # copier update produced nothing beyond the repo_id backfill commit
+            # (not just a version-string match — e.g. this rules out an
+            # unrelated YAML quote-style drift landing under this title).
             echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
           else
             echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
@@ -218,12 +227,13 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
           # Nothing to commit when the only change this run is the repo_id
           # backfill (already committed in its own step above) and copier
           # update itself produced no further diff.
-          if ! git diff --cached --quiet; then
+          if [ "${HAS_EXTRA_CHANGES}" = "true" ]; then
             git -c 'user.name=fohte-bot[bot]' \
                 -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
                 commit -m "${COMMIT_MESSAGE}"
@@ -250,11 +260,12 @@ jobs:
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
             summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
           else
             summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."

--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -52,6 +52,7 @@ jobs:
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
       - name: Backfill repo_id in copier answers
+        id: backfill
         env:
           REPO_ID: ${{ github.repository_id }}
         run: |
@@ -64,8 +65,16 @@ jobs:
           # a no-op here and picked up on a later run once copier adds it.
           if grep -q "^repo_id: ''$" .copier-answers.yml; then
             sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            # `copier update` refuses to run against a dirty working tree, so
+            # commit immediately rather than leaving this as an uncommitted change.
+            git add .copier-answers.yml
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "chore: backfill repo_id in copier answers"
+            echo "backfilled=true" >> "$GITHUB_OUTPUT"
             echo "Backfilled repo_id=${REPO_ID}"
           else
+            echo "backfilled=false" >> "$GITHUB_OUTPUT"
             echo "repo_id already set or key not present; skipping backfill" >&2
           fi
 
@@ -85,15 +94,18 @@ jobs:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           # Only set when workflow_dispatch explicitly pins a target version.
           MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          if [ "${CHANGED}" != "true" ]; then
+          if [ "${CHANGED}" != "true" ] && [ "${BACKFILLED}" != "true" ]; then
             echo "value=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          elif [ "${BACKFILLED}" != "true" ] && [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
             # copier-update-action's `changed` output reflects any diff (e.g. YAML
             # quote-style drift), not whether the template version itself moved.
             # Skip the no-op case for scheduled/latest-release runs; an explicit
             # manual target-version means the caller wants to re-apply regardless.
+            # A repo_id backfill is never skipped this way: this PR is the only
+            # path that lands it on the default branch.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -188,9 +200,18 @@ jobs:
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # Template version didn't move, so the only reason should-update
+            # is true is the repo_id backfill; don't claim a version bump
+            # that didn't happen (a manual re-apply of the same version, with
+            # nothing backfilled, still falls through to the branch below).
+            echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit and push changes
         if: steps.should-update.outputs.value == 'true'
@@ -199,10 +220,15 @@ jobs:
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
         run: |
           set -euo pipefail
-          git -c 'user.name=fohte-bot[bot]' \
-              -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
-              commit -m "${COMMIT_MESSAGE}"
-          # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
+          # Nothing to commit when the only change this run is the repo_id
+          # backfill (already committed in its own step above) and copier
+          # update itself produced no further diff.
+          if ! git diff --cached --quiet; then
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "${COMMIT_MESSAGE}"
+          fi
+          # Force-push so the remote branch always equals "default branch HEAD + this run's commits".
           # Without this, commits on the branch (fixed per template repo, reused across
           # versions) accumulate and the PR drifts from the default branch.
           #
@@ -223,11 +249,16 @@ jobs:
           HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
+          else
+            summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          fi
 
           needs_review=false
           body="${summary}"

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -192,6 +192,15 @@ jobs:
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
           git add -A
+          # Whether copier update produced anything beyond the repo_id backfill
+          # commit (already committed in the `backfill` step, if any). Computed
+          # once here and reused below so the title/commit/PR-body steps agree
+          # on whether this run is backfill-only.
+          if git diff --cached --quiet; then
+            echo "has-extra-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-extra-changes=true" >> "$GITHUB_OUTPUT"
+          fi
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
@@ -201,13 +210,13 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
-            # Template version didn't move, so the only reason should-update
-            # is true is the repo_id backfill; don't claim a version bump
-            # that didn't happen (a manual re-apply of the same version, with
-            # nothing backfilled, still falls through to the branch below).
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
+            # copier update produced nothing beyond the repo_id backfill commit
+            # (not just a version-string match — e.g. this rules out an
+            # unrelated YAML quote-style drift landing under this title).
             echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
           else
             echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
@@ -218,12 +227,13 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
           # Nothing to commit when the only change this run is the repo_id
           # backfill (already committed in its own step above) and copier
           # update itself produced no further diff.
-          if ! git diff --cached --quiet; then
+          if [ "${HAS_EXTRA_CHANGES}" = "true" ]; then
             git -c 'user.name=fohte-bot[bot]' \
                 -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
                 commit -m "${COMMIT_MESSAGE}"
@@ -250,11 +260,12 @@ jobs:
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
             summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
           else
             summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -52,6 +52,7 @@ jobs:
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
       - name: Backfill repo_id in copier answers
+        id: backfill
         env:
           REPO_ID: ${{ github.repository_id }}
         run: |
@@ -64,8 +65,16 @@ jobs:
           # a no-op here and picked up on a later run once copier adds it.
           if grep -q "^repo_id: ''$" .copier-answers.yml; then
             sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            # `copier update` refuses to run against a dirty working tree, so
+            # commit immediately rather than leaving this as an uncommitted change.
+            git add .copier-answers.yml
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "chore: backfill repo_id in copier answers"
+            echo "backfilled=true" >> "$GITHUB_OUTPUT"
             echo "Backfilled repo_id=${REPO_ID}"
           else
+            echo "backfilled=false" >> "$GITHUB_OUTPUT"
             echo "repo_id already set or key not present; skipping backfill" >&2
           fi
 
@@ -85,15 +94,18 @@ jobs:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           # Only set when workflow_dispatch explicitly pins a target version.
           MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          if [ "${CHANGED}" != "true" ]; then
+          if [ "${CHANGED}" != "true" ] && [ "${BACKFILLED}" != "true" ]; then
             echo "value=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          elif [ "${BACKFILLED}" != "true" ] && [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
             # copier-update-action's `changed` output reflects any diff (e.g. YAML
             # quote-style drift), not whether the template version itself moved.
             # Skip the no-op case for scheduled/latest-release runs; an explicit
             # manual target-version means the caller wants to re-apply regardless.
+            # A repo_id backfill is never skipped this way: this PR is the only
+            # path that lands it on the default branch.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -188,9 +200,18 @@ jobs:
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # Template version didn't move, so the only reason should-update
+            # is true is the repo_id backfill; don't claim a version bump
+            # that didn't happen (a manual re-apply of the same version, with
+            # nothing backfilled, still falls through to the branch below).
+            echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit and push changes
         if: steps.should-update.outputs.value == 'true'
@@ -199,10 +220,15 @@ jobs:
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
         run: |
           set -euo pipefail
-          git -c 'user.name=fohte-bot[bot]' \
-              -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
-              commit -m "${COMMIT_MESSAGE}"
-          # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
+          # Nothing to commit when the only change this run is the repo_id
+          # backfill (already committed in its own step above) and copier
+          # update itself produced no further diff.
+          if ! git diff --cached --quiet; then
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "${COMMIT_MESSAGE}"
+          fi
+          # Force-push so the remote branch always equals "default branch HEAD + this run's commits".
           # Without this, commits on the branch (fixed per template repo, reused across
           # versions) accumulate and the PR drifts from the default branch.
           #
@@ -223,11 +249,16 @@ jobs:
           HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
+          else
+            summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          fi
 
           needs_review=false
           body="${summary}"

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -192,6 +192,15 @@ jobs:
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
           git add -A
+          # Whether copier update produced anything beyond the repo_id backfill
+          # commit (already committed in the `backfill` step, if any). Computed
+          # once here and reused below so the title/commit/PR-body steps agree
+          # on whether this run is backfill-only.
+          if git diff --cached --quiet; then
+            echo "has-extra-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-extra-changes=true" >> "$GITHUB_OUTPUT"
+          fi
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
@@ -201,13 +210,13 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
-            # Template version didn't move, so the only reason should-update
-            # is true is the repo_id backfill; don't claim a version bump
-            # that didn't happen (a manual re-apply of the same version, with
-            # nothing backfilled, still falls through to the branch below).
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
+            # copier update produced nothing beyond the repo_id backfill commit
+            # (not just a version-string match — e.g. this rules out an
+            # unrelated YAML quote-style drift landing under this title).
             echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
           else
             echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
@@ -218,12 +227,13 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
           # Nothing to commit when the only change this run is the repo_id
           # backfill (already committed in its own step above) and copier
           # update itself produced no further diff.
-          if ! git diff --cached --quiet; then
+          if [ "${HAS_EXTRA_CHANGES}" = "true" ]; then
             git -c 'user.name=fohte-bot[bot]' \
                 -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
                 commit -m "${COMMIT_MESSAGE}"
@@ -250,11 +260,12 @@ jobs:
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
             summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
           else
             summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -52,6 +52,7 @@ jobs:
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
       - name: Backfill repo_id in copier answers
+        id: backfill
         env:
           REPO_ID: ${{ github.repository_id }}
         run: |
@@ -64,8 +65,16 @@ jobs:
           # a no-op here and picked up on a later run once copier adds it.
           if grep -q "^repo_id: ''$" .copier-answers.yml; then
             sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            # `copier update` refuses to run against a dirty working tree, so
+            # commit immediately rather than leaving this as an uncommitted change.
+            git add .copier-answers.yml
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "chore: backfill repo_id in copier answers"
+            echo "backfilled=true" >> "$GITHUB_OUTPUT"
             echo "Backfilled repo_id=${REPO_ID}"
           else
+            echo "backfilled=false" >> "$GITHUB_OUTPUT"
             echo "repo_id already set or key not present; skipping backfill" >&2
           fi
 
@@ -85,15 +94,18 @@ jobs:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           # Only set when workflow_dispatch explicitly pins a target version.
           MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          if [ "${CHANGED}" != "true" ]; then
+          if [ "${CHANGED}" != "true" ] && [ "${BACKFILLED}" != "true" ]; then
             echo "value=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          elif [ "${BACKFILLED}" != "true" ] && [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
             # copier-update-action's `changed` output reflects any diff (e.g. YAML
             # quote-style drift), not whether the template version itself moved.
             # Skip the no-op case for scheduled/latest-release runs; an explicit
             # manual target-version means the caller wants to re-apply regardless.
+            # A repo_id backfill is never skipped this way: this PR is the only
+            # path that lands it on the default branch.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -188,9 +200,18 @@ jobs:
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # Template version didn't move, so the only reason should-update
+            # is true is the repo_id backfill; don't claim a version bump
+            # that didn't happen (a manual re-apply of the same version, with
+            # nothing backfilled, still falls through to the branch below).
+            echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit and push changes
         if: steps.should-update.outputs.value == 'true'
@@ -199,10 +220,15 @@ jobs:
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
         run: |
           set -euo pipefail
-          git -c 'user.name=fohte-bot[bot]' \
-              -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
-              commit -m "${COMMIT_MESSAGE}"
-          # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
+          # Nothing to commit when the only change this run is the repo_id
+          # backfill (already committed in its own step above) and copier
+          # update itself produced no further diff.
+          if ! git diff --cached --quiet; then
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "${COMMIT_MESSAGE}"
+          fi
+          # Force-push so the remote branch always equals "default branch HEAD + this run's commits".
           # Without this, commits on the branch (fixed per template repo, reused across
           # versions) accumulate and the PR drifts from the default branch.
           #
@@ -223,11 +249,16 @@ jobs:
           HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
+          else
+            summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          fi
 
           needs_review=false
           body="${summary}"

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -192,6 +192,15 @@ jobs:
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
           git add -A
+          # Whether copier update produced anything beyond the repo_id backfill
+          # commit (already committed in the `backfill` step, if any). Computed
+          # once here and reused below so the title/commit/PR-body steps agree
+          # on whether this run is backfill-only.
+          if git diff --cached --quiet; then
+            echo "has-extra-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-extra-changes=true" >> "$GITHUB_OUTPUT"
+          fi
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
@@ -201,13 +210,13 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
-            # Template version didn't move, so the only reason should-update
-            # is true is the repo_id backfill; don't claim a version bump
-            # that didn't happen (a manual re-apply of the same version, with
-            # nothing backfilled, still falls through to the branch below).
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
+            # copier update produced nothing beyond the repo_id backfill commit
+            # (not just a version-string match — e.g. this rules out an
+            # unrelated YAML quote-style drift landing under this title).
             echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
           else
             echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
@@ -218,12 +227,13 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
           # Nothing to commit when the only change this run is the repo_id
           # backfill (already committed in its own step above) and copier
           # update itself produced no further diff.
-          if ! git diff --cached --quiet; then
+          if [ "${HAS_EXTRA_CHANGES}" = "true" ]; then
             git -c 'user.name=fohte-bot[bot]' \
                 -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
                 commit -m "${COMMIT_MESSAGE}"
@@ -250,11 +260,12 @@ jobs:
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
             summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
           else
             summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -52,6 +52,7 @@ jobs:
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
       - name: Backfill repo_id in copier answers
+        id: backfill
         env:
           REPO_ID: ${{ github.repository_id }}
         run: |
@@ -64,8 +65,16 @@ jobs:
           # a no-op here and picked up on a later run once copier adds it.
           if grep -q "^repo_id: ''$" .copier-answers.yml; then
             sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            # `copier update` refuses to run against a dirty working tree, so
+            # commit immediately rather than leaving this as an uncommitted change.
+            git add .copier-answers.yml
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "chore: backfill repo_id in copier answers"
+            echo "backfilled=true" >> "$GITHUB_OUTPUT"
             echo "Backfilled repo_id=${REPO_ID}"
           else
+            echo "backfilled=false" >> "$GITHUB_OUTPUT"
             echo "repo_id already set or key not present; skipping backfill" >&2
           fi
 
@@ -85,15 +94,18 @@ jobs:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           # Only set when workflow_dispatch explicitly pins a target version.
           MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          if [ "${CHANGED}" != "true" ]; then
+          if [ "${CHANGED}" != "true" ] && [ "${BACKFILLED}" != "true" ]; then
             echo "value=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          elif [ "${BACKFILLED}" != "true" ] && [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
             # copier-update-action's `changed` output reflects any diff (e.g. YAML
             # quote-style drift), not whether the template version itself moved.
             # Skip the no-op case for scheduled/latest-release runs; an explicit
             # manual target-version means the caller wants to re-apply regardless.
+            # A repo_id backfill is never skipped this way: this PR is the only
+            # path that lands it on the default branch.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -188,9 +200,18 @@ jobs:
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # Template version didn't move, so the only reason should-update
+            # is true is the repo_id backfill; don't claim a version bump
+            # that didn't happen (a manual re-apply of the same version, with
+            # nothing backfilled, still falls through to the branch below).
+            echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit and push changes
         if: steps.should-update.outputs.value == 'true'
@@ -199,10 +220,15 @@ jobs:
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
         run: |
           set -euo pipefail
-          git -c 'user.name=fohte-bot[bot]' \
-              -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
-              commit -m "${COMMIT_MESSAGE}"
-          # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
+          # Nothing to commit when the only change this run is the repo_id
+          # backfill (already committed in its own step above) and copier
+          # update itself produced no further diff.
+          if ! git diff --cached --quiet; then
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "${COMMIT_MESSAGE}"
+          fi
+          # Force-push so the remote branch always equals "default branch HEAD + this run's commits".
           # Without this, commits on the branch (fixed per template repo, reused across
           # versions) accumulate and the PR drifts from the default branch.
           #
@@ -223,11 +249,16 @@ jobs:
           HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
+          else
+            summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          fi
 
           needs_review=false
           body="${summary}"

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -192,6 +192,15 @@ jobs:
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
           git add -A
+          # Whether copier update produced anything beyond the repo_id backfill
+          # commit (already committed in the `backfill` step, if any). Computed
+          # once here and reused below so the title/commit/PR-body steps agree
+          # on whether this run is backfill-only.
+          if git diff --cached --quiet; then
+            echo "has-extra-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-extra-changes=true" >> "$GITHUB_OUTPUT"
+          fi
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
@@ -201,13 +210,13 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
-            # Template version didn't move, so the only reason should-update
-            # is true is the repo_id backfill; don't claim a version bump
-            # that didn't happen (a manual re-apply of the same version, with
-            # nothing backfilled, still falls through to the branch below).
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
+            # copier update produced nothing beyond the repo_id backfill commit
+            # (not just a version-string match — e.g. this rules out an
+            # unrelated YAML quote-style drift landing under this title).
             echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
           else
             echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
@@ -218,12 +227,13 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
           # Nothing to commit when the only change this run is the repo_id
           # backfill (already committed in its own step above) and copier
           # update itself produced no further diff.
-          if ! git diff --cached --quiet; then
+          if [ "${HAS_EXTRA_CHANGES}" = "true" ]; then
             git -c 'user.name=fohte-bot[bot]' \
                 -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
                 commit -m "${COMMIT_MESSAGE}"
@@ -250,11 +260,12 @@ jobs:
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
             summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
           else
             summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -52,6 +52,7 @@ jobs:
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
       - name: Backfill repo_id in copier answers
+        id: backfill
         env:
           REPO_ID: ${{ github.repository_id }}
         run: |
@@ -64,8 +65,16 @@ jobs:
           # a no-op here and picked up on a later run once copier adds it.
           if grep -q "^repo_id: ''$" .copier-answers.yml; then
             sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            # `copier update` refuses to run against a dirty working tree, so
+            # commit immediately rather than leaving this as an uncommitted change.
+            git add .copier-answers.yml
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "chore: backfill repo_id in copier answers"
+            echo "backfilled=true" >> "$GITHUB_OUTPUT"
             echo "Backfilled repo_id=${REPO_ID}"
           else
+            echo "backfilled=false" >> "$GITHUB_OUTPUT"
             echo "repo_id already set or key not present; skipping backfill" >&2
           fi
 
@@ -85,15 +94,18 @@ jobs:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           # Only set when workflow_dispatch explicitly pins a target version.
           MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          if [ "${CHANGED}" != "true" ]; then
+          if [ "${CHANGED}" != "true" ] && [ "${BACKFILLED}" != "true" ]; then
             echo "value=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          elif [ "${BACKFILLED}" != "true" ] && [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
             # copier-update-action's `changed` output reflects any diff (e.g. YAML
             # quote-style drift), not whether the template version itself moved.
             # Skip the no-op case for scheduled/latest-release runs; an explicit
             # manual target-version means the caller wants to re-apply regardless.
+            # A repo_id backfill is never skipped this way: this PR is the only
+            # path that lands it on the default branch.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -188,9 +200,18 @@ jobs:
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # Template version didn't move, so the only reason should-update
+            # is true is the repo_id backfill; don't claim a version bump
+            # that didn't happen (a manual re-apply of the same version, with
+            # nothing backfilled, still falls through to the branch below).
+            echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit and push changes
         if: steps.should-update.outputs.value == 'true'
@@ -199,10 +220,15 @@ jobs:
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
         run: |
           set -euo pipefail
-          git -c 'user.name=fohte-bot[bot]' \
-              -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
-              commit -m "${COMMIT_MESSAGE}"
-          # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
+          # Nothing to commit when the only change this run is the repo_id
+          # backfill (already committed in its own step above) and copier
+          # update itself produced no further diff.
+          if ! git diff --cached --quiet; then
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "${COMMIT_MESSAGE}"
+          fi
+          # Force-push so the remote branch always equals "default branch HEAD + this run's commits".
           # Without this, commits on the branch (fixed per template repo, reused across
           # versions) accumulate and the PR drifts from the default branch.
           #
@@ -223,11 +249,16 @@ jobs:
           HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
+          else
+            summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          fi
 
           needs_review=false
           body="${summary}"

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -192,6 +192,15 @@ jobs:
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
           git add -A
+          # Whether copier update produced anything beyond the repo_id backfill
+          # commit (already committed in the `backfill` step, if any). Computed
+          # once here and reused below so the title/commit/PR-body steps agree
+          # on whether this run is backfill-only.
+          if git diff --cached --quiet; then
+            echo "has-extra-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-extra-changes=true" >> "$GITHUB_OUTPUT"
+          fi
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
@@ -201,13 +210,13 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
-            # Template version didn't move, so the only reason should-update
-            # is true is the repo_id backfill; don't claim a version bump
-            # that didn't happen (a manual re-apply of the same version, with
-            # nothing backfilled, still falls through to the branch below).
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
+            # copier update produced nothing beyond the repo_id backfill commit
+            # (not just a version-string match — e.g. this rules out an
+            # unrelated YAML quote-style drift landing under this title).
             echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
           else
             echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
@@ -218,12 +227,13 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
           # Nothing to commit when the only change this run is the repo_id
           # backfill (already committed in its own step above) and copier
           # update itself produced no further diff.
-          if ! git diff --cached --quiet; then
+          if [ "${HAS_EXTRA_CHANGES}" = "true" ]; then
             git -c 'user.name=fohte-bot[bot]' \
                 -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
                 commit -m "${COMMIT_MESSAGE}"
@@ -250,11 +260,12 @@ jobs:
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
             summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
           else
             summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -52,6 +52,7 @@ jobs:
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
       - name: Backfill repo_id in copier answers
+        id: backfill
         env:
           REPO_ID: ${{ github.repository_id }}
         run: |
@@ -64,8 +65,16 @@ jobs:
           # a no-op here and picked up on a later run once copier adds it.
           if grep -q "^repo_id: ''$" .copier-answers.yml; then
             sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            # `copier update` refuses to run against a dirty working tree, so
+            # commit immediately rather than leaving this as an uncommitted change.
+            git add .copier-answers.yml
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "chore: backfill repo_id in copier answers"
+            echo "backfilled=true" >> "$GITHUB_OUTPUT"
             echo "Backfilled repo_id=${REPO_ID}"
           else
+            echo "backfilled=false" >> "$GITHUB_OUTPUT"
             echo "repo_id already set or key not present; skipping backfill" >&2
           fi
 
@@ -85,15 +94,18 @@ jobs:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           # Only set when workflow_dispatch explicitly pins a target version.
           MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          if [ "${CHANGED}" != "true" ]; then
+          if [ "${CHANGED}" != "true" ] && [ "${BACKFILLED}" != "true" ]; then
             echo "value=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          elif [ "${BACKFILLED}" != "true" ] && [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
             # copier-update-action's `changed` output reflects any diff (e.g. YAML
             # quote-style drift), not whether the template version itself moved.
             # Skip the no-op case for scheduled/latest-release runs; an explicit
             # manual target-version means the caller wants to re-apply regardless.
+            # A repo_id backfill is never skipped this way: this PR is the only
+            # path that lands it on the default branch.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -188,9 +200,18 @@ jobs:
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # Template version didn't move, so the only reason should-update
+            # is true is the repo_id backfill; don't claim a version bump
+            # that didn't happen (a manual re-apply of the same version, with
+            # nothing backfilled, still falls through to the branch below).
+            echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit and push changes
         if: steps.should-update.outputs.value == 'true'
@@ -199,10 +220,15 @@ jobs:
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
         run: |
           set -euo pipefail
-          git -c 'user.name=fohte-bot[bot]' \
-              -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
-              commit -m "${COMMIT_MESSAGE}"
-          # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
+          # Nothing to commit when the only change this run is the repo_id
+          # backfill (already committed in its own step above) and copier
+          # update itself produced no further diff.
+          if ! git diff --cached --quiet; then
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "${COMMIT_MESSAGE}"
+          fi
+          # Force-push so the remote branch always equals "default branch HEAD + this run's commits".
           # Without this, commits on the branch (fixed per template repo, reused across
           # versions) accumulate and the PR drifts from the default branch.
           #
@@ -223,11 +249,16 @@ jobs:
           HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
+          else
+            summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          fi
 
           needs_review=false
           body="${summary}"

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -192,6 +192,15 @@ jobs:
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
           git add -A
+          # Whether copier update produced anything beyond the repo_id backfill
+          # commit (already committed in the `backfill` step, if any). Computed
+          # once here and reused below so the title/commit/PR-body steps agree
+          # on whether this run is backfill-only.
+          if git diff --cached --quiet; then
+            echo "has-extra-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-extra-changes=true" >> "$GITHUB_OUTPUT"
+          fi
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
@@ -201,13 +210,13 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
-            # Template version didn't move, so the only reason should-update
-            # is true is the repo_id backfill; don't claim a version bump
-            # that didn't happen (a manual re-apply of the same version, with
-            # nothing backfilled, still falls through to the branch below).
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
+            # copier update produced nothing beyond the repo_id backfill commit
+            # (not just a version-string match — e.g. this rules out an
+            # unrelated YAML quote-style drift landing under this title).
             echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
           else
             echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
@@ -218,12 +227,13 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
           # Nothing to commit when the only change this run is the repo_id
           # backfill (already committed in its own step above) and copier
           # update itself produced no further diff.
-          if ! git diff --cached --quiet; then
+          if [ "${HAS_EXTRA_CHANGES}" = "true" ]; then
             git -c 'user.name=fohte-bot[bot]' \
                 -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
                 commit -m "${COMMIT_MESSAGE}"
@@ -250,11 +260,12 @@ jobs:
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
             summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
           else
             summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -52,6 +52,7 @@ jobs:
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
       - name: Backfill repo_id in copier answers
+        id: backfill
         env:
           REPO_ID: ${{ github.repository_id }}
         run: |
@@ -64,8 +65,16 @@ jobs:
           # a no-op here and picked up on a later run once copier adds it.
           if grep -q "^repo_id: ''$" .copier-answers.yml; then
             sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            # `copier update` refuses to run against a dirty working tree, so
+            # commit immediately rather than leaving this as an uncommitted change.
+            git add .copier-answers.yml
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "chore: backfill repo_id in copier answers"
+            echo "backfilled=true" >> "$GITHUB_OUTPUT"
             echo "Backfilled repo_id=${REPO_ID}"
           else
+            echo "backfilled=false" >> "$GITHUB_OUTPUT"
             echo "repo_id already set or key not present; skipping backfill" >&2
           fi
 
@@ -85,15 +94,18 @@ jobs:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           # Only set when workflow_dispatch explicitly pins a target version.
           MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          if [ "${CHANGED}" != "true" ]; then
+          if [ "${CHANGED}" != "true" ] && [ "${BACKFILLED}" != "true" ]; then
             echo "value=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          elif [ "${BACKFILLED}" != "true" ] && [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
             # copier-update-action's `changed` output reflects any diff (e.g. YAML
             # quote-style drift), not whether the template version itself moved.
             # Skip the no-op case for scheduled/latest-release runs; an explicit
             # manual target-version means the caller wants to re-apply regardless.
+            # A repo_id backfill is never skipped this way: this PR is the only
+            # path that lands it on the default branch.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -188,9 +200,18 @@ jobs:
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # Template version didn't move, so the only reason should-update
+            # is true is the repo_id backfill; don't claim a version bump
+            # that didn't happen (a manual re-apply of the same version, with
+            # nothing backfilled, still falls through to the branch below).
+            echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit and push changes
         if: steps.should-update.outputs.value == 'true'
@@ -199,10 +220,15 @@ jobs:
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
         run: |
           set -euo pipefail
-          git -c 'user.name=fohte-bot[bot]' \
-              -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
-              commit -m "${COMMIT_MESSAGE}"
-          # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
+          # Nothing to commit when the only change this run is the repo_id
+          # backfill (already committed in its own step above) and copier
+          # update itself produced no further diff.
+          if ! git diff --cached --quiet; then
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "${COMMIT_MESSAGE}"
+          fi
+          # Force-push so the remote branch always equals "default branch HEAD + this run's commits".
           # Without this, commits on the branch (fixed per template repo, reused across
           # versions) accumulate and the PR drifts from the default branch.
           #
@@ -223,11 +249,16 @@ jobs:
           HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
+          else
+            summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          fi
 
           needs_review=false
           body="${summary}"

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -192,6 +192,15 @@ jobs:
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
           git add -A
+          # Whether copier update produced anything beyond the repo_id backfill
+          # commit (already committed in the `backfill` step, if any). Computed
+          # once here and reused below so the title/commit/PR-body steps agree
+          # on whether this run is backfill-only.
+          if git diff --cached --quiet; then
+            echo "has-extra-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-extra-changes=true" >> "$GITHUB_OUTPUT"
+          fi
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
@@ -201,13 +210,13 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
-            # Template version didn't move, so the only reason should-update
-            # is true is the repo_id backfill; don't claim a version bump
-            # that didn't happen (a manual re-apply of the same version, with
-            # nothing backfilled, still falls through to the branch below).
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
+            # copier update produced nothing beyond the repo_id backfill commit
+            # (not just a version-string match — e.g. this rules out an
+            # unrelated YAML quote-style drift landing under this title).
             echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
           else
             echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
@@ -218,12 +227,13 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
           # Nothing to commit when the only change this run is the repo_id
           # backfill (already committed in its own step above) and copier
           # update itself produced no further diff.
-          if ! git diff --cached --quiet; then
+          if [ "${HAS_EXTRA_CHANGES}" = "true" ]; then
             git -c 'user.name=fohte-bot[bot]' \
                 -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
                 commit -m "${COMMIT_MESSAGE}"
@@ -250,11 +260,12 @@ jobs:
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
             summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
           else
             summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -52,6 +52,7 @@ jobs:
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
       - name: Backfill repo_id in copier answers
+        id: backfill
         env:
           REPO_ID: ${{ github.repository_id }}
         run: |
@@ -64,8 +65,16 @@ jobs:
           # a no-op here and picked up on a later run once copier adds it.
           if grep -q "^repo_id: ''$" .copier-answers.yml; then
             sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            # `copier update` refuses to run against a dirty working tree, so
+            # commit immediately rather than leaving this as an uncommitted change.
+            git add .copier-answers.yml
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "chore: backfill repo_id in copier answers"
+            echo "backfilled=true" >> "$GITHUB_OUTPUT"
             echo "Backfilled repo_id=${REPO_ID}"
           else
+            echo "backfilled=false" >> "$GITHUB_OUTPUT"
             echo "repo_id already set or key not present; skipping backfill" >&2
           fi
 
@@ -85,15 +94,18 @@ jobs:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           # Only set when workflow_dispatch explicitly pins a target version.
           MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          if [ "${CHANGED}" != "true" ]; then
+          if [ "${CHANGED}" != "true" ] && [ "${BACKFILLED}" != "true" ]; then
             echo "value=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          elif [ "${BACKFILLED}" != "true" ] && [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
             # copier-update-action's `changed` output reflects any diff (e.g. YAML
             # quote-style drift), not whether the template version itself moved.
             # Skip the no-op case for scheduled/latest-release runs; an explicit
             # manual target-version means the caller wants to re-apply regardless.
+            # A repo_id backfill is never skipped this way: this PR is the only
+            # path that lands it on the default branch.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -188,9 +200,18 @@ jobs:
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # Template version didn't move, so the only reason should-update
+            # is true is the repo_id backfill; don't claim a version bump
+            # that didn't happen (a manual re-apply of the same version, with
+            # nothing backfilled, still falls through to the branch below).
+            echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit and push changes
         if: steps.should-update.outputs.value == 'true'
@@ -199,10 +220,15 @@ jobs:
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
         run: |
           set -euo pipefail
-          git -c 'user.name=fohte-bot[bot]' \
-              -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
-              commit -m "${COMMIT_MESSAGE}"
-          # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
+          # Nothing to commit when the only change this run is the repo_id
+          # backfill (already committed in its own step above) and copier
+          # update itself produced no further diff.
+          if ! git diff --cached --quiet; then
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "${COMMIT_MESSAGE}"
+          fi
+          # Force-push so the remote branch always equals "default branch HEAD + this run's commits".
           # Without this, commits on the branch (fixed per template repo, reused across
           # versions) accumulate and the PR drifts from the default branch.
           #
@@ -223,11 +249,16 @@ jobs:
           HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
+          else
+            summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          fi
 
           needs_review=false
           body="${summary}"

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -192,6 +192,15 @@ jobs:
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
           git add -A
+          # Whether copier update produced anything beyond the repo_id backfill
+          # commit (already committed in the `backfill` step, if any). Computed
+          # once here and reused below so the title/commit/PR-body steps agree
+          # on whether this run is backfill-only.
+          if git diff --cached --quiet; then
+            echo "has-extra-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-extra-changes=true" >> "$GITHUB_OUTPUT"
+          fi
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
@@ -201,13 +210,13 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
-            # Template version didn't move, so the only reason should-update
-            # is true is the repo_id backfill; don't claim a version bump
-            # that didn't happen (a manual re-apply of the same version, with
-            # nothing backfilled, still falls through to the branch below).
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
+            # copier update produced nothing beyond the repo_id backfill commit
+            # (not just a version-string match — e.g. this rules out an
+            # unrelated YAML quote-style drift landing under this title).
             echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
           else
             echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
@@ -218,12 +227,13 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
           # Nothing to commit when the only change this run is the repo_id
           # backfill (already committed in its own step above) and copier
           # update itself produced no further diff.
-          if ! git diff --cached --quiet; then
+          if [ "${HAS_EXTRA_CHANGES}" = "true" ]; then
             git -c 'user.name=fohte-bot[bot]' \
                 -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
                 commit -m "${COMMIT_MESSAGE}"
@@ -250,11 +260,12 @@ jobs:
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
             summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
           else
             summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -52,6 +52,7 @@ jobs:
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
       - name: Backfill repo_id in copier answers
+        id: backfill
         env:
           REPO_ID: ${{ github.repository_id }}
         run: |
@@ -64,8 +65,16 @@ jobs:
           # a no-op here and picked up on a later run once copier adds it.
           if grep -q "^repo_id: ''$" .copier-answers.yml; then
             sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            # `copier update` refuses to run against a dirty working tree, so
+            # commit immediately rather than leaving this as an uncommitted change.
+            git add .copier-answers.yml
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "chore: backfill repo_id in copier answers"
+            echo "backfilled=true" >> "$GITHUB_OUTPUT"
             echo "Backfilled repo_id=${REPO_ID}"
           else
+            echo "backfilled=false" >> "$GITHUB_OUTPUT"
             echo "repo_id already set or key not present; skipping backfill" >&2
           fi
 
@@ -85,15 +94,18 @@ jobs:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           # Only set when workflow_dispatch explicitly pins a target version.
           MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          if [ "${CHANGED}" != "true" ]; then
+          if [ "${CHANGED}" != "true" ] && [ "${BACKFILLED}" != "true" ]; then
             echo "value=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          elif [ "${BACKFILLED}" != "true" ] && [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
             # copier-update-action's `changed` output reflects any diff (e.g. YAML
             # quote-style drift), not whether the template version itself moved.
             # Skip the no-op case for scheduled/latest-release runs; an explicit
             # manual target-version means the caller wants to re-apply regardless.
+            # A repo_id backfill is never skipped this way: this PR is the only
+            # path that lands it on the default branch.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -188,9 +200,18 @@ jobs:
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # Template version didn't move, so the only reason should-update
+            # is true is the repo_id backfill; don't claim a version bump
+            # that didn't happen (a manual re-apply of the same version, with
+            # nothing backfilled, still falls through to the branch below).
+            echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit and push changes
         if: steps.should-update.outputs.value == 'true'
@@ -199,10 +220,15 @@ jobs:
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
         run: |
           set -euo pipefail
-          git -c 'user.name=fohte-bot[bot]' \
-              -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
-              commit -m "${COMMIT_MESSAGE}"
-          # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
+          # Nothing to commit when the only change this run is the repo_id
+          # backfill (already committed in its own step above) and copier
+          # update itself produced no further diff.
+          if ! git diff --cached --quiet; then
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "${COMMIT_MESSAGE}"
+          fi
+          # Force-push so the remote branch always equals "default branch HEAD + this run's commits".
           # Without this, commits on the branch (fixed per template repo, reused across
           # versions) accumulate and the PR drifts from the default branch.
           #
@@ -223,11 +249,16 @@ jobs:
           HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
+          else
+            summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          fi
 
           needs_review=false
           body="${summary}"

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -192,6 +192,15 @@ jobs:
           # copier-update-action leaves unmerged entries in the index when
           # conflicts remain; stage everything so `git checkout -B` succeeds.
           git add -A
+          # Whether copier update produced anything beyond the repo_id backfill
+          # commit (already committed in the `backfill` step, if any). Computed
+          # once here and reused below so the title/commit/PR-body steps agree
+          # on whether this run is backfill-only.
+          if git diff --cached --quiet; then
+            echo "has-extra-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-extra-changes=true" >> "$GITHUB_OUTPUT"
+          fi
           git checkout -B "${branch}"
 
       - name: Compose commit and PR title
@@ -201,13 +210,13 @@ jobs:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
-            # Template version didn't move, so the only reason should-update
-            # is true is the repo_id backfill; don't claim a version bump
-            # that didn't happen (a manual re-apply of the same version, with
-            # nothing backfilled, still falls through to the branch below).
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
+            # copier update produced nothing beyond the repo_id backfill commit
+            # (not just a version-string match — e.g. this rules out an
+            # unrelated YAML quote-style drift landing under this title).
             echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
           else
             echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
@@ -218,12 +227,13 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
           # Nothing to commit when the only change this run is the repo_id
           # backfill (already committed in its own step above) and copier
           # update itself produced no further diff.
-          if ! git diff --cached --quiet; then
+          if [ "${HAS_EXTRA_CHANGES}" = "true" ]; then
             git -c 'user.name=fohte-bot[bot]' \
                 -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
                 commit -m "${COMMIT_MESSAGE}"
@@ -250,11 +260,12 @@ jobs:
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
           BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
+          HAS_EXTRA_CHANGES: ${{ steps.branch.outputs.has-extra-changes }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          if [ "${BACKFILLED}" = "true" ] && [ "${HAS_EXTRA_CHANGES}" != "true" ]; then
             summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
           else
             summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -52,6 +52,7 @@ jobs:
           echo "version=${from_version}" >> "$GITHUB_OUTPUT"
 
       - name: Backfill repo_id in copier answers
+        id: backfill
         env:
           REPO_ID: ${{ github.repository_id }}
         run: |
@@ -64,8 +65,16 @@ jobs:
           # a no-op here and picked up on a later run once copier adds it.
           if grep -q "^repo_id: ''$" .copier-answers.yml; then
             sed -i "s/^repo_id: ''$/repo_id: '${REPO_ID}'/" .copier-answers.yml
+            # `copier update` refuses to run against a dirty working tree, so
+            # commit immediately rather than leaving this as an uncommitted change.
+            git add .copier-answers.yml
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "chore: backfill repo_id in copier answers"
+            echo "backfilled=true" >> "$GITHUB_OUTPUT"
             echo "Backfilled repo_id=${REPO_ID}"
           else
+            echo "backfilled=false" >> "$GITHUB_OUTPUT"
             echo "repo_id already set or key not present; skipping backfill" >&2
           fi
 
@@ -85,15 +94,18 @@ jobs:
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
           # Only set when workflow_dispatch explicitly pins a target version.
           MANUAL_TARGET_VERSION: ${{ github.event.inputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          if [ "${CHANGED}" != "true" ]; then
+          if [ "${CHANGED}" != "true" ] && [ "${BACKFILLED}" != "true" ]; then
             echo "value=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+          elif [ "${BACKFILLED}" != "true" ] && [ -z "${MANUAL_TARGET_VERSION}" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
             # copier-update-action's `changed` output reflects any diff (e.g. YAML
             # quote-style drift), not whether the template version itself moved.
             # Skip the no-op case for scheduled/latest-release runs; an explicit
             # manual target-version means the caller wants to re-apply regardless.
+            # A repo_id backfill is never skipped this way: this PR is the only
+            # path that lands it on the default branch.
             echo "Template version unchanged (${FROM_VERSION}); skipping." >&2
             echo "value=false" >> "$GITHUB_OUTPUT"
           else
@@ -188,9 +200,18 @@ jobs:
         env:
           FROM_VERSION: ${{ steps.current-version.outputs.version }}
           TARGET_VERSION: ${{ steps.copier-update.outputs.target-version }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
-          echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            # Template version didn't move, so the only reason should-update
+            # is true is the repo_id backfill; don't claim a version bump
+            # that didn't happen (a manual re-apply of the same version, with
+            # nothing backfilled, still falls through to the branch below).
+            echo "value=chore: backfill repo_id in copier answers" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=chore: update ${TEMPLATE_REPO} from ${FROM_VERSION} to ${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit and push changes
         if: steps.should-update.outputs.value == 'true'
@@ -199,10 +220,15 @@ jobs:
           COMMIT_MESSAGE: ${{ steps.title.outputs.value }}
         run: |
           set -euo pipefail
-          git -c 'user.name=fohte-bot[bot]' \
-              -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
-              commit -m "${COMMIT_MESSAGE}"
-          # Force-push so the remote branch always equals "default branch HEAD + 1 copier-update commit".
+          # Nothing to commit when the only change this run is the repo_id
+          # backfill (already committed in its own step above) and copier
+          # update itself produced no further diff.
+          if ! git diff --cached --quiet; then
+            git -c 'user.name=fohte-bot[bot]' \
+                -c 'user.email=139195068+fohte-bot[bot]@users.noreply.github.com' \
+                commit -m "${COMMIT_MESSAGE}"
+          fi
+          # Force-push so the remote branch always equals "default branch HEAD + this run's commits".
           # Without this, commits on the branch (fixed per template repo, reused across
           # versions) accumulate and the PR drifts from the default branch.
           #
@@ -223,11 +249,16 @@ jobs:
           HAS_LOCKFILES: ${{ hashFiles('**/pnpm-lock.yaml', '**/Cargo.lock') != '' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+          BACKFILLED: ${{ steps.backfill.outputs.backfilled }}
         run: |
           set -euo pipefail
 
           release_url="https://github.com/${TEMPLATE_REPO}/releases/tag/${TARGET_VERSION}"
-          summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          if [ "${BACKFILLED}" = "true" ] && [ "${FROM_VERSION}" = "${TARGET_VERSION}" ]; then
+            summary="Backfill \`repo_id\` in \`.copier-answers.yml\` (template version unchanged at [\`${TARGET_VERSION}\`](${release_url}))."
+          else
+            summary="Update \`${TEMPLATE_REPO}\` from \`${FROM_VERSION}\` to [\`${TARGET_VERSION}\`](${release_url})."
+          fi
 
           needs_review=false
           body="${summary}"


### PR DESCRIPTION
## Purpose

- Template update workflows fail on repositories with `repo_id: ''`, preventing updates from being delivered
  - `copier update` fails with `Destination repository is dirty; cannot continue.`

## Approach

- Commit the `repo_id` backfill in advance to ensure template updates and backfill PR creation complete successfully
  - Uncommitted `repo_id` changes previously halted `copier update`, and PR creation was skipped when the template version remained unchanged
