### PR TITLE
chore(scripts): increase search result limit and add truncation warning

### DIFF
--- a/scripts/list-boilerplate-usage
+++ b/scripts/list-boilerplate-usage
@@ -63,10 +63,19 @@ done <<< "$update_prs"
 # tokenizer and matches nothing, so strip it and use --filename instead of embedding it in
 # the query. --limit is raised above the default of 30 since raw (pre-path-filter) hits already
 # exceed that across fohte org repos.
+search_limit=100
+raw_results=$(gh search code --owner "$OWNER" --filename "${FILE_PATH#.}" --limit "$search_limit" --json repository,path)
+
+# Warn if results were truncated instead of silently under-reporting repos to
+# trigger-boilerplate-update-prs / auto-merge-boilerplate-prs downstream.
+raw_count=$(echo "$raw_results" | jq 'length')
+if [[ "$raw_count" -ge "$search_limit" ]]; then
+  echo "warning: gh search code returned $raw_count results, hitting --limit $search_limit; results may be truncated" >&2
+fi
+
 repos=$(
-  gh search code --owner "$OWNER" --filename "${FILE_PATH#.}" --limit 100 \
-    --json repository,path \
-    --jq ".[] | select(.path == \"${FILE_PATH}\") | .repository.nameWithOwner" |
+  echo "$raw_results" |
+    jq -r ".[] | select(.path == \"${FILE_PATH}\") | .repository.nameWithOwner" |
     sort -u
 )
 

--- a/scripts/list-boilerplate-usage
+++ b/scripts/list-boilerplate-usage
@@ -59,12 +59,12 @@ while IFS= read -r pr_json; do
 done <<< "$update_prs"
 
 # Search for repos containing .copier-answers.yml (root only, exclude templates/fixtures).
-# The `filename:` search qualifier's leading dot is dropped by GitHub's (legacy) code search
-# tokenizer and matches nothing, so strip it and use --filename instead of embedding it in
-# the query. --limit is raised above the default of 30 since raw (pre-path-filter) hits already
-# exceed that across fohte org repos.
+# --limit is raised above the default of 30 since raw (pre-path-filter) hits already exceed
+# that across fohte org repos. GitHub's code search index can also miss repos independently
+# of --limit (a known indexing gap this script cannot correct for), so a raw count under the
+# limit is not a completeness guarantee -- only a saturated limit is something we can detect.
 search_limit=100
-raw_results=$(gh search code --owner "$OWNER" --filename "${FILE_PATH#.}" --limit "$search_limit" --json repository,path)
+raw_results=$(gh search code --owner "$OWNER" "filename:${FILE_PATH}" --limit "$search_limit" --json repository,path)
 
 # Warn if results were truncated instead of silently under-reporting repos to
 # trigger-boilerplate-update-prs / auto-merge-boilerplate-prs downstream.

--- a/scripts/list-boilerplate-usage
+++ b/scripts/list-boilerplate-usage
@@ -58,9 +58,13 @@ while IFS= read -r pr_json; do
   update_pr_map["$repo_name"]="$pr_json"
 done <<< "$update_prs"
 
-# Search for repos containing .copier-answers.yml (root only, exclude templates/fixtures)
+# Search for repos containing .copier-answers.yml (root only, exclude templates/fixtures).
+# The `filename:` search qualifier's leading dot is dropped by GitHub's (legacy) code search
+# tokenizer and matches nothing, so strip it and use --filename instead of embedding it in
+# the query. --limit is raised above the default of 30 since raw (pre-path-filter) hits already
+# exceed that across fohte org repos.
 repos=$(
-  gh search code --owner "$OWNER" "filename:${FILE_PATH}" \
+  gh search code --owner "$OWNER" --filename "${FILE_PATH#.}" --limit 100 \
     --json repository,path \
     --jq ".[] | select(.path == \"${FILE_PATH}\") | .repository.nameWithOwner" |
     sort -u

--- a/scripts/list-boilerplate-usage
+++ b/scripts/list-boilerplate-usage
@@ -59,10 +59,7 @@ while IFS= read -r pr_json; do
 done <<< "$update_prs"
 
 # Search for repos containing .copier-answers.yml (root only, exclude templates/fixtures).
-# --limit is raised above the default of 30 since raw (pre-path-filter) hits already exceed
-# that across fohte org repos. GitHub's code search index can also miss repos independently
-# of --limit (a known indexing gap this script cannot correct for), so a raw count under the
-# limit is not a completeness guarantee -- only a saturated limit is something we can detect.
+# --limit is raised above the default of 30 since raw (pre-path-filter) hits already exceed it.
 search_limit=100
 raw_results=$(gh search code --owner "$OWNER" "filename:${FILE_PATH}" --limit "$search_limit" --json repository,path)
 


### PR DESCRIPTION
## Purpose

- `scripts/list-boilerplate-usage` fails to detect repositories using `generic-boilerplate`, halting the template update workflow

## Approach

- Increase the code search result limit and add a truncation warning to detect missing results
  - The default search limit (30 items) truncated results before filtering by path
