### PR TITLE
chore: serve octo-sts trust policies from this repository

### DIFF
--- a/.github/chainguard/generic-boilerplate-boilerplate-update.sts.yaml
+++ b/.github/chainguard/generic-boilerplate-boilerplate-update.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/generic-boilerplate@996201414:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/generic-boilerplate/\.github/workflows/boilerplate-update\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write
+  workflows: write

--- a/.github/chainguard/generic-boilerplate-bootstrap.sts.yaml
+++ b/.github/chainguard/generic-boilerplate-bootstrap.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/generic-boilerplate@996201414:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/generic-boilerplate/\.github/workflows/bootstrap\.yml@[^@]+$
+permissions:
+  contents: write

--- a/.github/chainguard/generic-boilerplate-release-please.sts.yaml
+++ b/.github/chainguard/generic-boilerplate-release-please.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/generic-boilerplate@996201414:ref:refs/heads/(main|master)$
+claim_pattern:
+  job_workflow_ref: ^fohte/generic-boilerplate/\.github/workflows/release-please\.yml@[^@]+$
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/chainguard/generic-boilerplate.sts.yaml
+++ b/.github/chainguard/generic-boilerplate.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: ^repo:fohte@11088009/generic-boilerplate@996201414:ref:refs/heads/.+$
+claim_pattern:
+  job_workflow_ref: ^fohte/generic-boilerplate/\.github/workflows/test\.yml@[^@]+$
+permissions:
+  contents: write


### PR DESCRIPTION
## Purpose

- octo-sts trust policies for this repository live in the public `fohte/.github`, where anyone can read them
- Serving them from the repository they grant access to keeps them scoped to that repository

## Approach

- Add the repo-scoped policies under `.github/chainguard/`
    - The contents are what the generic-boilerplate template renders for this repository, so a later template change to them still applies cleanly
- Leave the workflows on `scope: fohte` for now
    - octo-sts reads a repo-scoped policy from the default branch, so the switch has to wait until these files are merged