### PR TITLE
fix(template): exclude .copier-answers.yml from prettier

### DIFF
--- a/generated/base-public/.prettierignore
+++ b/generated/base-public/.prettierignore
@@ -1,2 +1,6 @@
 # Auto-generated files
 CHANGELOG.md
+
+# Copier rewraps this to a width prettier doesn't agree with, so the two
+# fight over its formatting on every `copier update`.
+.copier-answers.yml

--- a/generated/base-release/.prettierignore
+++ b/generated/base-release/.prettierignore
@@ -1,2 +1,6 @@
 # Auto-generated files
 CHANGELOG.md
+
+# Copier rewraps this to a width prettier doesn't agree with, so the two
+# fight over its formatting on every `copier update`.
+.copier-answers.yml

--- a/generated/base/.prettierignore
+++ b/generated/base/.prettierignore
@@ -1,2 +1,6 @@
 # Auto-generated files
 CHANGELOG.md
+
+# Copier rewraps this to a width prettier doesn't agree with, so the two
+# fight over its formatting on every `copier update`.
+.copier-answers.yml

--- a/generated/monorepo-node-workspace/.prettierignore
+++ b/generated/monorepo-node-workspace/.prettierignore
@@ -1,6 +1,10 @@
 # Auto-generated files
 CHANGELOG.md
 
+# Copier rewraps this to a width prettier doesn't agree with, so the two
+# fight over its formatting on every `copier update`.
+.copier-answers.yml
+
 # Lock files
 pnpm-lock.yaml
 

--- a/generated/monorepo/.prettierignore
+++ b/generated/monorepo/.prettierignore
@@ -1,6 +1,10 @@
 # Auto-generated files
 CHANGELOG.md
 
+# Copier rewraps this to a width prettier doesn't agree with, so the two
+# fight over its formatting on every `copier update`.
+.copier-answers.yml
+
 # Lock files
 pnpm-lock.yaml
 

--- a/generated/node/.prettierignore
+++ b/generated/node/.prettierignore
@@ -1,5 +1,9 @@
 # Auto-generated files
 CHANGELOG.md
 
+# Copier rewraps this to a width prettier doesn't agree with, so the two
+# fight over its formatting on every `copier update`.
+.copier-answers.yml
+
 # Lock files
 pnpm-lock.yaml

--- a/generated/rust-release/.prettierignore
+++ b/generated/rust-release/.prettierignore
@@ -1,2 +1,6 @@
 # Auto-generated files
 CHANGELOG.md
+
+# Copier rewraps this to a width prettier doesn't agree with, so the two
+# fight over its formatting on every `copier update`.
+.copier-answers.yml

--- a/generated/rust-with-node-subpackage/.prettierignore
+++ b/generated/rust-with-node-subpackage/.prettierignore
@@ -1,5 +1,9 @@
 # Auto-generated files
 CHANGELOG.md
 
+# Copier rewraps this to a width prettier doesn't agree with, so the two
+# fight over its formatting on every `copier update`.
+.copier-answers.yml
+
 # Lock files
 pnpm-lock.yaml

--- a/generated/rust/.prettierignore
+++ b/generated/rust/.prettierignore
@@ -1,2 +1,6 @@
 # Auto-generated files
 CHANGELOG.md
+
+# Copier rewraps this to a width prettier doesn't agree with, so the two
+# fight over its formatting on every `copier update`.
+.copier-answers.yml

--- a/template/.prettierignore.jinja
+++ b/template/.prettierignore.jinja
@@ -1,5 +1,9 @@
 # Auto-generated files
 CHANGELOG.md
+
+# Copier rewraps this to a width prettier doesn't agree with, so the two
+# fight over its formatting on every `copier update`.
+.copier-answers.yml
 {% if has_node %}
 # Lock files
 pnpm-lock.yaml


### PR DESCRIPTION
## Purpose

- Template updates introduce unrelated diffs in `.copier-answers.yml` to PRs

## Approach

- Exclude `.copier-answers.yml` from prettier formatting
