### PR TITLE
fix(template): switch octo-sts reference to individual repositories

### DIFF
--- a/generated/base-public/.github/workflows/boilerplate-update.yml
+++ b/generated/base-public/.github/workflows/boilerplate-update.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-boilerplate-update
           domain: octo-sts.fohte.net
 

--- a/generated/base-public/.github/workflows/test.yml
+++ b/generated/base-public/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}
           domain: octo-sts.fohte.net
 

--- a/generated/base-release/.github/workflows/boilerplate-update.yml
+++ b/generated/base-release/.github/workflows/boilerplate-update.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-boilerplate-update
           domain: octo-sts.fohte.net
 

--- a/generated/base-release/.github/workflows/release-please.yml
+++ b/generated/base-release/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-release-please
           domain: octo-sts.fohte.net
 

--- a/generated/base-release/.github/workflows/test.yml
+++ b/generated/base-release/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}
           domain: octo-sts.fohte.net
 

--- a/generated/base/.github/workflows/boilerplate-update.yml
+++ b/generated/base/.github/workflows/boilerplate-update.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-boilerplate-update
           domain: octo-sts.fohte.net
 

--- a/generated/base/.github/workflows/test.yml
+++ b/generated/base/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}
           domain: octo-sts.fohte.net
 

--- a/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/boilerplate-update.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-boilerplate-update
           domain: octo-sts.fohte.net
 

--- a/generated/monorepo-node-workspace/.github/workflows/bootstrap.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/bootstrap.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-bootstrap
           domain: octo-sts.fohte.net
 

--- a/generated/monorepo-node-workspace/.github/workflows/test.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}
           domain: octo-sts.fohte.net
 

--- a/generated/monorepo/.github/workflows/boilerplate-update.yml
+++ b/generated/monorepo/.github/workflows/boilerplate-update.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-boilerplate-update
           domain: octo-sts.fohte.net
 

--- a/generated/monorepo/.github/workflows/bootstrap.yml
+++ b/generated/monorepo/.github/workflows/bootstrap.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-bootstrap
           domain: octo-sts.fohte.net
 

--- a/generated/monorepo/.github/workflows/test.yml
+++ b/generated/monorepo/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}
           domain: octo-sts.fohte.net
 

--- a/generated/node/.github/workflows/boilerplate-update.yml
+++ b/generated/node/.github/workflows/boilerplate-update.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-boilerplate-update
           domain: octo-sts.fohte.net
 

--- a/generated/node/.github/workflows/bootstrap.yml
+++ b/generated/node/.github/workflows/bootstrap.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-bootstrap
           domain: octo-sts.fohte.net
 

--- a/generated/node/.github/workflows/test.yml
+++ b/generated/node/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}
           domain: octo-sts.fohte.net
 

--- a/generated/rust-release/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-release/.github/workflows/boilerplate-update.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-boilerplate-update
           domain: octo-sts.fohte.net
 

--- a/generated/rust-release/.github/workflows/bootstrap.yml
+++ b/generated/rust-release/.github/workflows/bootstrap.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-bootstrap
           domain: octo-sts.fohte.net
 

--- a/generated/rust-release/.github/workflows/release-please.yml
+++ b/generated/rust-release/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-release-please
           domain: octo-sts.fohte.net
 

--- a/generated/rust-release/.github/workflows/test.yml
+++ b/generated/rust-release/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}
           domain: octo-sts.fohte.net
 

--- a/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/boilerplate-update.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-boilerplate-update
           domain: octo-sts.fohte.net
 

--- a/generated/rust-with-node-subpackage/.github/workflows/bootstrap.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/bootstrap.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-bootstrap
           domain: octo-sts.fohte.net
 

--- a/generated/rust-with-node-subpackage/.github/workflows/test.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}
           domain: octo-sts.fohte.net
 

--- a/generated/rust/.github/workflows/boilerplate-update.yml
+++ b/generated/rust/.github/workflows/boilerplate-update.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-boilerplate-update
           domain: octo-sts.fohte.net
 

--- a/generated/rust/.github/workflows/bootstrap.yml
+++ b/generated/rust/.github/workflows/bootstrap.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-bootstrap
           domain: octo-sts.fohte.net
 

--- a/generated/rust/.github/workflows/test.yml
+++ b/generated/rust/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}
           domain: octo-sts.fohte.net
 

--- a/template/.github/workflows/boilerplate-update.yml
+++ b/template/.github/workflows/boilerplate-update.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-boilerplate-update
           domain: octo-sts.fohte.net
 

--- a/template/.github/workflows/bootstrap.yml.jinja
+++ b/template/.github/workflows/bootstrap.yml.jinja
@@ -34,7 +34,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: {% raw %}${{ github.repository }}{% endraw %}
           identity: {% raw %}${{ github.event.repository.name }}-bootstrap{% endraw %}
           domain: octo-sts.fohte.net
 

--- a/template/.github/workflows/release-please.yml.jinja
+++ b/template/.github/workflows/release-please.yml.jinja
@@ -37,7 +37,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: {% raw %}${{ github.repository }}{% endraw %}
           identity: {% raw %}${{ github.event.repository.name }}{% endraw %}-release-please
           domain: octo-sts.fohte.net
 

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -41,7 +41,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: {% raw %}${{ github.repository }}{% endraw %}
           identity: {% raw %}${{ github.event.repository.name }}{% endraw %}
           domain: octo-sts.fohte.net
 


### PR DESCRIPTION
## Purpose

- Prevent private repository information from being exposed through dependencies on public `fohte/.github` in repositories created from the template

## Approach

- Update generated workflows to authenticate with `octo-sts` using each repository's own settings instead of the centralized repository
