### PR TITLE
feat(template): automatically apply subpackage labels to PRs

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -120,6 +120,10 @@ _exclude:
   - '{% if not has_web_app %}.github/workflows/docker-publish.yml{% endif %}'
   # Exclude coverage files when coverage is disabled
   - '{% if not use_coverage %}/codecov.yml{% endif %}'
+  # scope/<name> PR labels are only meaningful when there's more than one
+  # subpackage to distinguish between.
+  - '{% if not subpackages %}.github/labeler.yml{% endif %}'
+  - '{% if not subpackages %}.github/workflows/labeler.yml{% endif %}'
   # spa is a subpackage-only flag (see subpackages help below); there is no
   # standalone root SPA.
   - '{% if not has_spa_pkg %}.github/workflows/storybook.yml{% endif %}'

--- a/copier.yml
+++ b/copier.yml
@@ -120,8 +120,8 @@ _exclude:
   - '{% if not has_web_app %}.github/workflows/docker-publish.yml{% endif %}'
   # Exclude coverage files when coverage is disabled
   - '{% if not use_coverage %}/codecov.yml{% endif %}'
-  # scope/<name> PR labels are only meaningful when there's more than one
-  # subpackage to distinguish between.
+  # scope/<name> PR labels need at least one subpackage to scope to; a repo
+  # with none has no path prefix worth distinguishing.
   - '{% if not subpackages %}.github/labeler.yml{% endif %}'
   - '{% if not subpackages %}.github/workflows/labeler.yml{% endif %}'
   # spa is a subpackage-only flag (see subpackages help below); there is no

--- a/generated/monorepo-node-workspace/.github/labeler.yml
+++ b/generated/monorepo-node-workspace/.github/labeler.yml
@@ -1,0 +1,6 @@
+scope/frontend:
+  - changed-files:
+      - any-glob-to-any-file: frontend/**
+scope/backend:
+  - changed-files:
+      - any-glob-to-any-file: backend/**

--- a/generated/monorepo-node-workspace/.github/workflows/labeler.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: PR labeler
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0

--- a/generated/monorepo/.github/labeler.yml
+++ b/generated/monorepo/.github/labeler.yml
@@ -1,0 +1,6 @@
+scope/frontend:
+  - changed-files:
+      - any-glob-to-any-file: frontend/**
+scope/backend:
+  - changed-files:
+      - any-glob-to-any-file: backend/**

--- a/generated/monorepo/.github/workflows/labeler.yml
+++ b/generated/monorepo/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: PR labeler
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0

--- a/generated/rust-with-node-subpackage/.github/labeler.yml
+++ b/generated/rust-with-node-subpackage/.github/labeler.yml
@@ -1,0 +1,3 @@
+scope/docs:
+  - changed-files:
+      - any-glob-to-any-file: docs/**

--- a/generated/rust-with-node-subpackage/.github/workflows/labeler.yml
+++ b/generated/rust-with-node-subpackage/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: PR labeler
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0

--- a/template/.github/labeler.yml.jinja
+++ b/template/.github/labeler.yml.jinja
@@ -1,0 +1,5 @@
+{%- for pkg in subpackages -%}
+{{ "" if loop.first else "\n" }}scope/{{ pkg.name }}:
+  - changed-files:
+      - any-glob-to-any-file: {{ pkg.name }}/**
+{%- endfor %}

--- a/template/.github/workflows/labeler.yml
+++ b/template/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: PR labeler
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0


### PR DESCRIPTION
## Purpose

- Allow identifying the target subpackage of each PR from the PR list in derived monorepo repositories

## Approach

- Automatically apply `scope/<subpackage>` labels indicating the target subpackage based on changed file paths
