### PR TITLE
fix(template): remove unused @eslint/eslintrc dependency

### DIFF
--- a/generated/monorepo-node-workspace/package.json
+++ b/generated/monorepo-node-workspace/package.json
@@ -16,7 +16,6 @@
   },
   "devDependencies": {
     "@commitlint/cli": "21.2.1",
-    "@eslint/eslintrc": "3.3.6",
     "@fohte/eslint-config": "0.4.1",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@tsconfig/node-lts": "24.0.0",

--- a/generated/monorepo/frontend/package.json
+++ b/generated/monorepo/frontend/package.json
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "@commitlint/cli": "21.2.1",
-    "@eslint/eslintrc": "3.3.6",
     "@fohte/eslint-config": "0.4.1",
     "@fohte/storybook-addon": "0.1.5",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",

--- a/generated/node/package.json
+++ b/generated/node/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "@commitlint/cli": "21.2.1",
-    "@eslint/eslintrc": "3.3.6",
     "@fohte/eslint-config": "0.4.1",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@tsconfig/node-lts": "24.0.0",

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -49,7 +49,6 @@
 {%- endif %}
   "devDependencies": {
     "@commitlint/cli": "21.2.1",
-    "@eslint/eslintrc": "3.3.6",
     "@fohte/eslint-config": "0.4.1",
     "@ninoseki/eslint-plugin-neverthrow": "0.2.0",
     "@tsconfig/node-lts": "24.0.0",

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
@@ -100,7 +100,6 @@
 {%- if has_tests and not is_workspace %}
   "devDependencies": {
     "@commitlint/cli": "21.2.1",
-    "@eslint/eslintrc": "3.3.6",
     "@fohte/eslint-config": "0.4.1",
 {%- if pkg_has_spa %}
     "@fohte/storybook-addon": "0.1.5",


### PR DESCRIPTION
## Purpose

- Generated Node.js repositories include the unused `@eslint/eslintrc` dependency

## Approach

- Remove `@eslint/eslintrc` from the template
