### PR TITLE
feat(template): add knip CI to detect unused code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ The repository root itself is a consumer of this template, managed via `.copier-
 - `_src_path` in `.copier-answers.yml` points at the remote URL (same as any downstream consumer), so Renovate's Copier manager opens `copier update` PRs against root when a new tag is released
 - Root-only additions (e.g., `bats` in `.mise.toml`, `ignorePaths`/`packageRules` in `renovate.json5`, the `Run bats tests` step in `.github/workflows/test.yml`, the `generated/` entry in `.prettierignore`) are kept via conflict resolution on `copier update` — resolve them the same way a downstream repo would
 - Template-only infrastructure (`template/`, `tests/`, `generated/`, `copier.yml`, `scripts/generate-snapshots`, `scripts/apply-renovate-patch`, `.github/workflows/validate-template.yml`, `.github/workflows/sync-generated-to-template.yml`, `CHANGELOG.md`, etc.) lives only at root and is never emitted by the template
-- To preview how an in-flight template change will land at root before release, run `copier copy --overwrite --defaults --data-file <fixture-like-data>.yml . .` against the local template
+- To preview how an in-flight template change will land at root before release, run `copier copy --overwrite --defaults --vcs-ref HEAD --data-file <fixture-like-data>.yml . .` against the local template. `--vcs-ref HEAD` is required — without it, copier checks out the latest git tag instead of the working tree, silently dropping any unreleased template change from the preview
 
 ## Snapshot generation
 

--- a/copier.yml
+++ b/copier.yml
@@ -71,6 +71,7 @@ _exclude:
   - "{% if type != 'node' and not is_workspace %}/package.json{% endif %}"
   - "{% if type != 'node' %}/tsconfig.json{% endif %}"
   - "{% if type != 'node' and not is_workspace %}/eslint.config.js{% endif %}"
+  - "{% if type != 'node' and not is_workspace %}/knip.json{% endif %}"
   - "{% if type != 'node' %}/vitest.config.ts{% endif %}"
   # pnpm-workspace.yaml holds workspace packages and pnpm settings (allowBuilds).
   # Required for any project with a node root package; non-workspace node subpackages

--- a/generated/monorepo-node-workspace/.github/workflows/test.yml
+++ b/generated/monorepo-node-workspace/.github/workflows/test.yml
@@ -243,3 +243,36 @@ jobs:
     if: failure()
     steps:
       - run: exit 1
+
+  knip:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          version: 2026.7.12
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: |
+          corepack enable
+          mise reshim
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run knip
+        run: pnpm exec knip

--- a/generated/monorepo-node-workspace/backend/vitest.config.ts
+++ b/generated/monorepo-node-workspace/backend/vitest.config.ts
@@ -1,3 +1,10 @@
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig({})
+export default defineConfig({
+  test: {
+    // Spelled out (matching Vitest's own default) so knip's static analysis
+    // of this file can resolve test entry files; Vitest's own runtime
+    // behavior is unchanged.
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+  },
+})

--- a/generated/monorepo-node-workspace/knip.json
+++ b/generated/monorepo-node-workspace/knip.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "workspaces": {
+    ".": {
+      "ignoreDependencies": ["@commitlint/cli"],
+      "ignoreBinaries": ["playwright"]
+    },
+    "frontend": {
+      "entry": ["src/lib/**"],
+      "ignore": ["public/mockServiceWorker.js"],
+      "ignoreDependencies": [
+        "neverthrow",
+        "reg-suit",
+        "reg-publish-s3-plugin",
+        "reg-simple-keygen-plugin"
+      ]
+    },
+    "backend": {
+      "ignoreDependencies": ["neverthrow"]
+    }
+  }
+}

--- a/generated/monorepo-node-workspace/package.json
+++ b/generated/monorepo-node-workspace/package.json
@@ -25,6 +25,7 @@
     "eslint": "10.6.0",
     "eslint-plugin-storybook": "10.4.6",
     "eslint-plugin-tailwindcss": "4.2.0",
+    "knip": "6.32.2",
     "prettier": "3.9.6",
     "typescript": "6.0.3",
     "vitest": "4.1.10"

--- a/generated/monorepo/.github/workflows/test.yml
+++ b/generated/monorepo/.github/workflows/test.yml
@@ -258,3 +258,38 @@ jobs:
     if: failure()
     steps:
       - run: exit 1
+
+  knip:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          version: 2026.7.12
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: |
+          corepack enable
+          mise reshim
+
+      - name: Get pnpm store directory (frontend)
+        id: pnpm-store-frontend
+        working-directory: frontend
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store (frontend)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ${{ steps.pnpm-store-frontend.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+
+      - name: Install pnpm dependencies (frontend)
+        run: cd "frontend" && pnpm install --frozen-lockfile
+
+      - name: Run knip (frontend)
+        run: cd "frontend" && pnpm exec knip

--- a/generated/monorepo/.github/workflows/test.yml
+++ b/generated/monorepo/.github/workflows/test.yml
@@ -275,16 +275,15 @@ jobs:
           corepack enable
           mise reshim
 
-      - name: Get pnpm store directory (frontend)
-        id: pnpm-store-frontend
-        working-directory: frontend
+      - name: Get pnpm store directory
+        id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
-      - name: Cache pnpm store (frontend)
+      - name: Cache pnpm store
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
-            ${{ steps.pnpm-store-frontend.outputs.path }}
+            ${{ steps.pnpm-store.outputs.path }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('frontend/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
 

--- a/generated/monorepo/frontend/knip.json
+++ b/generated/monorepo/frontend/knip.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "entry": ["src/lib/**"],
+  "ignore": ["public/mockServiceWorker.js"],
+  "ignoreDependencies": [
+    "@commitlint/cli",
+    "neverthrow",
+    "reg-suit",
+    "reg-publish-s3-plugin",
+    "reg-simple-keygen-plugin"
+  ]
+}

--- a/generated/monorepo/frontend/package.json
+++ b/generated/monorepo/frontend/package.json
@@ -64,6 +64,7 @@
     "eslint": "10.6.0",
     "eslint-plugin-storybook": "10.4.6",
     "eslint-plugin-tailwindcss": "4.2.0",
+    "knip": "6.32.2",
     "msw": "2.15.0",
     "msw-storybook-addon": "3.0.0",
     "playwright": "1.62.1",

--- a/generated/node/.github/workflows/test.yml
+++ b/generated/node/.github/workflows/test.yml
@@ -128,3 +128,36 @@ jobs:
 
       - name: Run tests
         run: pnpm run test
+
+  knip:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          version: 2026.7.12
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: |
+          corepack enable
+          mise reshim
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run knip
+        run: pnpm exec knip

--- a/generated/node/knip.json
+++ b/generated/node/knip.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "ignoreDependencies": ["@commitlint/cli", "neverthrow"]
+}

--- a/generated/node/package.json
+++ b/generated/node/package.json
@@ -32,6 +32,7 @@
     "@types/node": "24.13.3",
     "concurrently": "10.0.4",
     "eslint": "10.6.0",
+    "knip": "6.32.2",
     "prettier": "3.9.6",
     "tsup": "8.5.1",
     "tsx": "4.23.11",

--- a/generated/node/vitest.config.ts
+++ b/generated/node/vitest.config.ts
@@ -1,3 +1,10 @@
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig({})
+export default defineConfig({
+  test: {
+    // Spelled out (matching Vitest's own default) so knip's static analysis
+    // of this file can resolve test entry files; Vitest's own runtime
+    // behavior is unchanged.
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+  },
+})

--- a/scripts/generate-snapshots
+++ b/scripts/generate-snapshots
@@ -78,10 +78,8 @@ generate_fixture() {
   # is the desired signal. Silently falling back to defaults would hide the
   # oversight and let unintended values leak into snapshots.
   #
-  # --vcs-ref HEAD is required: without it, copier checks out the latest git
-  # tag instead of the working tree (see `copier copy --help`), so any commit
-  # or uncommitted template change newer than the last release tag would be
-  # silently dropped from the snapshot.
+  # Without --vcs-ref HEAD, copier defaults to the latest git tag instead of
+  # the working tree.
   $COPIER_CMD copy --trust --overwrite --vcs-ref HEAD --data-file "tests/fixtures/$fixture.yml" . "$output_dir"
 
   # Remove answers file as it contains a commit hash that changes on every run

--- a/scripts/generate-snapshots
+++ b/scripts/generate-snapshots
@@ -77,7 +77,12 @@ generate_fixture() {
   # fixture, copier raises "Interactive session required" here — that failure
   # is the desired signal. Silently falling back to defaults would hide the
   # oversight and let unintended values leak into snapshots.
-  $COPIER_CMD copy --trust --overwrite --data-file "tests/fixtures/$fixture.yml" . "$output_dir"
+  #
+  # --vcs-ref HEAD is required: without it, copier checks out the latest git
+  # tag instead of the working tree (see `copier copy --help`), so any commit
+  # or uncommitted template change newer than the last release tag would be
+  # silently dropped from the snapshot.
+  $COPIER_CMD copy --trust --overwrite --vcs-ref HEAD --data-file "tests/fixtures/$fixture.yml" . "$output_dir"
 
   # Remove answers file as it contains a commit hash that changes on every run
   rm -f "$output_dir/.copier-answers.yml"

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -113,7 +113,7 @@ jobs:
     No fixture combines type: rust with a testable node subpackage (testable
     multi-package setups use monorepo mode instead), so this branch has no
     snapshot coverage. Render it manually via `copier copy --overwrite
-    --defaults --data-file <fixture>.yml . .` when editing. #}
+    --defaults --vcs-ref HEAD --data-file <fixture>.yml . .` when editing. #}
 
       # corepack creates the pnpm executable inside mise's node install bin
       # directory; reshim so the mise shims dir (which is on PATH) picks it up.
@@ -784,8 +784,8 @@ jobs:
     cache (same pattern as the lefthook job above). No fixture combines
     type: rust with a testable node subpackage (testable multi-package setups
     use monorepo mode instead), so this branch has no snapshot coverage.
-    Render it manually via `copier copy --overwrite --defaults --data-file
-    <fixture>.yml . .` when editing. #}
+    Render it manually via `copier copy --overwrite --defaults --vcs-ref HEAD
+    --data-file <fixture>.yml . .` when editing. #}
 
       - name: Get pnpm store directory
         id: pnpm-store

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -742,3 +742,65 @@ jobs:
       - run: exit 1
 {%- endif %}
 {%- endif %}
+{%- if type == 'node' or is_workspace or testable_node_pkgs %}
+
+  knip:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          version: 2026.7.12
+
+      # corepack creates the pnpm executable inside mise's node install bin
+      # directory; reshim so the mise shims dir (which is on PATH) picks it up.
+      - run: |
+          corepack enable
+          mise reshim
+{%- if type == 'node' or is_workspace %}
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            {% raw %}${{ steps.pnpm-store.outputs.path }}{% endraw %}
+          key: {% raw %}${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}{% endraw %}
+          restore-keys: {% raw %}${{ runner.os }}-pnpm-store-{% endraw %}
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run knip
+        run: pnpm exec knip
+{%- else %}
+{#- Non-workspace mode: each testable node subpackage is its own isolated
+    pnpm project (own lockfile, own knip.json), so knip runs once per
+    subpackage from its own directory. #}
+{%- for pkg in testable_node_pkgs %}
+
+      - name: Get pnpm store directory ({{ pkg.name }})
+        id: pnpm-store-{{ pkg.name }}
+        working-directory: {{ pkg.name }}
+        run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store ({{ pkg.name }})
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            {% raw %}${{ steps.pnpm-store-{% endraw %}{{ pkg.name }}{% raw %}.outputs.path }}{% endraw %}
+          key: {% raw %}${{ runner.os }}-pnpm-store-${{ hashFiles({% endraw %}'{{ pkg.name }}/pnpm-lock.yaml'{% raw %}) }}{% endraw %}
+          restore-keys: {% raw %}${{ runner.os }}-pnpm-store-{% endraw %}
+
+      - name: Install pnpm dependencies ({{ pkg.name }})
+        run: cd "{{ pkg.name }}" && pnpm install --frozen-lockfile
+
+      - name: Run knip ({{ pkg.name }})
+        run: cd "{{ pkg.name }}" && pnpm exec knip
+{%- endfor %}
+{%- endif %}
+{%- endif %}

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -780,21 +780,25 @@ jobs:
 {%- else %}
 {#- Non-workspace mode: each testable node subpackage is its own isolated
     pnpm project (own lockfile, own knip.json), so knip runs once per
-    subpackage from its own directory. #}
-{%- for pkg in testable_node_pkgs %}
+    subpackage from its own directory, sharing one combined-key pnpm store
+    cache (same pattern as the lefthook job above). No fixture combines
+    type: rust with a testable node subpackage (testable multi-package setups
+    use monorepo mode instead), so this branch has no snapshot coverage.
+    Render it manually via `copier copy --overwrite --defaults --data-file
+    <fixture>.yml . .` when editing. #}
 
-      - name: Get pnpm store directory ({{ pkg.name }})
-        id: pnpm-store-{{ pkg.name }}
-        working-directory: {{ pkg.name }}
+      - name: Get pnpm store directory
+        id: pnpm-store
         run: echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
-      - name: Cache pnpm store ({{ pkg.name }})
+      - name: Cache pnpm store
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
-            {% raw %}${{ steps.pnpm-store-{% endraw %}{{ pkg.name }}{% raw %}.outputs.path }}{% endraw %}
-          key: {% raw %}${{ runner.os }}-pnpm-store-${{ hashFiles({% endraw %}'{{ pkg.name }}/pnpm-lock.yaml'{% raw %}) }}{% endraw %}
+            {% raw %}${{ steps.pnpm-store.outputs.path }}{% endraw %}
+          key: {% raw %}${{ runner.os }}-pnpm-store-${{ hashFiles({% endraw %}{% for pkg in testable_node_pkgs %}{% if not loop.first %}, {% endif %}'{{ pkg.name }}/pnpm-lock.yaml'{% endfor %}{% raw %}) }}{% endraw %}
           restore-keys: {% raw %}${{ runner.os }}-pnpm-store-{% endraw %}
+{%- for pkg in testable_node_pkgs %}
 
       - name: Install pnpm dependencies ({{ pkg.name }})
         run: cd "{{ pkg.name }}" && pnpm install --frozen-lockfile

--- a/template/knip.json.jinja
+++ b/template/knip.json.jinja
@@ -1,0 +1,42 @@
+{%- if is_workspace -%}
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "workspaces": {
+    ".": {
+      "ignoreDependencies": ["@commitlint/cli"]{{ "," if (is_public or has_spa_pkg) else "" }}
+{%- if is_public %}
+      "ignore": ["commitlint-plugin-no-external-refs.cjs"]{{ "," if has_spa_pkg else "" }}
+{%- endif %}
+{%- if has_spa_pkg %}
+      "ignoreBinaries": ["playwright"]
+{%- endif %}
+    },
+{%- for pkg in node_pkgs if pkg.tests | default(true) %}
+    "{{ pkg.name }}": {
+{%- if pkg.spa | default(false) %}
+      "entry": ["src/lib/**"],
+      "ignore": ["public/mockServiceWorker.js"],
+{%- endif %}
+{%- if pkg.vrt | default(false) %}
+      "ignoreDependencies": [
+        "neverthrow",
+        "reg-suit",
+        "reg-publish-s3-plugin",
+        "reg-simple-keygen-plugin"
+      ]
+{%- else %}
+      "ignoreDependencies": ["neverthrow"]
+{%- endif %}
+    }{{ "," if not loop.last else "" }}
+{%- endfor %}
+  }
+}
+{%- else -%}
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "ignoreDependencies": ["@commitlint/cli", "neverthrow"]{{ "," if is_public else "" }}
+{%- if is_public %}
+  "ignore": ["commitlint-plugin-no-external-refs.cjs"]
+{%- endif %}
+}
+{%- endif %}

--- a/template/knip.json.jinja
+++ b/template/knip.json.jinja
@@ -1,4 +1,5 @@
 {%- if is_workspace -%}
+{%- set knip_ws_pkgs = node_pkgs | rejectattr('tests', 'equalto', false) | list -%}
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
@@ -10,8 +11,8 @@
 {%- if has_spa_pkg %}
       "ignoreBinaries": ["playwright"]
 {%- endif %}
-    },
-{%- for pkg in node_pkgs if pkg.tests | default(true) %}
+    }{{ "," if knip_ws_pkgs else "" }}
+{%- for pkg in knip_ws_pkgs %}
     "{{ pkg.name }}": {
 {%- if pkg.spa | default(false) %}
       "entry": ["src/lib/**"],

--- a/template/package.json.jinja
+++ b/template/package.json.jinja
@@ -60,6 +60,7 @@
     "eslint-plugin-storybook": "10.4.6",
     "eslint-plugin-tailwindcss": "4.2.0",
 {%- endif %}
+    "knip": "6.32.2",
     "prettier": "3.9.6",
 {%- if root_is_web_app %}
     "tsup": "8.5.1",

--- a/template/vitest.config.ts.jinja
+++ b/template/vitest.config.ts.jinja
@@ -45,5 +45,12 @@ export default mergeConfig(
 {%- else -%}
 import { defineConfig } from 'vitest/config'
 
-export default defineConfig({})
+export default defineConfig({
+  test: {
+    // Spelled out (matching Vitest's own default) so knip's static analysis
+    // of this file can resolve test entry files; Vitest's own runtime
+    // behavior is unchanged.
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+  },
+})
 {%- endif %}

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' %}package.json{% endif %}.jinja
@@ -132,6 +132,9 @@
 {%- if pkg_has_spa %}
     "eslint-plugin-storybook": "10.4.6",
     "eslint-plugin-tailwindcss": "4.2.0",
+{%- endif %}
+    "knip": "6.32.2",
+{%- if pkg_has_spa %}
     "msw": "2.15.0",
     "msw-storybook-addon": "3.0.0",
     "playwright": "1.62.1",

--- a/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) and not (monorepo_node_workspace | default(false)) %}knip.json{% endif %}.jinja
+++ b/template/{% yield pkg from subpackages %}{{ pkg.name }}{% endyield %}/{% if pkg.type == 'node' and pkg.tests | default(true) and not (monorepo_node_workspace | default(false)) %}knip.json{% endif %}.jinja
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+{%- if pkg.spa | default(false) %}
+  "entry": ["src/lib/**"],
+  "ignore": ["public/mockServiceWorker.js"],
+{%- endif %}
+{%- if pkg.vrt | default(false) %}
+  "ignoreDependencies": [
+    "@commitlint/cli",
+    "neverthrow",
+    "reg-suit",
+    "reg-publish-s3-plugin",
+    "reg-simple-keygen-plugin"
+  ]
+{%- else %}
+  "ignoreDependencies": ["@commitlint/cli", "neverthrow"]
+{%- endif %}
+}


### PR DESCRIPTION
## Purpose

- Support automatic detection of unreferenced exports, types, unused dependencies, and files lingering in the codebase across generated Node.js projects

## Approach

- Add knip configuration and a CI workflow to the Node.js template to detect unused code and dependencies in CI

<details>
<summary>Design decisions</summary>

#### Unused code detection tool

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen | `knip` | Comprehensively detects unused exports, types, dependencies, and files, and works with ESLint 10 and later | Requires introducing a dedicated tool and managing its configuration |
| Rejected | `eslint-plugin-import-x` (`no-unused-modules`) | Can be introduced simply by adding a rule to the existing ESLint configuration | Does not work with ESLint 10 and cannot detect issues in entry points, package.json, or non-JS files |

</details>
