### PR TITLE
ci(validate-template): skip release-please branches

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -24,11 +24,11 @@ jobs:
     # we may use stale template/ (before sync completes), causing incorrect regeneration.
     # By skipping here, we let sync finish first, then validate runs on sync's commit.
     #
-    # Skip for release-please branches: their PRs only touch CHANGELOG.md and the
-    # version manifest, so template validation is redundant. Skipping here (rather
-    # than at the workflow's `on.push` trigger) keeps the workflow triggered, so
-    # validate-status below still reports the required status check.
-    if: github.actor != 'renovate[bot]' && !startsWith(github.ref_name, 'release-please--branches--')
+    # Skip release-please branches (only touch CHANGELOG.md/version manifest) at
+    # job level so validate-status still reports the required status check.
+    if: |
+      github.actor != 'renovate[bot]' &&
+      !(github.actor == 'fohte-bot[bot]' && startsWith(github.ref_name, 'release-please--branches--'))
     outputs:
       fixtures: ${{ steps.list.outputs.fixtures }}
     steps:

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -23,7 +23,12 @@ jobs:
     # to sync changes to template/. If we run regenerate here on Renovate's commit,
     # we may use stale template/ (before sync completes), causing incorrect regeneration.
     # By skipping here, we let sync finish first, then validate runs on sync's commit.
-    if: github.actor != 'renovate[bot]'
+    #
+    # Skip for release-please branches: their PRs only touch CHANGELOG.md and the
+    # version manifest, so template validation is redundant. Skipping here (rather
+    # than at the workflow's `on.push` trigger) keeps the workflow triggered, so
+    # validate-status below still reports the required status check.
+    if: github.actor != 'renovate[bot]' && !startsWith(github.ref_name, 'release-please--branches--')
     outputs:
       fixtures: ${{ steps.list.outputs.fixtures }}
     steps:


### PR DESCRIPTION
## Purpose

- Unnecessary template validation runs on release-please release PRs, wasting CI time

## Approach

- Skip template validation on release-please release PRs
